### PR TITLE
add data from gun violence archive

### DIFF
--- a/data/2013-02-11 - 2017-03-18.csv
+++ b/data/2013-02-11 - 2017-03-18.csv
@@ -1,0 +1,1051 @@
+"Incident ID","Incident Date",State,"City Or County",Address,"# Killed","# Injured",Operations
+797809,"March 18, 2017",Delaware,"Ocean View","36000 block of Pine Grove Ln",0,1,N/A
+794788,"March 13, 2017",Delaware,Dover,"255 Webbs Ln.",0,0,N/A
+793255,"March 12, 2017",Delaware,Wilmington,"1000 block of W. 7th St.",0,1,N/A
+791511,"March 8, 2017",Delaware,Wilmington,"1000 block of N Lombard St",0,1,N/A
+791515,"March 8, 2017",Delaware,Wilmington,"900 block of Marshall St",1,0,N/A
+790132,"March 7, 2017",Delaware,Dover,"800 block of Bacon Ave",0,0,N/A
+789337,"March 6, 2017",Delaware,Newark,"1913 Sheldon Dr",0,0,N/A
+786956,"March 2, 2017",Delaware,Harbeson,"22000 block of Hurdle Ditch Rd",0,0,N/A
+787185,"March 1, 2017",Delaware,Dover,"South Queen Street and Bank Lane",0,0,N/A
+785476,"February 28, 2017",Delaware,Wilmington,"900 block of Vandever Avenue",0,1,N/A
+786092,"February 28, 2017",Delaware,Dover,"820 Carvel Dr",1,0,N/A
+782049,"February 23, 2017",Delaware,Wilmington,"600 block of E 23rd St",1,1,N/A
+783405,"February 22, 2017",Delaware,Newark,"1000 block of S College Rd",0,0,N/A
+779848,"February 21, 2017",Delaware,Wilmington,"2200 block of N Market St",2,0,N/A
+779874,"February 20, 2017",Delaware,Wilmington,"800 block of Vandever Avenue",0,1,N/A
+777947,"February 18, 2017",Delaware,Newark,"S College Ave and Christina Pkwy",0,0,N/A
+779855,"February 18, 2017",Delaware,"New Castle","1500 block of Surry Ct",1,0,N/A
+777624,"February 17, 2017",Delaware,"New Castle","700 block of Grantham Ln",0,1,N/A
+1538245,"February 16, 2017",Delaware,Wilmington,"400 block of Delamore Pl",0,1,N/A
+1538242,"February 16, 2017",Delaware,Wilmington,"942 Bennett St",0,1,N/A
+777953,"February 16, 2017",Delaware,Wilmington,"900 block of Lombard",0,0,N/A
+776160,"February 14, 2017",Delaware,Wilmington,"2000 block of Shallcross Avenue",0,0,N/A
+774954,"February 13, 2017",Delaware,Wilmington,"2101 Prior Rd",0,0,N/A
+774964,"February 12, 2017",Delaware,Wilmington,"400 block of W. 29th St",0,1,N/A
+774030,"February 11, 2017",Delaware,Wilmington,"1100 block of B Street",0,1,N/A
+774066,"February 10, 2017",Delaware,"New Castle","Fairhaven Court",0,0,N/A
+772271,"February 10, 2017",Delaware,Dover,"Stevenson Dr",0,0,N/A
+772276,"February 9, 2017",Delaware,Wilmington,"1000 block of W 3rd St",0,1,N/A
+771092,"February 8, 2017",Delaware,"New Castle","100 block of Parma Ave",0,1,N/A
+771085,"February 8, 2017",Delaware,Wilmington,"1700 block of Conrad Street",0,1,N/A
+771083,"February 8, 2017",Delaware,Wilmington,"2400 block of N. Monroe St.",0,1,N/A
+784933,"February 7, 2017",Delaware,Dover,"S New St",0,1,N/A
+774948,"February 7, 2017",Delaware,"New Castle","Revelle and Deen streets",0,0,N/A
+770313,"February 3, 2017",Delaware,Wilmington,"Lancaster Avenue and South Van Buren Street",0,0,N/A
+767812,"February 3, 2017",Delaware,Greenwood,"Deep Grass Ln",0,0,N/A
+767185,"February 3, 2017",Delaware,Wilmington,"S Van Buren St and Beech St",0,1,N/A
+767183,"January 31, 2017",Delaware,Milford,"N Rehoboth Rd",0,0,N/A
+764910,"January 31, 2017",Delaware,Selbyville,"31000 block of Lighthouse Rd",0,0,N/A
+764469,"January 30, 2017",Delaware,Wilmington,"1200 block of Oak St",0,1,N/A
+765159,"January 30, 2017",Delaware,Wilmington,"3rd and Washington streets",0,1,N/A
+763483,"January 29, 2017",Delaware,Wilmington,"2900 block of N. Claymont St.",0,1,N/A
+763107,"January 29, 2017",Delaware,Wilmington,"300 block of East 5th Street",0,1,N/A
+762863,"January 29, 2017",Delaware,Laurel,"56 Sunset Dr",1,0,N/A
+762758,"January 29, 2017",Delaware,Wilmington,"13th St and French St",0,1,N/A
+762736,"January 27, 2017",Delaware,Wilmington,"9th St and N Pine St",0,1,N/A
+762752,"January 27, 2017",Delaware,Laurel,"Laurel Rd and Shiloh Church Rd",0,0,N/A
+761825,"January 27, 2017",Delaware,"New Castle","Booker Circle",0,1,N/A
+760722,"January 26, 2017",Delaware,Dover,"700 block of S State St",0,0,N/A
+1131906,"January 26, 2017",Delaware,Newark,"700 block of Vinings Way",1,0,N/A
+760718,"January 25, 2017",Delaware,Dover,"300 block of Fulton Street",0,0,N/A
+761612,"January 24, 2017",Delaware,Newark,"Prospect Ave",0,1,N/A
+759893,"January 24, 2017",Delaware,Wilmington,"200 block of N Market St",0,2,N/A
+760129,"January 23, 2017",Delaware,Claymont,"Naamans Road",0,0,N/A
+758480,"January 23, 2017",Delaware,Wilmington,"1700 block of W 13th St",1,0,N/A
+757386,"January 22, 2017",Delaware,Newark,"700 Prides Crossing",0,0,N/A
+758270,"January 22, 2017",Delaware,Wilmington,"2300 block of N. Pine St",1,0,N/A
+759226,"January 22, 2017",Delaware,"New Castle","100 block of Wimbledon Court",0,0,N/A
+757946,"January 21, 2017",Delaware,Harrington,"4000 block of Cattail Branch Rd",0,0,N/A
+756261,"January 20, 2017",Delaware,Wilmington,"200 block of S Harrison St",1,1,N/A
+756252,"January 19, 2017",Delaware,Dover,"Loockerman and Queen Streets",0,0,N/A
+755421,"January 18, 2017",Delaware,Wilmington,"S Market St",0,0,N/A
+755781,"January 17, 2017",Delaware,Wilmington,"South Heald Street and A Street",0,1,N/A
+753081,"January 17, 2017",Delaware,Wilmington,"7th and Market streets",1,0,N/A
+755775,"January 17, 2017",Delaware,Wilmington,"200 block of N Rodney St",0,1,N/A
+753084,"January 16, 2017",Delaware,Greenwood,"Unity Ln",0,1,N/A
+1538240,"January 16, 2017",Delaware,Wilmington,"E 22nd St and N Spruce St",0,1,N/A
+751257,"January 15, 2017",Delaware,Wilmington,"2200 block of N Church St",0,1,N/A
+751222,"January 15, 2017",Delaware,Wilmington,"1400 block of Northeast Blvd",0,1,N/A
+750823,"January 14, 2017",Delaware,Wilmington,"2200 block of Lamotte St",1,0,N/A
+760324,"January 13, 2017",Delaware,"Rehoboth Beach","1900 block of Duffy St",0,1,N/A
+747867,"January 11, 2017",Delaware,Wilmington,"100 block of E 14th St",1,0,N/A
+748642,"January 11, 2017",Delaware,Wilmington,"300 block of S. Jackson St.",0,3,N/A
+747875,"January 10, 2017",Delaware,Dover,"120 Haman Dr",1,0,N/A
+747170,"January 9, 2017",Delaware,Wilmington,"101 N Clayton St",1,0,N/A
+747177,"January 8, 2017",Delaware,Wilmington,"200 block of Porter St",1,0,N/A
+743757,"January 3, 2017",Delaware,Dover,"S. Queen St.",0,0,N/A
+742572,"January 3, 2017",Delaware,Wilmington,"7th Street and North Jackson Street",0,1,N/A
+741648,"January 1, 2017",Delaware,Harrington,"301 Dorman St",0,1,N/A
+737847,"December 30, 2016",Delaware,Magnolia,"Flint Dr",0,1,N/A
+1060765,"December 29, 2016",Delaware,Dover,"W North Street and Saulsbury Rd",0,0,N/A
+737837,"December 29, 2016",Delaware,"Seaford (Blades)","West 2nd St",0,0,N/A
+736908,"December 28, 2016",Delaware,Wilmington,"100 block of S Jackson St",0,1,N/A
+736910,"December 27, 2016",Delaware,Wilmington,"300 block of 9th Street",0,1,N/A
+735846,"December 27, 2016",Delaware,Laurel,"1000 block of Hollybrook Apartments",0,0,N/A
+733453,"December 23, 2016",Delaware,Dover,"Collins Drive",0,2,N/A
+730679,"December 20, 2016",Delaware,Wilmington,"1000 block of Linda Rd",1,0,N/A
+729961,"December 18, 2016",Delaware,Milford,"Southwest Front Street",0,0,N/A
+724865,"December 13, 2016",Delaware,Wilmington,"200 block of W. 30th Street",0,0,N/A
+726392,"December 13, 2016",Delaware,Dover,"400 block of New Castle Avenue",0,0,N/A
+725882,"December 12, 2016",Delaware,Dover,"1400 block of South Farmview",0,1,N/A
+723549,"December 10, 2016",Delaware,Dover,"100 block of South New Street",0,2,N/A
+722345,"December 8, 2016",Delaware,Wilmington,"W. Fifth and N. Scott streets",0,1,N/A
+720529,"December 6, 2016",Delaware,Dover,"400 block of Aspen Drive",1,0,N/A
+719768,"December 5, 2016",Delaware,Wilmington,"22nd Street and Pine Street",0,1,N/A
+719761,"December 4, 2016",Delaware,Bear,"100 block of Garwood Drive",0,1,N/A
+717114,"December 1, 2016",Delaware,Wilmington,"2900 block of Baynard Blvd",0,1,N/A
+715258,"November 30, 2016",Delaware,"New Castle","Howell Drive and Daniel Lane",0,1,N/A
+717109,"November 30, 2016",Delaware,"New Castle","Deen and Pell Street",0,0,N/A
+714336,"November 28, 2016",Delaware,Millsboro,"25935 Plaza Drive",0,0,N/A
+714170,"November 28, 2016",Delaware,Dover,"South New Street",0,0,N/A
+713618,"November 28, 2016",Delaware,Wilmington,"22nd and Jefferson streets",1,0,N/A
+712811,"November 28, 2016",Delaware,Wilmington,"West 27th and North Van Buren streets",0,1,N/A
+717116,"November 27, 2016",Delaware,"Dover (Leipsic)","Walnut Street",0,0,N/A
+711670,"November 25, 2016",Delaware,Wilmington,"Seventh and Washington",0,0,N/A
+709617,"November 24, 2016",Delaware,Wilmington,"North Van Buren Street",0,1,N/A
+709141,"November 23, 2016",Delaware,Newark,"100 block of South Patrice Drive",0,2,N/A
+709139,"November 23, 2016",Delaware,Dover,"30 South New Street",0,0,N/A
+707305,"November 21, 2016",Delaware,Dover,"300 block of Martin St",0,0,N/A
+705687,"November 19, 2016",Delaware,Wilmington,"800 block of Morrow St.",1,0,N/A
+705053,"November 18, 2016",Delaware,Wilmington,"Cedar Ave and Maryland Avenue",0,2,N/A
+703122,"November 16, 2016",Delaware,Millsboro,"W Monroe St and Houston St",1,0,N/A
+702539,"November 16, 2016",Delaware,Wilmington,"Linden and S. Van Buren",0,1,N/A
+700986,"November 14, 2016",Delaware,Wilmington,"8th and N. Madison streets",0,1,N/A
+699363,"November 11, 2016",Delaware,Dover,"1st block of S. New Street",0,0,N/A
+698615,"November 9, 2016",Delaware,Bridgeville,"2000 block of Windy Lane",0,0,N/A
+696569,"November 8, 2016",Delaware,Claymont,"200 block of Dewey Court",1,0,N/A
+697136,"November 8, 2016",Delaware,Dover,"South New and Reed streets",0,0,N/A
+697132,"November 7, 2016",Delaware,Wilmington,"2152 Melson Rd",0,0,N/A
+694687,"November 6, 2016",Delaware,Bear,"US 40 and Brookmont Dr",0,0,N/A
+694259,"November 6, 2016",Delaware,Newark,"100 block of Flamingo Dr",0,1,N/A
+697145,"November 5, 2016",Delaware,Seaford,"100 block of Woodland Mills",0,0,N/A
+697751,"November 3, 2016",Delaware,Dover,"Kenton Road and College Road",0,0,N/A
+697748,"November 3, 2016",Delaware,Dover,"Cooper Road",0,0,N/A
+692082,"November 3, 2016",Delaware,Wilmington,"409 W 25th St",0,1,N/A
+692556,"November 3, 2016",Delaware,Wilmington,"600 block of N. Madison St",0,0,N/A
+693267,"November 2, 2016",Delaware,Wilmington,"1000 block of N. Church Street",0,0,N/A
+692319,"November 2, 2016",Delaware,Wilmington,"1200 block of Lancaster Ave",0,1,N/A
+692092,"November 2, 2016",Delaware,Wilmington,"1300 block of Chestnut St",0,1,N/A
+692090,"November 2, 2016",Delaware,Wilmington,"1300 block of Chestnut St",0,1,N/A
+691326,"November 1, 2016",Delaware,Wilmington,"200 block of E. 24th St.",1,0,N/A
+690282,"October 31, 2016",Delaware,"New Castle","Revelle Street and Baylis Street",0,1,N/A
+686274,"October 26, 2016",Delaware,Wilmington,"500 block of W. 25th St",0,2,N/A
+684541,"October 25, 2016",Delaware,Dover,"400 block of New Castle Ave",0,1,N/A
+685121,"October 25, 2016",Delaware,Middletown,"500 block of New Street",0,1,N/A
+683784,"October 24, 2016",Delaware,Dover,"500 block of River Road",1,0,N/A
+683027,"October 24, 2016",Delaware,Newark,"100 Christiana Mall Road",0,0,N/A
+683023,"October 23, 2016",Delaware,"Wilmington (Newport)","500 block of Jackson Ave",0,1,N/A
+680304,"October 20, 2016",Delaware,Wilmington,"Fourth and North Madison streets",0,1,N/A
+681681,"October 20, 2016",Delaware,"New Castle","50 block of Highland Blvd",0,1,N/A
+681690,"October 20, 2016",Delaware,Wilmington,"1600 block of West 3rd Street",0,0,N/A
+681688,"October 20, 2016",Delaware,Milton,"West Springside Drive",0,1,N/A
+679897,"October 19, 2016",Delaware,Wilmington,"2600 block of N. West St",0,1,N/A
+680310,"October 18, 2016",Delaware,Wilmington,"499 Bethune Dr",0,1,N/A
+679038,"October 17, 2016",Delaware,Wilmington,"1000 block of Clayton Road",0,0,N/A
+679044,"October 16, 2016",Delaware,Dover,"1400 block of Forrest Ave",0,1,N/A
+679042,"October 16, 2016",Delaware,Wilmington,"1500 block of W. Fourth St",0,0,N/A
+677268,"October 15, 2016",Delaware,"Rehoboth Beach","Wolfe Neck Road",0,1,N/A
+677749,"October 14, 2016",Delaware,Wilmington,"W. Third St. and N. Clayton St.",0,1,N/A
+674414,"October 11, 2016",Delaware,Wilmington,"3100 block of N. Harrison St.",0,1,N/A
+673762,"October 10, 2016",Delaware,Wilmington,"W 9th St and N West St",0,1,N/A
+673765,"October 10, 2016",Delaware,Dover,"100 block of W. Loockerman St",0,0,N/A
+672889,"October 9, 2016",Delaware,Wilmington,"W 22nd St",0,1,N/A
+672887,"October 8, 2016",Delaware,Felton,"Walnut Shade Rd and S DuPont Hwy",0,0,N/A
+673757,"October 8, 2016",Delaware,"Wilmington (Stanton)","500 block of Sixth Ave",0,0,N/A
+670047,"October 4, 2016",Delaware,Harbeson,"25000 block of Hollis Road",0,0,N/A
+669393,"October 3, 2016",Delaware,Newark,"20 block of Gogh Cir",0,1,N/A
+668667,"October 3, 2016",Delaware,Wilmington,"700 block of E. 10th St",0,1,N/A
+669015,"October 3, 2016",Delaware,Newark,"Gogh Circle and Ruebens Circle",0,1,N/A
+668615,"October 2, 2016",Delaware,Wilmington,"1200 block of Elm Street",0,0,N/A
+668609,"October 2, 2016",Delaware,"New Castle","100 block of Jillian's Way",0,1,N/A
+668624,"September 30, 2016",Delaware,Newark,"300 block of Auckland Drive",0,1,N/A
+665049,"September 27, 2016",Delaware,Dover,"Leipsic Road",0,0,N/A
+662956,"September 24, 2016",Delaware,Bear,"U.S. 40",0,0,N/A
+659412,"September 20, 2016",Delaware,Wilmington,"1500 block of West 3rd Street",0,1,N/A
+660092,"September 20, 2016",Delaware,Wilmington,"200 block of East 14th Street",0,1,N/A
+657805,"September 18, 2016",Delaware,Wilmington,"200 block of W 20th St",1,1,N/A
+657958,"September 16, 2016",Delaware,Wilmington,"2700 block of West St.",0,2,N/A
+657517,"September 16, 2016",Delaware,Wilmington,"900 block of N Pine St",0,0,N/A
+657502,"September 15, 2016",Delaware,Dover,"1700 N Dupont Hwy",0,0,N/A
+655198,"September 14, 2016",Delaware,Wilmington,"2600 block of North Market Street",0,1,N/A
+656351,"September 14, 2016",Delaware,Millsboro,"20000 block of Miller Drive",0,1,N/A
+654286,"September 11, 2016",Delaware,"New Castle","100 block of N.Dupont Highway",0,0,N/A
+652981,"September 11, 2016",Delaware,"New Castle","500 block of S. DuPont Highway",0,1,N/A
+652983,"September 10, 2016",Delaware,"New Castle","DE-273 and Airport Rd",0,1,N/A
+650907,"September 8, 2016",Delaware,"New Castle","50 block of Morris Rd",0,1,N/A
+649012,"September 5, 2016",Delaware,"New Castle","300 block of Wildel Ave",0,1,N/A
+647723,"September 3, 2016",Delaware,Wilmington,"200 block of N. Franklin St.",0,1,N/A
+647716,"September 3, 2016",Delaware,Wilmington,"50 block of W 27th St",0,1,N/A
+647711,"September 3, 2016",Delaware,"New Castle",N/A,0,1,N/A
+646713,"September 1, 2016",Delaware,Wilmington,"300 block of W. 24th Street",0,1,N/A
+645022,"September 1, 2016",Delaware,Wilmington,"West 27th Street",0,3,N/A
+646127,"August 31, 2016",Delaware,Dover,"River Road and Water Street",0,0,N/A
+647726,"August 30, 2016",Delaware,Wilmington,"10th and Spruce streets",0,0,N/A
+642964,"August 29, 2016",Delaware,Wilmington,"500 block of W Sixth St",0,1,N/A
+640343,"August 26, 2016",Delaware,Wilmington,"Lea Blvd and N Market St",0,1,N/A
+639517,"August 25, 2016",Delaware,Wilmington,"700  S. Vanburen Street",0,1,N/A
+637934,"August 23, 2016",Delaware,Wilmington,"27th and N. Tatnall streets",0,1,N/A
+636999,"August 22, 2016",Delaware,Wilmington,"500 block of W. 31st St",0,1,N/A
+635091,"August 21, 2016",Delaware,Wilmington,"1200 block of Elm St.",0,1,N/A
+636757,"August 21, 2016",Delaware,Dover,"300 block of Charring Cross Rd",0,0,N/A
+633849,"August 18, 2016",Delaware,Dover,"100 block of South Queen Street",1,0,N/A
+632869,"August 17, 2016",Delaware,Wilmington,"31st and North West streets",0,1,N/A
+632871,"August 16, 2016",Delaware,Dover,"River Road and New Castle Avenue",0,0,N/A
+630459,"August 15, 2016",Delaware,Wilmington,"3800 block of N. Market St.",0,0,N/A
+630456,"August 15, 2016",Delaware,Wilmington,"600 block of W. Sixth St.",0,1,N/A
+631476,"August 15, 2016",Delaware,"New Castle","700 block of Center St",0,0,N/A
+629733,"August 14, 2016",Delaware,Wilmington,"500 block of W. 38th Street",0,1,N/A
+630463,"August 13, 2016",Delaware,Dover,"200 block of Bradley Road",0,0,N/A
+629393,"August 13, 2016",Delaware,Wilmington,"1600 block of West Third Street",0,1,N/A
+629164,"August 13, 2016",Delaware,"New Castle","44 Birkshire Rd",0,1,N/A
+629090,"August 13, 2016",Delaware,Lincoln,"10000 block of Crescent Shores Drive",0,1,N/A
+626478,"August 10, 2016",Delaware,"Wilmington (Elsmere)","131 Scarborough Park",0,1,N/A
+623234,"August 6, 2016",Delaware,Dover,"100 block of Holmes Street",0,1,N/A
+623513,"August 6, 2016",Delaware,Wilmington,"Burnside Blvd and Newport Gap Pk",0,1,N/A
+624714,"August 4, 2016",Delaware,Wilmington,"300 block of  E. 23rd St.",0,0,N/A
+621571,"August 3, 2016",Delaware,Dover,"100 block of Madison Court",0,0,N/A
+620582,"August 2, 2016",Delaware,Wilmington,"9th and Spruce streets",0,1,N/A
+618053,"July 31, 2016",Delaware,Wilmington,"2600 block of N. Market Street",0,1,N/A
+618821,"July 31, 2016",Delaware,Wilmington,"400 block of Concord Ave",0,1,N/A
+616180,"July 29, 2016",Delaware,Dover,"Stevenson Drive",0,0,N/A
+615416,"July 27, 2016",Delaware,Wilmington,"100 block of E. 27th St",0,1,N/A
+612770,"July 24, 2016",Delaware,Dover,"51 Webbs Lane",0,0,N/A
+610490,"July 23, 2016",Delaware,Wilmington,"1300 West 5th Street",0,1,N/A
+611552,"July 23, 2016",Delaware,Wilmington,"3500 block of N. Church St.",0,1,N/A
+610513,"July 22, 2016",Delaware,Wilmington,"4021 Kennett Pike",0,0,N/A
+606949,"July 18, 2016",Delaware,"New Castle","260 Christiana Road",2,0,N/A
+606626,"July 18, 2016",Delaware,Wilmington,"Third Street",1,0,N/A
+616174,"July 18, 2016",Delaware,Milford,"Big Stone Beach Road",0,0,N/A
+606945,"July 18, 2016",Delaware,Wilmington,"700 block of E 11th St",1,0,N/A
+605400,"July 15, 2016",Delaware,Harrington,"Milford Harrington Highway",0,0,N/A
+603328,"July 13, 2016",Delaware,Newark,"1300 block of Greentree Rd",0,2,N/A
+601519,"July 12, 2016",Delaware,Wilmington,"200 block of W. 23rd St.",0,2,N/A
+601526,"July 9, 2016",Delaware,Newark,"First block of Baywatch Road",0,0,N/A
+599765,"July 9, 2016",Delaware,Wilmington,"West Fourth and North Jefferson Streets",0,1,N/A
+598995,"July 9, 2016",Delaware,"New Castle","600 block of Country Path Dr",1,0,N/A
+598988,"July 8, 2016",Delaware,Wilmington,"600 block of W. Sixth St",0,2,N/A
+602620,"July 8, 2016",Delaware,Wilmington,N/A,0,2,N/A
+597490,"July 6, 2016",Delaware,Bear,"700 block of Red Clay Drive",0,1,N/A
+595792,"July 5, 2016",Delaware,Dover,"200 block of Stardust Drive",0,1,N/A
+596804,"July 5, 2016",Delaware,Newark,"Raven Turn",0,1,N/A
+595796,"July 4, 2016",Delaware,Wilmington,"Sherman Street and Clifford Brown Walk",0,1,N/A
+594974,"July 3, 2016",Delaware,Wilmington,"East 10th and Spruce streets",0,1,N/A
+594152,"July 2, 2016",Delaware,Wilmington,"300 block of North Lincoln Street",0,1,N/A
+594475,"July 2, 2016",Delaware,Wilmington,"221 Chestnut Avenue",2,0,N/A
+595786,"July 1, 2016",Delaware,Wilmington,"300 block of E. 5th St.",0,0,N/A
+594150,"July 1, 2016",Delaware,Smyrna,"Providence Drive",0,0,N/A
+590815,"June 28, 2016",Delaware,Wilmington,"800 block of N. Adams St.",0,1,N/A
+589808,"June 27, 2016",Delaware,Newark,"400 block of N Barrett Ln",0,0,N/A
+590820,"June 27, 2016",Delaware,Wilmington,"1300 block of N. Walnut St",0,1,N/A
+590887,"June 27, 2016",Delaware,Frederica,"S DE-1",1,0,N/A
+589790,"June 26, 2016",Delaware,Wilmington,"27th and Moore streets",0,1,N/A
+589797,"June 26, 2016",Delaware,Wilmington,"900 block of N Spruce St",1,0,N/A
+588086,"June 24, 2016",Delaware,Newark,"2102 Ashkirk Drive",1,0,N/A
+586092,"June 22, 2016",Delaware,Wilmington,"Northeast Boulevard and East 30th Street",0,1,N/A
+583267,"June 18, 2016",Delaware,Wilmington,"900 block of North Pine Street",1,0,N/A
+580848,"June 14, 2016",Delaware,Wilmington,"South Van Buren and Elm streets",0,4,N/A
+580558,"June 14, 2016",Delaware,Felton,"50 block of Weatherstone Ln",0,1,N/A
+580561,"June 13, 2016",Delaware,Wilmington,"200 block of South Harrison",0,1,N/A
+579394,"June 12, 2016",Delaware,Newark,"700 block of Vining's Way",0,2,N/A
+579044,"June 11, 2016",Delaware,Wilmington,"1200 block of East 22nd Street",0,1,N/A
+576986,"June 10, 2016",Delaware,Wilmington,"1200 block of Oak Street",0,1,N/A
+579042,"June 10, 2016",Delaware,Seaford,"Coverdale Road",0,0,N/A
+574437,"June 7, 2016",Delaware,Wilmington,"50 block of Jensen Dr",1,0,N/A
+574440,"June 6, 2016",Delaware,Wilmington,"800 block of Kirkwood Street",0,1,N/A
+573549,"June 5, 2016",Delaware,Wilmington,"Concord Avenue and North Washington Street",0,1,N/A
+573554,"June 3, 2016",Delaware,Wilmington,"900 block of Martin Luther King Boulevard",0,0,N/A
+570753,"June 2, 2016",Delaware,Wilmington,"Maryland Avenue and Robinson Lane",0,1,N/A
+570745,"June 2, 2016",Delaware,Wilmington,"700 block of S. Van Buren St",0,1,N/A
+570762,"June 1, 2016",Delaware,Dover,"1000 block of S. Bradford St",0,0,N/A
+570770,"May 31, 2016",Delaware,Dover,"1300 block of S. Farmview Drive",0,0,N/A
+567481,"May 28, 2016",Delaware,Wilmington,"2600 block of Bowers St",0,1,N/A
+567044,"May 26, 2016",Delaware,Dover,"100 block of Cherry Street",0,0,N/A
+567023,"May 25, 2016",Delaware,Claymont,"2705 Philadelphia Pike",0,1,N/A
+565523,"May 25, 2016",Delaware,Dover,"First block of Webbs Lane",0,1,N/A
+567003,"May 25, 2016",Delaware,Claymont,"2705 Philadelphia Pike",0,1,N/A
+565535,"May 24, 2016",Delaware,Wilmington,"200 block of S. Harrison Street",0,1,N/A
+565538,"May 24, 2016",Delaware,"New Castle","50 block of W Balbach Ave",0,1,N/A
+563942,"May 21, 2016",Delaware,Seaford,"22000 block of Coverdale Road",0,0,N/A
+562364,"May 19, 2016",Delaware,Wilmington,"900 block of Clifford Brown Walk",1,0,N/A
+562367,"May 18, 2016",Delaware,Wilmington,"1600 block of Thatcher St",0,1,N/A
+562371,"May 17, 2016",Delaware,Dover,"South Kirkwood and Division streets",0,0,N/A
+562088,"May 17, 2016",Delaware,Wilmington,"Beech and South Van Buren Streets",0,1,N/A
+561099,"May 16, 2016",Delaware,Wilmington,"1000 block of N. Lombard St.",0,1,N/A
+562093,"May 16, 2016",Delaware,Middletown,"Marl Pit Road",0,0,N/A
+559908,"May 15, 2016",Delaware,Wilmington,"600 block of W. Sixth St.",0,1,N/A
+559898,"May 15, 2016",Delaware,Dover,"Fulton Street",0,1,N/A
+559893,"May 14, 2016",Delaware,Dover,"East Water Street and New Castle Avenue",0,1,N/A
+557792,"May 11, 2016",Delaware,Milford,"300 Aurora Place",0,1,N/A
+556605,"May 9, 2016",Delaware,Wilmington,"N Market St and 23rd St",0,1,N/A
+556041,"May 8, 2016",Delaware,Wilmington,"100 block of South Franklin Street",0,1,N/A
+822763,"May 7, 2016",Delaware,Dover,"900 block of Janeka Lane",0,1,N/A
+556036,"May 7, 2016",Delaware,Wilmington,"North Market and 27th streets",0,2,N/A
+556039,"May 7, 2016",Delaware,Wilmington,"W 3rd St and N Rodney St",1,0,N/A
+553141,"May 3, 2016",Delaware,Wilmington,"600 block of N. Madison St",0,1,N/A
+551677,"May 2, 2016",Delaware,"Wilmington (Edgemoor)","Rysing Dr and N Cannon Dr",0,2,N/A
+552527,"May 1, 2016",Delaware,Magnolia,"400 block of West Chestnut Ridge Drive",0,0,N/A
+552525,"April 30, 2016",Delaware,Dover,"North DuPont Highway and Lake View Drive",0,0,N/A
+552521,"April 29, 2016",Delaware,Dover,"200 block of Acorn Lane",0,0,N/A
+549094,"April 26, 2016",Delaware,"New Castle","100 block of Freedom Trail",1,0,N/A
+549091,"April 26, 2016",Delaware,Dover,"Queen and Reed streets",0,1,N/A
+548254,"April 25, 2016",Delaware,Wilmington,"400 block of Anderson Dr",1,0,N/A
+546101,"April 22, 2016",Delaware,Townsend,"500 block of Dogtown Rd",1,0,N/A
+546095,"April 21, 2016",Delaware,Wilmington,"400 block of W 3rd St",0,1,N/A
+543635,"April 16, 2016",Delaware,Wilmington,"10th and Bennett streets",0,0,N/A
+541404,"April 15, 2016",Delaware,Bear,"800 block of Seymour Road",0,1,N/A
+544213,"April 14, 2016",Delaware,Magnolia,"100 block of Terry Dr",0,0,N/A
+537216,"April 8, 2016",Delaware,"New Castle","Simmonds Drive",0,0,N/A
+535119,"April 4, 2016",Delaware,Wilmington,"400 block of Maryland Ave.",0,1,N/A
+536112,"April 1, 2016",Delaware,Wilmington,"800 block of N. Pine St.",0,0,N/A
+1058478,"April 1, 2016",Delaware,Wilmington,"3806 Governor Printz Blvd",1,1,N/A
+532441,"March 30, 2016",Delaware,"New Castle","Centerville Road",0,1,N/A
+532432,"March 30, 2016",Delaware,"New Castle","3000 block of New Castle Avenue",0,1,N/A
+532430,"March 30, 2016",Delaware,Wilmington,"1100 block of Elm St",1,0,N/A
+1102836,"March 30, 2016",Delaware,Dover,"2300 block of Port Mahon Rd",1,0,N/A
+530730,"March 28, 2016",Delaware,Dover,"Reese and Lincoln streets",0,0,N/A
+530025,"March 28, 2016",Delaware,Wilmington,"12th Street and Northeast Boulevard",0,1,N/A
+529968,"March 27, 2016",Delaware,Wilmington,"28th and Market streets",0,1,N/A
+529964,"March 27, 2016",Delaware,Wilmington,"2700 block of N. Pine Street",0,1,N/A
+530732,"March 27, 2016",Delaware,Harrington,"300 block of Flat Iron Rd",0,1,N/A
+528179,"March 23, 2016",Delaware,Dover,"Cecil and New Streets",0,0,N/A
+526919,"March 22, 2016",Delaware,Wilmington,"600 block of North Jefferson Street",0,1,N/A
+527231,"March 22, 2016",Delaware,Wilmington,"400 block of Porter St.",0,1,N/A
+527228,"March 22, 2016",Delaware,Dover,"North Kirkwood Street",0,0,N/A
+526128,"March 20, 2016",Delaware,Newark,"268 Cornell Dr",0,0,N/A
+525283,"March 19, 2016",Delaware,Wilmington,"300 block of New Castle Ave",0,1,N/A
+1065973,"March 17, 2016",Delaware,Wilmington,"200 block of Franklin St",0,1,N/A
+524869,"March 17, 2016",Delaware,Wilmington,"200 block of N Connell St",1,0,N/A
+531400,"March 16, 2016",Delaware,Wilmington,"1100 block of Lorewood Grove Road",0,0,N/A
+523430,"March 16, 2016",Delaware,Wilmington,"800 block of Morrow St.",0,1,N/A
+523437,"March 15, 2016",Delaware,Wilmington,"Ninth and Spruce streets",0,1,N/A
+523433,"March 15, 2016",Delaware,Wilmington,"1100 block of Lancaster Avenue",0,1,N/A
+523435,"March 14, 2016",Delaware,Wilmington,"11th and Clifford Brown Walk",0,1,N/A
+521616,"March 12, 2016",Delaware,Wilmington,"400 block of W. Seventh Street",0,1,N/A
+521063,"March 11, 2016",Delaware,Wilmington,"600 block of Taylor St",1,0,N/A
+532446,"March 10, 2016",Delaware,Dover,"100 block of Westover Drive",0,0,N/A
+520100,"March 10, 2016",Delaware,Wilmington,"900 block of Bennett St",0,1,N/A
+521964,"March 10, 2016",Delaware,Dover,"S. New and Division streets",0,0,N/A
+520108,"March 9, 2016",Delaware,"New Castle","100 block of Covington Place",0,1,N/A
+519243,"March 8, 2016",Delaware,Wilmington,"50 block of Gordon St",1,0,N/A
+519246,"March 8, 2016",Delaware,Wilmington,"Taylor and Bennett streets",0,1,N/A
+518862,"March 7, 2016",Delaware,Wilmington,"Seventh and Franklin streets",1,0,N/A
+516723,"March 4, 2016",Delaware,Wilmington,"1200 block of West 7th Street",1,0,N/A
+516407,"March 3, 2016",Delaware,Wilmington,"500 block of W. 6th St.",0,1,N/A
+516182,"March 3, 2016",Delaware,Dover,"257 N Dupont Hwy",0,0,N/A
+516172,"March 3, 2016",Delaware,Wilmington,"500 block of West 6th Street",0,1,N/A
+516003,"March 2, 2016",Delaware,Wilmington,"2100 block of Pine Street",0,0,N/A
+514968,"March 1, 2016",Delaware,Wilmington,"2900 block of Jessup Street",0,1,N/A
+513141,"February 28, 2016",Delaware,"New Castle","50 block of Oakmont Dr",0,1,N/A
+513121,"February 27, 2016",Delaware,Wilmington,"2100 block of North Pine Street",0,1,N/A
+513484,"February 27, 2016",Delaware,Newark,"4140 Ogletown-Stanton Road",0,0,N/A
+513119,"February 27, 2016",Delaware,Newark,"16 Chatham Ln",1,0,N/A
+512682,"February 26, 2016",Delaware,Wilmington,"1000 block of North Pine Street",1,0,N/A
+512687,"February 26, 2016",Delaware,Wilmington,"Shearman Street",0,1,N/A
+512685,"February 26, 2016",Delaware,Wilmington,"800 block of North Pine Street",0,1,N/A
+512332,"February 25, 2016",Delaware,Dover,"200 block of S. Governors Boulevard",1,0,N/A
+510725,"February 23, 2016",Delaware,Wilmington,"200 block of North Madison Street",0,0,N/A
+509438,"February 21, 2016",Delaware,Dover,"West Reed Street",0,1,N/A
+508827,"February 20, 2016",Delaware,Dover,"316 Fulton Street",0,0,N/A
+508832,"February 20, 2016",Delaware,Wilmington,"Madison Street",0,1,N/A
+508052,"February 19, 2016",Delaware,Wilmington,"1900 block of Maryland Avenue",0,2,N/A
+507527,"February 18, 2016",Delaware,Wilmington,"1300 block of Clifford Brown Walk",0,1,N/A
+506140,"February 16, 2016",Delaware,Newark,"750 East Delaware Avenue",0,0,N/A
+504897,"February 13, 2016",Delaware,Wilmington,"1700 block of West Second Street",0,1,N/A
+504411,"February 12, 2016",Delaware,Wilmington,"300 block of Clyde Street",1,1,N/A
+503693,"February 10, 2016",Delaware,Wilmington,"200 block of W. 30th St.",0,0,N/A
+503690,"February 9, 2016",Delaware,Wilmington,"1100 block of Linden Street",0,0,N/A
+503687,"February 9, 2016",Delaware,Wilmington,"200 block of West 29th Street",0,0,N/A
+502411,"February 8, 2016",Delaware,Wilmington,"1100 block of W. Second St.",0,1,N/A
+502159,"February 8, 2016",Delaware,"New Castle","128 N Dupont Hwy",1,0,N/A
+502414,"February 7, 2016",Delaware,Bridgeville,"Apple Tree Road",0,0,N/A
+502418,"February 5, 2016",Delaware,Wilmington,"Hay Road",0,0,N/A
+500577,"February 3, 2016",Delaware,Dover,"Barrister Place",0,0,N/A
+497655,"January 29, 2016",Delaware,Dover,"800 block of Lincoln Street",0,0,N/A
+893697,"January 28, 2016",Delaware,Wilmington,"25th Street",0,0,N/A
+495247,"January 28, 2016",Delaware,Wilmington,"2500 block of West Street",0,0,N/A
+494253,"January 27, 2016",Delaware,"New Castle","Wilton Blvd",0,1,N/A
+494245,"January 26, 2016",Delaware,Wilmington,"2200 block of Jessup Street",0,1,N/A
+495252,"January 25, 2016",Delaware,Wilmington,"West 36th Street",0,0,N/A
+490623,"January 21, 2016",Delaware,Dover,"Greenhill Avenue and White Oak Road",0,0,N/A
+490842,"January 20, 2016",Delaware,Wilmington,"27th Street and Bowers Street",0,0,N/A
+485185,"January 13, 2016",Delaware,Wilmington,"1200 block of N. Locust St",1,0,N/A
+484383,"January 12, 2016",Delaware,Dover,"211 Delaware Avenue",0,0,N/A
+483750,"January 11, 2016",Delaware,Wilmington,"900 block of Brown Street",1,4,N/A
+483758,"January 11, 2016",Delaware,Wilmington,"1800 block of West Second Street",0,1,N/A
+484462,"January 8, 2016",Delaware,Dover,"2600 block of South State Street",0,0,N/A
+480933,"January 7, 2016",Delaware,Bridgeville,"2000 block of Conrail Street",1,0,N/A
+482083,"January 7, 2016",Delaware,Bridgeville,"2000 block of Conrail Road",0,0,N/A
+481062,"January 7, 2016",Delaware,Dover,"Churchmans Road",0,0,N/A
+478192,"January 3, 2016",Delaware,Wilmington,"600 block of West Fifth St.",0,1,N/A
+478185,"January 3, 2016",Delaware,Newark,"50 block of Mercer Dr",0,1,N/A
+477725,"January 2, 2016",Delaware,"Wilmington (Edgemoor)","South Cannon Drive",0,0,N/A
+476209,"December 30, 2015",Delaware,Middletown,"300 block of Jefferson Street",0,3,N/A
+476203,"December 30, 2015",Delaware,Newark,"4126 Ogletown Stanton Road",0,1,N/A
+474562,"December 28, 2015",Delaware,Wilmington,"Concord Avenue and Jefferson Street",0,1,N/A
+473312,"December 27, 2015",Delaware,Wilmington,"North Broom Street and West Third Street",0,2,N/A
+473295,"December 27, 2015",Delaware,Dover,"801 N Dupont Hwy",0,1,N/A
+474086,"December 27, 2015",Delaware,Newark,"Kirkwood Highway and Wollaston Avenue",0,0,N/A
+474083,"December 27, 2015",Delaware,Wilmington,"East 23rd and Lamotte Streets",1,1,N/A
+472684,"December 26, 2015",Delaware,Lincoln,"21000 block of West Mayhew Drive",0,1,N/A
+474081,"December 23, 2015",Delaware,Wilmington,"Gov. Printz Boulevard",0,1,N/A
+472068,"December 23, 2015",Delaware,Wilmington,"1100 block of Beech Street",0,1,N/A
+469319,"December 21, 2015",Delaware,Claymont,"749 Montclair Drive",0,1,N/A
+470080,"December 21, 2015",Delaware,Wilmington,"East 23rd Street",1,0,N/A
+472043,"December 21, 2015",Delaware,Dover,"1502 E Lebanon Rd",0,0,N/A
+469061,"December 20, 2015",Delaware,Wilmington,"Locust and East 23rd Streets",0,1,N/A
+470073,"December 20, 2015",Delaware,"Millsboro (Long Neck)","34000 block of Starboard Court",0,0,N/A
+470070,"December 20, 2015",Delaware,Wilmington,"1000 block of West Fourth Street",0,1,N/A
+469301,"December 18, 2015",Delaware,Bear,"100 block of Hawk Drive",0,1,N/A
+467928,"December 17, 2015",Delaware,Laurel,"Sussex Highway",0,0,N/A
+467899,"December 17, 2015",Delaware,Wilmington,"2300 block of N Monroe St",0,1,N/A
+467937,"December 17, 2015",Delaware,Newark,"300 block of Salem Church Road",0,1,N/A
+468290,"December 15, 2015",Delaware,Dover,"South Little Creek Road",0,0,N/A
+466078,"December 15, 2015",Delaware,"New Castle","100 block of Freedom Trail",0,1,N/A
+467939,"December 13, 2015",Delaware,Dover,"779 North DuPont Highway",0,0,N/A
+466085,"December 11, 2015",Delaware,Wilmington,"1300 block of Read St.",0,1,N/A
+463944,"December 10, 2015",Delaware,Dover,"Village Drive",0,1,N/A
+463619,"December 9, 2015",Delaware,Wilmington,"West Fourth Street",0,0,N/A
+467901,"December 9, 2015",Delaware,Wilmington,"2200 block of North Market Street",0,1,N/A
+467894,"December 8, 2015",Delaware,Georgetown,"Park Avenue",0,0,N/A
+467903,"December 5, 2015",Delaware,Wilmington,"2500 block of Bowers Street",0,1,N/A
+459713,"December 3, 2015",Delaware,Wilmington,"2702 Jacqueline Dr",1,0,N/A
+459928,"December 3, 2015",Delaware,Dover,"Cecil and New",0,0,N/A
+457165,"December 1, 2015",Delaware,Wilmington,"700 block of E. 22nd St.",1,0,N/A
+455263,"November 29, 2015",Delaware,Frederica,"Johnny Cake Landing Road",0,2,N/A
+455268,"November 28, 2015",Delaware,Wilmington,"2700 block of Northeast Boulevard",0,1,N/A
+454440,"November 27, 2015",Delaware,Bear,"1921 Pulaski Hwy",1,0,N/A
+454286,"November 26, 2015",Delaware,"New Castle","3000 block of New Castle Ave",0,0,N/A
+454301,"November 25, 2015",Delaware,Wilmington,"2500 block of Carter Street",0,1,N/A
+453108,"November 24, 2015",Delaware,Bear,"Brookmont Dr and Pulaski Hwy",0,0,N/A
+453110,"November 23, 2015",Delaware,Dover,"200 block of South New Street",0,0,N/A
+450860,"November 20, 2015",Delaware,Wilmington,"W 20th St and N West St",0,1,N/A
+450852,"November 18, 2015",Delaware,Newark,"100 Mcintosh Plaza",0,0,N/A
+450616,"November 17, 2015",Delaware,Dover,"Lincoln Street and Gibbs Drive",0,0,N/A
+448724,"November 16, 2015",Delaware,Dover,"White Oak Road and Frear Drive",0,0,N/A
+1274281,"November 16, 2015",Delaware,Wilmington,"1031 S Market St",1,0,N/A
+447533,"November 13, 2015",Delaware,Claymont,"Harvey Road and Garfield Avenue",1,0,N/A
+447061,"November 13, 2015",Delaware,Harrington,"West Center Street",0,0,N/A
+445591,"November 10, 2015",Delaware,"Wilmington (Edgemoor)","Philadelphia Pk and Beeson Ave",0,0,N/A
+441709,"November 3, 2015",Delaware,Wilmington,"900 block of Maryland Avenue",0,1,N/A
+440963,"November 2, 2015",Delaware,Wilmington,"3rd and North Harrison Street",0,2,N/A
+441729,"November 2, 2015",Delaware,Dover,"Beechwood Avenue",0,1,N/A
+441713,"November 2, 2015",Delaware,Wilmington,"South Heald and Lobdell street",0,1,N/A
+441711,"November 2, 2015",Delaware,Wilmington,"Taylor and Kirkwood",0,1,N/A
+440528,"November 1, 2015",Delaware,Wilmington,"10th and Bennett Streets",0,2,N/A
+440048,"October 31, 2015",Delaware,Dover,"1131 N Dupont Hwy",0,1,N/A
+440114,"October 31, 2015",Delaware,Milford,"100 block of West St.",0,0,N/A
+443068,"October 29, 2015",Delaware,Wilmington,"1801 Milltown Road",0,0,N/A
+438800,"October 28, 2015",Delaware,Felton,"Barney Jenkins Rd and S DuPont Hwy",0,0,N/A
+437693,"October 27, 2015",Delaware,Wilmington,"1300 block of Lancaster Avenue",0,2,N/A
+437889,"October 27, 2015",Delaware,Wilmington,"1800 block of Prospect Rd",0,1,N/A
+437703,"October 25, 2015",Delaware,Laurel,"County Seat Highway",0,1,N/A
+435563,"October 22, 2015",Delaware,Wilmington,"800 block of Vanever Avenue",0,3,N/A
+434682,"October 21, 2015",Delaware,Dover,"South Du Pont Highway and Martin Luther King Jr. Boulevard",0,0,N/A
+434668,"October 21, 2015",Delaware,Wilmington,"800 block of Spruce St.",0,1,N/A
+434684,"October 20, 2015",Delaware,Wilmington,"100 block of Lower Oak St.",1,0,N/A
+434676,"October 19, 2015",Delaware,"New Castle","1300 block of W. Fourth St.",0,0,N/A
+432165,"October 17, 2015",Delaware,Dover,"1400 John Clark Road",2,1,N/A
+431669,"October 15, 2015",Delaware,Wilmington,"900 W. Eighth St",0,0,N/A
+431490,"October 15, 2015",Delaware,Wilmington,"West 27th and Tatnall Streets",0,1,N/A
+430941,"October 14, 2015",Delaware,Wilmington,"Claymont Street",0,1,N/A
+430929,"October 14, 2015",Delaware,Wilmington,"300 block of N Monroe St",1,0,N/A
+430932,"October 14, 2015",Delaware,Wilmington,"West Third and North Lincoln Streets",0,3,N/A
+430936,"October 13, 2015",Delaware,Wilmington,"900 block of Buyer Street",0,0,N/A
+429644,"October 11, 2015",Delaware,"New Castle","50 block of Oakmont Dr",0,1,N/A
+429813,"October 11, 2015",Delaware,"New Castle","Oakmont Drive",0,1,N/A
+429806,"October 11, 2015",Delaware,Middletown,"Greenlawn Boulevard",0,0,N/A
+430596,"October 6, 2015",Delaware,Dover,"West Division and North Queen Streets",0,0,N/A
+426731,"October 5, 2015",Delaware,Wilmington,"Bennett and East Eighth streets",0,1,N/A
+426769,"October 5, 2015",Delaware,Wilmington,"100 block of W. 27th St.",0,1,N/A
+425419,"October 5, 2015",Delaware,Wilmington,"300 block of E. 14th St.",0,1,N/A
+426733,"October 4, 2015",Delaware,"New Castle","30 Highland Blvd",0,0,N/A
+424405,"October 2, 2015",Delaware,Dover,"400 Barrister Place",1,0,N/A
+424430,"October 2, 2015",Delaware,Newark,"1-29 E Cleveland Ave",0,1,N/A
+424341,"October 1, 2015",Delaware,Wilmington,"West 28th and North West",0,1,N/A
+424630,"October 1, 2015",Delaware,Wilmington,"E. 23rd St.",0,1,N/A
+422728,"September 29, 2015",Delaware,Dover,"Fulton Street",0,1,N/A
+421473,"September 27, 2015",Delaware,Wilmington,"600 block of N. Jefferson St.",0,1,N/A
+421470,"September 27, 2015",Delaware,Wilmington,"1000 block of S. Market St.",0,1,N/A
+420034,"September 24, 2015",Delaware,"New Castle","Jensen Drive",0,1,N/A
+420027,"September 24, 2015",Delaware,Bear,"Pulaski Highway",0,1,N/A
+419319,"September 23, 2015",Delaware,Wilmington,"Tulip and South Scott streets",1,0,N/A
+415920,"September 18, 2015",Delaware,Wilmington,"4th and N. Van Buren",0,0,N/A
+415911,"September 16, 2015",Delaware,"New Castle","100 Wildfire Lane",0,0,N/A
+415295,"September 16, 2015",Delaware,Bear,"100 block of Wimbledon Court",0,0,N/A
+412222,"September 10, 2015",Delaware,Wilmington,"4th and Lombard Streets",0,1,N/A
+411604,"September 9, 2015",Delaware,Wilmington,"500 block of E. Ninth Street",0,1,N/A
+411596,"September 8, 2015",Delaware,Dover,"Kent Avenue and Water Street",0,0,N/A
+410901,"September 8, 2015",Delaware,Wilmington,"Pennsylvania Avenue and North Van Buren Street",0,0,N/A
+410388,"September 7, 2015",Delaware,Claymont,"Ridge Road",0,1,N/A
+410386,"September 7, 2015",Delaware,Wilmington,"600 block of W. Sixth St.",1,0,N/A
+410390,"September 6, 2015",Delaware,Felton,"1000 block of Cabin Ridge Road",1,0,N/A
+409031,"September 5, 2015",Delaware,Wilmington,"600 block of N. Monroe St.",0,1,N/A
+408928,"September 4, 2015",Delaware,Dover,N/A,0,1,N/A
+408921,"September 4, 2015",Delaware,Wilmington,"800 block of W. Third St",0,0,N/A
+408418,"September 3, 2015",Delaware,Dover,"1019 Walker Road",0,0,N/A
+408409,"September 3, 2015",Delaware,Wilmington,"North Madison Street and West 24th Street",0,1,N/A
+408407,"September 3, 2015",Delaware,Wilmington,"West 25th Street and North Market Street",0,1,N/A
+405510,"September 1, 2015",Delaware,Wilmington,"Gordon and Lamotte streets",0,1,N/A
+404153,"August 30, 2015",Delaware,"Ocean View","37000 block of Muddy Neck Road",0,1,N/A
+502948,"August 30, 2015",Delaware,"Ocean View (Oceanview)","37000 block of Muddy Neck Road",0,1,N/A
+405005,"August 29, 2015",Delaware,Laurel,"West Eighth Street",0,0,N/A
+404399,"August 29, 2015",Delaware,Wilmington,"1200 block of Vandever Ave",0,1,N/A
+404397,"August 29, 2015",Delaware,Wilmington,"West Sixth Street",0,1,N/A
+405527,"August 28, 2015",Delaware,Dover,"Webbs Lane",0,1,N/A
+405517,"August 28, 2015",Delaware,Milford,"300 Aurora Pl",0,0,N/A
+403519,"August 28, 2015",Delaware,Wilmington,"Delamore Place",0,0,N/A
+403517,"August 28, 2015",Delaware,Dover,"100 block of New Street",0,1,N/A
+402512,"August 24, 2015",Delaware,Hockessin,"Saint Clair Dr",1,0,N/A
+399627,"August 22, 2015",Delaware,Claymont,"Harvey Rd and Jackson Ave",0,1,N/A
+399162,"August 21, 2015",Delaware,Wilmington,"200 block of North Monroe Street",0,1,N/A
+399158,"August 21, 2015",Delaware,Wilmington,"200 block of Delamore Place",0,1,N/A
+402485,"August 21, 2015",Delaware,Dover,"South Governors Avenue",0,0,N/A
+397955,"August 18, 2015",Delaware,Wilmington,"500 block of Vandever Ave.",0,1,N/A
+396949,"August 18, 2015",Delaware,Wilmington,"700 block of Townsend Place",0,1,N/A
+396674,"August 17, 2015",Delaware,Wilmington,"10th and Bennett Streets",0,1,N/A
+396668,"August 16, 2015",Delaware,Wilmington,"West 6th and Madison Streets",0,1,N/A
+395924,"August 15, 2015",Delaware,Wilmington,"North Locust Street",0,1,N/A
+395926,"August 15, 2015",Delaware,Wilmington,"800 block of Vandever Ave",1,0,N/A
+394815,"August 13, 2015",Delaware,Wilmington,"West Second Street and North Madison Street",0,1,N/A
+394813,"August 13, 2015",Delaware,Wilmington,"Pleasant Street and North Van Buren Street",0,1,N/A
+394819,"August 12, 2015",Delaware,Wilmington,"17th and Thatcher Streets",0,0,N/A
+394829,"August 12, 2015",Delaware,Newark,"200 block of Warfield Rd",0,0,N/A
+391450,"August 10, 2015",Delaware,Wilmington,"400 block of W. 7th Street",1,2,N/A
+394253,"August 10, 2015",Delaware,Dover,"1210 White Oak Road",0,1,N/A
+394251,"August 10, 2015",Delaware,Dover,"Manchester Square and Stevenson Drive",0,0,N/A
+393978,"August 9, 2015",Delaware,Dover,"652 North DuPont Highway",0,0,N/A
+391403,"August 9, 2015",Delaware,Lincoln,"21000 block of W. Mayhew Dr.",0,2,N/A
+394248,"August 9, 2015",Delaware,Wilmington,"2400 block of North Tatnall Street",0,1,N/A
+393966,"August 8, 2015",Delaware,Dover,"500 Persimmon Tree Ln",0,1,N/A
+390405,"August 8, 2015",Delaware,Milford,"500 block of N Walnut St",1,0,N/A
+390146,"August 7, 2015",Delaware,Wilmington,"2400 block of Carter Street",0,1,N/A
+389585,"August 6, 2015",Delaware,Dagsboro,"28000 block of East Diamond Dr",0,0,N/A
+385271,"July 31, 2015",Delaware,Claymont,"Pennsylvania Avenue and Mansion Avenue",0,1,N/A
+385093,"July 30, 2015",Delaware,"Rehoboth Beach","300 block of Rehoboth Ave",0,0,N/A
+383572,"July 29, 2015",Delaware,"New Castle","300 block of Martin Drive",1,1,N/A
+383564,"July 29, 2015",Delaware,Wilmington,"777 Delaware Park Blvd",0,1,N/A
+389589,"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",1,1,N/A
+383055,"July 25, 2015",Delaware,Newark,"First block of Raven Turn",0,0,N/A
+383051,"July 24, 2015",Delaware,Wilmington,"800 block of of W. Ninth St.",0,0,N/A
+381692,"July 24, 2015",Delaware,Wilmington,"2501 Newport Gap Pike",0,1,N/A
+381203,"July 24, 2015",Delaware,Claymont,"4th Avenue",0,1,N/A
+381085,"July 23, 2015",Delaware,Wilmington,"West Fourth and Washington Streets",1,0,N/A
+385084,"July 22, 2015",Delaware,Wilmington,"500 block of N. Madison St",0,1,N/A
+379387,"July 22, 2015",Delaware,Wilmington,"900 block of Maryland Ave",0,1,N/A
+379382,"July 22, 2015",Delaware,Wilmington,"500 block of North Madison St",0,1,N/A
+381205,"July 22, 2015",Delaware,Dover,"400 block of Sussex Avenue",0,0,N/A
+379390,"July 21, 2015",Delaware,Wilmington,"Chestnut and South Franklin streets",0,1,N/A
+378653,"July 21, 2015",Delaware,Wilmington,"2400 block of Carter St",0,1,N/A
+379384,"July 21, 2015",Delaware,Bear,"20 block of Monferrato Ct",2,0,N/A
+378645,"July 20, 2015",Delaware,Wilmington,"800 block of Vandever Ave",0,0,N/A
+376804,"July 18, 2015",Delaware,Wilmington,"Concord Avenue and North Washington",0,2,N/A
+377414,"July 18, 2015",Delaware,Wilmington,"100 block of N. Clayton St",0,1,N/A
+376126,"July 16, 2015",Delaware,Dover,"400 block of New Castle Avenue",0,0,N/A
+376116,"July 16, 2015",Delaware,Wilmington,"Lancaster Avenue and Du Pont Street",1,0,N/A
+1267751,"July 15, 2015",Delaware,Wilmington,"1800 block of Foulk Rd",0,0,N/A
+375307,"July 14, 2015",Delaware,Wilmington,"400 block of S. Madison St",0,1,N/A
+373963,"July 13, 2015",Delaware,"Wilmington (Edgemoor)",N/A,0,1,N/A
+373968,"July 13, 2015",Delaware,Dover,"900 block of W. North St.",1,0,N/A
+372149,"July 11, 2015",Delaware,Wilmington,"2300 block of Baynard Blvd.",0,1,N/A
+372147,"July 10, 2015",Delaware,Wilmington,"100 block of S. Franklin Street",0,1,N/A
+372085,"July 9, 2015",Delaware,Wilmington,"1300 block of West 6th Street",0,0,N/A
+371231,"July 8, 2015",Delaware,Wilmington,"100 block of N. Van Buren St.",0,1,N/A
+372083,"July 8, 2015",Delaware,Wilmington,"37012 Country Club Road",0,0,N/A
+371229,"July 8, 2015",Delaware,Newark,"Finch Way",0,0,N/A
+370471,"July 7, 2015",Delaware,Wilmington,"10th and Spruce streets",0,1,N/A
+372137,"July 7, 2015",Delaware,"Rehoboth Beach","37000 block of Country Club Road",0,0,N/A
+369883,"July 6, 2015",Delaware,Wilmington,"Sixth and Madison Streets",0,1,N/A
+369880,"July 6, 2015",Delaware,Dover,"N. New St.",0,1,N/A
+369877,"July 6, 2015",Delaware,Seaford,"Tull Drive",0,2,N/A
+369875,"July 6, 2015",Delaware,Wilmington,"1400 block of W. Second St.",0,0,N/A
+367923,"July 2, 2015",Delaware,Wilmington,"603 Philadelphia Pike",0,0,N/A
+367377,"July 2, 2015",Delaware,Middletown,"100 block of St. Augustine Court",0,0,N/A
+367379,"July 1, 2015",Delaware,Wilmington,"900 block of N. Jefferson St.",0,0,N/A
+366806,"June 30, 2015",Delaware,Wilmington,"600 block of N. Broom St",1,0,N/A
+366798,"June 29, 2015",Delaware,Wilmington,"2900 block of N. Washington St",1,0,N/A
+366802,"June 29, 2015",Delaware,Wilmington,"400 block of S. Heald St.",0,0,N/A
+365399,"June 28, 2015",Delaware,Harrington,"100 block of East St",0,6,N/A
+365284,"June 26, 2015",Delaware,Newark,"Penman Seventy 6 Dr and Sandburg Pl",0,1,N/A
+363188,"June 23, 2015",Delaware,Wilmington,"600 block of N. Broom St",0,1,N/A
+363190,"June 22, 2015",Delaware,Bear,"100 block of Wimbledon Court",0,1,N/A
+358520,"June 15, 2015",Delaware,"New Castle","3 Memorial Dr",0,1,N/A
+358523,"June 14, 2015",Delaware,Wilmington,"600 block of North Jefferson Street",1,0,N/A
+360629,"June 14, 2015",Delaware,Milford,"100 block of NW Front St",0,0,N/A
+358525,"June 13, 2015",Delaware,Magnolia,"300 block of Marshview Terrace",0,2,N/A
+360627,"June 13, 2015",Delaware,Dover,"500 block of South Dupont Highway",0,0,N/A
+356044,"June 10, 2015",Delaware,Wilmington,"100 block of N. Connell St",0,1,N/A
+356047,"June 9, 2015",Delaware,Wilmington,"100 block of Delamore Place",0,1,N/A
+354415,"June 7, 2015",Delaware,Dover,"100 block of S. New St.",0,0,N/A
+353182,"June 6, 2015",Delaware,Dover,"South Little Creek Road",0,2,N/A
+353180,"June 6, 2015",Delaware,Dover,"1131 N Dupont Hwy",0,1,N/A
+351832,"June 2, 2015",Delaware,Wilmington,"West Fourth and Delamore Streets",0,1,N/A
+352594,"June 2, 2015",Delaware,Dover,"200 block of Frear Drive",0,0,N/A
+352588,"June 2, 2015",Delaware,"New Castle","Powhaten Road",0,2,N/A
+350696,"June 1, 2015",Delaware,Wilmington,"500 block of E. 10th St.",0,0,N/A
+351825,"June 1, 2015",Delaware,Wilmington,"100 block of North Broom Street",0,1,N/A
+351823,"June 1, 2015",Delaware,Wilmington,"Bedford Drive",0,1,N/A
+352592,"June 1, 2015",Delaware,Dover,"200 block of N. Kirkwood St.",0,1,N/A
+350667,"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",0,3,N/A
+352844,"May 31, 2015",Delaware,Dover,"100 block of Madison Court",0,0,N/A
+350659,"May 31, 2015",Delaware,"Port Penn","W. Market St.",1,0,N/A
+351817,"May 30, 2015",Delaware,Wilmington,"200 block of North Broom Street",0,0,N/A
+350648,"May 30, 2015",Delaware,Wilmington,"700 block of N. Washington Street",0,1,N/A
+349697,"May 29, 2015",Delaware,"New Castle","Christiana Road",0,0,N/A
+349078,"May 29, 2015",Delaware,Wilmington,"South Broom Street",0,1,N/A
+350687,"May 29, 2015",Delaware,Claymont,"600 block of Naamans Road",0,0,N/A
+349197,"May 28, 2015",Delaware,Newark,"750 E. Delaware Ave.",0,0,N/A
+347448,"May 27, 2015",Delaware,"Wilmington (Elsmere)","100 block of Brookside Avenue",1,0,N/A
+347474,"May 26, 2015",Delaware,Townsend,"3900 block of South Du Pont Highway",0,1,N/A
+394224,"May 26, 2015",Delaware,Townsend,"3900 block of DuPont Pkwy",0,2,N/A
+347450,"May 25, 2015",Delaware,Wilmington,"1900 block of West Street",0,1,N/A
+345589,"May 23, 2015",Delaware,Wilmington,"N Spruce St and Taylor St",0,1,N/A
+345218,"May 23, 2015",Delaware,Wilmington,N/A,0,1,N/A
+344293,"May 20, 2015",Delaware,Wilmington,"600 block of N. Madison St.",0,1,N/A
+343453,"May 19, 2015",Delaware,Wilmington,"12th Street and Northeast Boulevard",0,1,N/A
+343085,"May 18, 2015",Delaware,Dover,"1000 block of S. Little Creek Road",0,1,N/A
+340873,"May 15, 2015",Delaware,Dover,"East Water Street and Sussex Avenue",0,1,N/A
+352960,"May 15, 2015",Delaware,Dover,"Sussex Ave",0,1,N/A
+340216,"May 13, 2015",Delaware,Dover,"Harmony Lane",1,0,N/A
+340206,"May 13, 2015",Delaware,Bear,"100 block of Antlers Lane",1,0,N/A
+349195,"May 13, 2015",Delaware,Wilmington,"800 block of W. Third St.",0,1,N/A
+337796,"May 9, 2015",Delaware,Wilmington,"1000 block of S. Market St.",0,0,N/A
+337433,"May 8, 2015",Delaware,Newark,"Stanton-Christiana Road",0,0,N/A
+333262,"May 2, 2015",Delaware,Smyrna,"Malvern Lane",1,0,N/A
+332829,"April 30, 2015",Delaware,Dover,N/A,1,0,N/A
+331185,"April 28, 2015",Delaware,Dover,"100 block of South Queen Street",0,1,N/A
+331459,"April 28, 2015",Delaware,Wilmington,"600 block of W. Sixth St.",1,1,N/A
+331182,"April 27, 2015",Delaware,Wilmington,"Concord Avenue and West Street",0,0,N/A
+329802,"April 26, 2015",Delaware,Wilmington,"400 block of Maryland Avenue",0,1,N/A
+330310,"April 26, 2015",Delaware,Magnolia,"400 block of Lambert Drive",0,0,N/A
+330301,"April 26, 2015",Delaware,Dover,"N. New St.",1,0,N/A
+330306,"April 26, 2015",Delaware,"New Castle","100 block of Carvel Ave",0,0,N/A
+328172,"April 22, 2015",Delaware,Dover,"89 Kings Highway",0,0,N/A
+328734,"April 22, 2015",Delaware,Smyrna,"SR 1",0,0,N/A
+341571,"April 19, 2015",Delaware,Dover,"1200 N Dupont Hwy",0,0,N/A
+325516,"April 18, 2015",Delaware,Dover,"430 State College Road",0,3,N/A
+324265,"April 16, 2015",Delaware,Wilmington,"7th and West Streets",0,0,N/A
+323994,"April 15, 2015",Delaware,Wilmington,"800 block of Kirkwood Street",0,1,N/A
+323323,"April 14, 2015",Delaware,Wilmington,"W 27th St",1,0,N/A
+328177,"April 14, 2015",Delaware,Milford,"400 block of East Street",0,0,N/A
+323131,"April 13, 2015",Delaware,Wilmington,"800 block of Vandever Avenue",0,0,N/A
+318991,"April 6, 2015",Delaware,Wilmington,"700 block of Townsend Place",0,1,N/A
+318989,"April 6, 2015",Delaware,Newark,"Kimberton Drive",0,1,N/A
+325014,"April 4, 2015",Delaware,Wilmington,"200 block of N Monroe St",1,1,N/A
+318090,"April 4, 2015",Delaware,Wilmington,"Second and Madison Streets",1,1,N/A
+317576,"April 3, 2015",Delaware,Bridgeville,"Oak and Sanfilippo Roads",1,0,N/A
+317126,"April 3, 2015",Delaware,Wilmington,"West Seventh Street",0,1,N/A
+317123,"April 3, 2015",Delaware,Wilmington,"1031 S. Market St.",0,1,N/A
+317006,"April 1, 2015",Delaware,Dover,"300 block of W. Division St.",0,0,N/A
+316467,"April 1, 2015",Delaware,Wilmington,"200 block of N. Scott St.",0,1,N/A
+316021,"March 31, 2015",Delaware,Wilmington,"Lancaster Avenue and Delamore Place",0,1,N/A
+313749,"March 27, 2015",Delaware,Dover,"North Governors Avenue",0,0,N/A
+316027,"March 27, 2015",Delaware,Dover,"Queen and Cecil Streets",0,0,N/A
+313978,"March 27, 2015",Delaware,Wilmington,"South Franklin and Linden Streets",0,1,N/A
+313981,"March 27, 2015",Delaware,Magnolia,"Grays Ln",1,0,N/A
+314910,"March 27, 2015",Delaware,Wilmington,"Bethel Road",0,0,N/A
+313202,"March 25, 2015",Delaware,Claymont,"3300 Brandywine Parkway",0,1,N/A
+313184,"March 25, 2015",Delaware,Wilmington,"400 block of N. Rodney St.",0,0,N/A
+312779,"March 24, 2015",Delaware,Wilmington,"600 block of W. 4th St.",0,1,N/A
+312308,"March 24, 2015",Delaware,Wilmington,"5500 block of Heritage Court Dr",0,0,N/A
+311188,"March 22, 2015",Delaware,"New Castle","Moores Lane",0,2,N/A
+310731,"March 21, 2015",Delaware,Wilmington,"6th and N. Jefferson Streets",0,1,N/A
+310226,"March 20, 2015",Delaware,Delmar,"10000 block of Bacons Road",0,0,N/A
+308378,"March 16, 2015",Delaware,Dover,"Daniel Rodney Drive and David Hall Road",0,1,N/A
+305177,"March 12, 2015",Delaware,Wilmington,"Second and North Scott streets",0,1,N/A
+304724,"March 9, 2015",Delaware,Dover,"200 block of N. Du Pont Highway",0,1,N/A
+303132,"March 8, 2015",Delaware,"New Castle","I-495 and US-13",1,1,N/A
+304709,"March 8, 2015",Delaware,Newark,"300 block of Delaware Circle",0,0,N/A
+303119,"March 8, 2015",Delaware,Claymont,"600 block of Naamans Road",1,0,N/A
+303144,"March 7, 2015",Delaware,Dover,"1426 N Dupont Hwy",0,1,N/A
+303137,"March 7, 2015",Delaware,Dover,"100 block of S. Little Creek Road",0,0,N/A
+301062,"March 2, 2015",Delaware,Sussex,"35000 block of Spruce Road",0,0,N/A
+299872,"March 1, 2015",Delaware,Wilmington,"22nd and Spruce",0,1,N/A
+299868,"February 28, 2015",Delaware,Dover,"First block of Webbs Lane",0,0,N/A
+299292,"February 27, 2015",Delaware,Dover,"River Road and E. Water Street",0,0,N/A
+299103,"February 26, 2015",Delaware,Wilmington,"1200 block of Elm St.",0,0,N/A
+297290,"February 24, 2015",Delaware,"New Castle","Wilmington Road and East Sixth St.",0,0,N/A
+297008,"February 23, 2015",Delaware,Wilmington,"1300 block of French St.",0,0,N/A
+296397,"February 23, 2015",Delaware,Wilmington,"South Heald and Lobdell streets",0,1,N/A
+297018,"February 21, 2015",Delaware,Wilmington,"1200 block of N. Union St.",0,0,N/A
+294274,"February 16, 2015",Delaware,Wilmington,"E 24th St and Carter St",1,0,N/A
+294296,"February 16, 2015",Delaware,"New Castle","19 Lambson Ln",1,0,N/A
+294819,"February 14, 2015",Delaware,Townsend,"600 block of Marilyn Ct",1,0,N/A
+293089,"February 13, 2015",Delaware,Wilmington,"400 block of North Madison Street",0,0,N/A
+293094,"February 12, 2015",Delaware,Newark,"400 block of Kemper Dr",0,1,N/A
+291798,"February 11, 2015",Delaware,Wilmington,"Seventh and North Washington streets",0,1,N/A
+293097,"February 11, 2015",Delaware,"New Castle","Amstel Drive",1,0,N/A
+293354,"February 10, 2015",Delaware,Dover,"Stevenson Drive",0,0,N/A
+291800,"February 10, 2015",Delaware,Wilmington,"200 block of Delamore Place",0,0,N/A
+291380,"February 8, 2015",Delaware,Newark,"Albert St",0,0,N/A
+290388,"February 8, 2015",Delaware,Dover,"Rte 13",0,1,N/A
+290723,"February 6, 2015",Delaware,"New Castle","Sandalwood Court",0,0,N/A
+289515,"February 5, 2015",Delaware,Wilmington,"200 block of South Harrison Street",0,1,N/A
+288868,"February 4, 2015",Delaware,Wilmington,"Lobdell Street and New Castle Avenue",0,1,N/A
+287928,"February 2, 2015",Delaware,Wilmington,"800 block of Kirkwood St",0,1,N/A
+287926,"February 2, 2015",Delaware,Wilmington,"Cedar and Anchorage streets",0,1,N/A
+287339,"February 1, 2015",Delaware,"New Castle","5000 block of East Brigantine Court",0,1,N/A
+287341,"February 1, 2015",Delaware,Wilmington,"E. 26th St. and Northeast Boulevard",0,1,N/A
+287343,"January 31, 2015",Delaware,Elsmere,"200 block of Birch Ave",0,0,N/A
+288387,"January 31, 2015",Delaware,Wilmington,"Fourth and Jackson streets",0,0,N/A
+286540,"January 30, 2015",Delaware,Wilmington,"11th and Tatnell",0,0,N/A
+285267,"January 27, 2015",Delaware,Wilmington,"900 block of East 17th Street",1,0,N/A
+285275,"January 26, 2015",Delaware,Wilmington,"200 block of N. Broom St.",0,0,N/A
+283554,"January 24, 2015",Delaware,Wilmington,"300 block of W 21st Street",1,0,N/A
+283300,"January 23, 2015",Delaware,Wilmington,"200 block of N. Broom St.",1,2,N/A
+281759,"January 20, 2015",Delaware,"New Castle","500 block of S. DuPont Highway",0,1,N/A
+295695,"January 20, 2015",Delaware,"New Castle","500 block of South DuPont Highway",0,1,N/A
+281136,"January 19, 2015",Delaware,Dover,"North Kirkwood Street",0,0,N/A
+281132,"January 19, 2015",Delaware,Seaford,"26000 block of Bethel Concord Road",0,0,N/A
+280693,"January 18, 2015",Delaware,Wilmington,"700 block of E. 26th St.",1,0,N/A
+280301,"January 17, 2015",Delaware,Greenville,"Barley Mill Road",0,0,N/A
+280093,"January 15, 2015",Delaware,Sussex,"23000 block of Cinnamon Lane",0,0,N/A
+279158,"January 15, 2015",Delaware,Wilmington,"Vandever Ave. and Lamotte St",0,1,N/A
+279096,"January 14, 2015",Delaware,Wilmington,"700 block of N. Monroe St",0,0,N/A
+279093,"January 14, 2015",Delaware,"New Castle","Christiana Road",0,1,N/A
+279550,"January 14, 2015",Delaware,Wilmington,"600 block of Concord Avenue",1,0,N/A
+279091,"January 13, 2015",Delaware,Townsend,"Gum Bush Rd",1,0,N/A
+278098,"January 12, 2015",Delaware,Wilmington,"200 block of W. 23rd St.",1,0,N/A
+278092,"January 12, 2015",Delaware,Newark,"Vinings Way",2,0,N/A
+276839,"January 9, 2015",Delaware,"New Castle","200 block of Parma Ave",1,0,N/A
+310214,"January 8, 2015",Delaware,Dover,"Rt. 13",0,1,N/A
+276514,"January 8, 2015",Delaware,Kent,"4200 block of N. Du Pont Highway",0,1,N/A
+274953,"January 5, 2015",Delaware,Wilmington,"800 block of West St.",0,1,N/A
+272880,"December 30, 2014",Delaware,Milford,"1000 block of N. Walnut St.",0,0,N/A
+268404,"December 22, 2014",Delaware,Wilmington,"200 block of N. Clayton St.",0,0,N/A
+267133,"December 21, 2014",Delaware,Dover,"50 Greenway Square",1,0,N/A
+267911,"December 20, 2014",Delaware,Wilmington,"13 Lowry Dr",1,0,N/A
+266382,"December 19, 2014",Delaware,Wilmington,"700 block of Vandever Avenue",1,0,N/A
+266678,"December 18, 2014",Delaware,Wilmington,"500 block of Concord Ave",0,0,N/A
+266153,"December 15, 2014",Delaware,Wilmington,"300 block of E. Front St.",0,0,N/A
+264227,"December 15, 2014",Delaware,Wilmington,"900 block of N. Madison Street",0,1,N/A
+264229,"December 14, 2014",Delaware,Wilmington,"Heritage Drive",0,0,N/A
+263275,"December 12, 2014",Delaware,"Cedar Heights","Walnut and Maple Avenues",1,0,N/A
+262314,"December 9, 2014",Delaware,Wilmington,"Vanlyn Ct",0,0,N/A
+261041,"December 7, 2014",Delaware,Wilmington,"400 block of S. Heald St.",0,1,N/A
+266649,"December 6, 2014",Delaware,Laurel,N/A,0,0,N/A
+259686,"December 5, 2014",Delaware,Wilmington,"1051 S. Market St",0,0,N/A
+259674,"December 4, 2014",Delaware,Wilmington,"1100 block of West Second St.,",0,1,N/A
+259534,"December 4, 2014",Delaware,Wilmington,"West 2nd and Van Buren Streets",0,1,N/A
+227487,"December 3, 2014",Delaware,Wilmington,"2200 bock of N. Pine St. ",0,1,N/A
+226178,"November 26, 2014",Delaware,Newark,"N Bellwoode Dr",0,1,N/A
+226182,"November 26, 2014",Delaware,"New Castle","100 block of W 9th St",1,0,N/A
+225707,"November 26, 2014",Delaware,Wilmington,"23rd Street",0,1,N/A
+225767,"November 26, 2014",Delaware,Wilmington,"22nd and Spruce streets",0,1,N/A
+225795,"November 26, 2014",Delaware,Newark,"Bell Wood Drive",0,1,N/A
+225221,"November 25, 2014",Delaware,Wilmington,"200 block of W. 28th St.",0,1,N/A
+225227,"November 25, 2014",Delaware,Wilmington,"Maryland Avenue and Stroud Street",0,2,N/A
+224836,"November 24, 2014",Delaware,Milton,"501 Palmer St",1,1,N/A
+224054,"November 23, 2014",Delaware,Wilmington,"West 28th Street",0,1,N/A
+224831,"November 23, 2014",Delaware,Wilmington,"300 block of South Harrison Street",0,2,N/A
+223933,"November 22, 2014",Delaware,Wilmington,"27th Street and West Street",1,0,N/A
+223523,"November 21, 2014",Delaware,Wilmington,"700 block of East 10th Street",0,1,N/A
+223525,"November 20, 2014",Delaware,Wilmington,"22nd and N. Spruce Streets",0,1,N/A
+223527,"November 19, 2014",Delaware,Wilmington,"2700 block of Enterprise St.",0,1,N/A
+221727,"November 15, 2014",Delaware,Lincoln,"8819 Cedar Creek Road",0,1,N/A
+221704,"November 15, 2014",Delaware,Georgetown,"Cedar Creek Road",0,1,N/A
+221448,"November 15, 2014",Delaware,"New Castle","N. DuPont Highway",0,0,N/A
+221043,"November 14, 2014",Delaware,Claymont,"Harvey Road and Garfield Avenue",1,0,N/A
+221401,"November 14, 2014",Delaware,Wilmington,"700 N Monroe St",0,1,N/A
+221675,"November 13, 2014",Delaware,Newark,"Marrows Road",1,0,N/A
+221681,"November 12, 2014",Delaware,Bridgeville,"4700 block of Rabbit Run Road",0,0,N/A
+220104,"November 11, 2014",Delaware,Wilmington,"1100 block of W. Second St.",0,1,N/A
+220107,"November 11, 2014",Delaware,Wilmington,"1500 block of Lancaster Ave.",0,1,N/A
+220109,"November 11, 2014",Delaware,Wilmington,"4865 Governor Printz Blvd.",0,1,N/A
+220550,"November 11, 2014",Delaware,Wilmington,"Taylor and Bennett streets",0,1,N/A
+218426,"November 9, 2014",Delaware,Wilmington,"1200 block of Pleasant St",0,1,N/A
+217869,"November 8, 2014",Delaware,Wilmington,"24th and N. Tatnall Street",0,2,N/A
+217755,"November 7, 2014",Delaware,Wilmington,"South Road",0,2,N/A
+217308,"November 7, 2014",Delaware,Wilmington,"2400 block of N. Market St.",0,1,N/A
+217310,"November 6, 2014",Delaware,Wilmington,"Fourth and North Rodney Streets",0,0,N/A
+217312,"November 5, 2014",Delaware,Wilmington,"400 block of S. Heald St.",0,0,N/A
+217314,"November 5, 2014",Delaware,Wilmington,"Taylor and Kirkwood Streets",0,1,N/A
+221725,"November 5, 2014",Delaware,Wilmington,"200 block of Atlantic Avenue",0,0,N/A
+217319,"November 4, 2014",Delaware,Wilmington,"600 block of N. Jefferson St.",0,0,N/A
+216218,"November 4, 2014",Delaware,Wilmington,"Fifth and North Spruce Streets",0,1,N/A
+215051,"November 3, 2014",Delaware,Dover,"1570 N Dupont Hwy",0,1,N/A
+215054,"November 2, 2014",Delaware,Dover,"133 S. Bradford St.",0,1,N/A
+214316,"November 1, 2014",Delaware,Dover,"Loockerman Street",0,1,N/A
+213896,"October 30, 2014",Delaware,Wilmington,"Fifth and Webb Streets",0,1,N/A
+213894,"October 29, 2014",Delaware,Wilmington,"700 block of E. 26th St.",0,1,N/A
+211267,"October 26, 2014",Delaware,Dover,"Starboard Court",0,0,N/A
+212733,"October 25, 2014",Delaware,Wilmington,"500 block of Concord Avenue",0,0,N/A
+212735,"October 25, 2014",Delaware,Seaford,"Norman Eskridge Highway",0,0,N/A
+210887,"October 24, 2014",Delaware,Wilmington,"700 block of Wollaston St.",0,0,N/A
+210881,"October 23, 2014",Delaware,Wilmington,"900 block of East 17th Street",0,0,N/A
+210099,"October 23, 2014",Delaware,Wilmington,"Garasches Lane",0,1,N/A
+210113,"October 21, 2014",Delaware,Wilmington,"W. 29th St.",0,0,N/A
+210115,"October 21, 2014",Delaware,Wilmington,"300 block of W. 29th St.",0,0,N/A
+208242,"October 20, 2014",Delaware,Dover,"835 Bay Road",0,1,N/A
+208277,"October 19, 2014",Delaware,Wilmington,"Fifth and Springer Streets",0,1,N/A
+208841,"October 19, 2014",Delaware,Wilmington,"East 24th Street",0,0,N/A
+204622,"October 10, 2014",Delaware,Wilmington,"800 block of North Monroe Street",0,0,N/A
+204632,"October 9, 2014",Delaware,Dagsboro,"30000 block of Hoot Owl Ln",0,0,N/A
+204014,"October 8, 2014",Delaware,"Wilmington (Edgemoor)","Rysing Dr and S Rodney Dr",0,1,N/A
+203205,"October 8, 2014",Delaware,Wilmington,"Old Capitol Trail and St. James Road",0,0,N/A
+203236,"October 6, 2014",Delaware,Wilmington,"10th and Bennett Streets",0,0,N/A
+201858,"October 5, 2014",Delaware,Wilmington,"1030 S. Market St.",0,1,N/A
+200381,"October 2, 2014",Delaware,Wilmington,N/A,0,1,N/A
+200409,"October 2, 2014",Delaware,Wilmington,"West 3rd and North Dupont Street",0,0,N/A
+200407,"October 2, 2014",Delaware,Wilmington,"Northeast Boulevard and Vandever Avenue",0,0,N/A
+200369,"October 1, 2014",Delaware,Wilmington,"1100 block of B Street",0,0,N/A
+200374,"October 1, 2014",Delaware,Wilmington,"1300 block of E. 28th St.",0,0,N/A
+200386,"September 30, 2014",Delaware,Wilmington,"Ninth and Lombard Streets",0,0,N/A
+198725,"September 30, 2014",Delaware,Wilmington,"Cliffside Court",0,1,N/A
+198727,"September 28, 2014",Delaware,Wilmington,"800 block of Fourth Street",0,1,N/A
+197248,"September 27, 2014",Delaware,Newark,"Adelene Avenue",0,0,N/A
+197426,"September 27, 2014",Delaware,Wilmington,"800 block of Vandever Avenue",0,1,N/A
+195899,"September 23, 2014",Delaware,Wilmington,"2900 block of Washington Street",0,1,N/A
+194517,"September 20, 2014",Delaware,Wilmington,"Second and West Streets",0,1,N/A
+194244,"September 19, 2014",Delaware,Wilmington,"100 N Franklin St",0,1,N/A
+194233,"September 17, 2014",Delaware,Dover,"3400 block of Judith Rd",0,1,N/A
+191692,"September 15, 2014",Delaware,Elsmere,"2100 block of Seneca Road",0,2,N/A
+191695,"September 14, 2014",Delaware,Wilmington,"26th and North Heald streets",0,0,N/A
+189848,"September 11, 2014",Delaware,Laurel,"31000 block of White St",0,1,N/A
+189866,"September 11, 2014",Delaware,"New Castle","Route 141",0,0,N/A
+189856,"September 10, 2014",Delaware,Glasgow,"2200 block of Glasgow Avenue",0,1,N/A
+189861,"September 9, 2014",Delaware,Dover,"South Governors Boulevard and State Circle",0,1,N/A
+189824,"September 9, 2014",Delaware,Wilmington,"2900 block of West Street",1,0,N/A
+187972,"September 8, 2014",Delaware,Wilmington,"7th Street and Washington Street",0,1,N/A
+189836,"September 8, 2014",Delaware,Wilmington,"7th and Washington streets",0,1,N/A
+187260,"September 6, 2014",Delaware,Wilmington,"700 block of Tatnall Street",0,1,N/A
+187273,"September 5, 2014",Delaware,Middletown,"Lockwood Street",0,2,N/A
+186842,"September 5, 2014",Delaware,Wilmington,"Taylor and Kirkwood",0,1,N/A
+187778,"September 4, 2014",Delaware,Wilmington,"300 block of W. 24th St.",0,0,N/A
+185631,"September 3, 2014",Delaware,Wilmington,"East Seventh Street",0,0,N/A
+185652,"September 3, 2014",Delaware,Wilmington,"900 block of East 26th Street",0,1,N/A
+185654,"September 3, 2014",Delaware,Wilmington,"36th and Shipley Streets",0,1,N/A
+184880,"September 2, 2014",Delaware,Wilmington,"1200 block of Lancaster Avenue",0,1,N/A
+184885,"September 1, 2014",Delaware,Wilmington,"Taylor and Pine Streets",0,1,N/A
+183645,"August 31, 2014",Delaware,Wilmington,N/A,1,0,N/A
+183647,"August 31, 2014",Delaware,Wilmington,"27th St and Tatnall St",1,0,N/A
+183654,"August 30, 2014",Delaware,Wilmington,"1030 South Market Street",0,1,N/A
+183675,"August 30, 2014",Delaware,Wilmington,"300 block of North Bancroft Parkway",0,0,N/A
+183677,"August 30, 2014",Delaware,Wilmington,"800 block of North Spruce Street",0,0,N/A
+183649,"August 30, 2014",Delaware,Wilmington,"1600 block of West Fifth Street",0,0,N/A
+183656,"August 28, 2014",Delaware,Wilmington,"2700 block of North Heald Street",0,1,N/A
+181740,"August 27, 2014",Delaware,Dover,"North Kirkwood Street",0,1,N/A
+183662,"August 27, 2014",Delaware,"Mill Creek","1200 block of Braken Avenue",0,0,N/A
+181749,"August 26, 2014",Delaware,Wilmington,"50 block of Cunard St",0,1,N/A
+181727,"August 26, 2014",Delaware,Wilmington,"1000 block of South Rodney Street",0,0,N/A
+183651,"August 26, 2014",Delaware,Wilmington,"1400 block of North Washington Street",0,0,N/A
+181756,"August 25, 2014",Delaware,Wilmington,"800 block of Pine Street",0,0,N/A
+179911,"August 24, 2014",Delaware,Dover,"300 block of Simon Circle",1,1,N/A
+181226,"August 24, 2014",Delaware,Dover,"South Kirkwood Street",1,0,N/A
+179651,"August 23, 2014",Delaware,Seaford,"Ponds End Rd",0,2,N/A
+179913,"August 23, 2014",Delaware,Wilmington,"3000 block of Washington Street",0,0,N/A
+179216,"August 21, 2014",Delaware,Wilmington,"4600 block of North Market Street",0,1,N/A
+179332,"August 21, 2014",Delaware,Dover,"100 Governors Avenue",0,0,N/A
+178507,"August 21, 2014",Delaware,Lewes,"17000 block of King Philip Way",0,0,N/A
+177228,"August 19, 2014",Delaware,Wilmington,"West Third Street",1,0,N/A
+177634,"August 19, 2014",Delaware,Wilmington,"800 block of West Fourth Street",0,1,N/A
+177002,"August 17, 2014",Delaware,Wilmington,"400 block of North Washington Street",0,0,N/A
+177239,"August 17, 2014",Delaware,Bear,"Pulaski Highway and Wrangle Hill Road",0,0,N/A
+177012,"August 17, 2014",Delaware,Wilmington,"500 block of West 35th Street",0,0,N/A
+177262,"August 17, 2014",Delaware,Dover,"South New Street",0,1,N/A
+177266,"August 17, 2014",Delaware,"New Castle","100 block of Parma Avenue",0,1,N/A
+175966,"August 17, 2014",Delaware,Wilmington,"700 block of East 28th Street",0,1,N/A
+177222,"August 17, 2014",Delaware,"New Castle","West Eighth and Delaware Streets",0,0,N/A
+176797,"August 17, 2014",Delaware,Elsmere,"2700 block of Boulevard Road",0,0,N/A
+177018,"August 16, 2014",Delaware,Millsboro,"Mount Joy Road",0,0,N/A
+175975,"August 16, 2014",Delaware,Lincoln,"20639 Fleatown Road",0,1,N/A
+175977,"August 16, 2014",Delaware,Harrington,"South Du Pont Highway",0,0,N/A
+175960,"August 15, 2014",Delaware,Wilmington,"2700 block of Northeast Boulevard",0,1,N/A
+174610,"August 14, 2014",Delaware,Wilmington,"10th and Adams Streets",0,1,N/A
+174612,"August 13, 2014",Delaware,Wilmington,"24th and Claymont Streets",0,1,N/A
+173866,"August 12, 2014",Delaware,"New Castle","1627 New Jersey Ave",0,1,N/A
+173862,"August 12, 2014",Delaware,Wilmington,"300 block of North Du Pont Street",0,1,N/A
+173873,"August 12, 2014",Delaware,"New Castle","Memorial Drive",0,0,N/A
+173854,"August 12, 2014",Delaware,Wilmington,"400 block of North Monroe Street",0,3,N/A
+173923,"August 11, 2014",Delaware,Dover,N/A,0,0,N/A
+172237,"August 10, 2014",Delaware,Newark,"Old Baltimore Pike",0,0,N/A
+173701,"August 10, 2014",Delaware,Greenwood,"11000 block of Adamsville Road",0,0,N/A
+172239,"August 8, 2014",Delaware,Wilmington,"500 block of Shearman Street",0,1,N/A
+172241,"August 8, 2014",Delaware,Wilmington,"East 13th and Claymont Streets",1,0,N/A
+173888,"August 8, 2014",Delaware,"New Castle","U.S. 13",0,0,N/A
+172244,"August 8, 2014",Delaware,Wilmington,"West 27th and North Tatnall Streets",0,2,N/A
+173898,"August 8, 2014",Delaware,"New Castle","Stonebridge Boulevard",0,0,N/A
+171104,"August 7, 2014",Delaware,Wilmington,"600 block of West Lea Boulevard",1,0,N/A
+171107,"August 6, 2014",Delaware,Bear,"Delaware 71",0,0,N/A
+170923,"August 5, 2014",Delaware,Stanton,"1900 block of West Newport Pike",0,1,N/A
+171122,"August 4, 2014",Delaware,Wilmington,N/A,0,0,N/A
+169158,"August 3, 2014",Delaware,Laurel,"30661 Sussex Highway",0,0,N/A
+169162,"August 3, 2014",Delaware,Wilmington,"300 block of Concord Avenue",0,1,N/A
+177541,"August 3, 2014",Delaware,"New Castle","100 block of Stamm Boulevard",0,0,N/A
+169164,"August 1, 2014",Delaware,Wilmington,"300 block of Concord Avenue",0,1,N/A
+167145,"July 29, 2014",Delaware,Wilmington,"200 block of Washington Street",0,0,N/A
+167157,"July 29, 2014",Delaware,Wilmington,"700 block of Curlett Street",0,1,N/A
+167136,"July 28, 2014",Delaware,Newark,"50 block of Thorn Ln",0,1,N/A
+167177,"July 27, 2014",Delaware,Wilmington,"1300 block of Chestnut Street",0,1,N/A
+164602,"July 26, 2014",Delaware,Bear,"1800 block of Pulaski Highway",0,1,N/A
+167175,"July 25, 2014",Delaware,Seaford,"300 North Dual Highway",0,0,N/A
+164612,"July 22, 2014",Delaware,Smyrna,"50 block of E South St",0,0,N/A
+162092,"July 21, 2014",Delaware,Dover,"Saulsbury and Walker Roads",0,0,N/A
+162083,"July 20, 2014",Delaware,Dover,"N DuPont Hwy and Leipsic Rd",0,0,N/A
+164622,"July 17, 2014",Delaware,Millsboro,N/A,0,0,N/A
+160668,"July 17, 2014",Delaware,"New Castle","Buttonwood Ave",0,0,N/A
+160023,"July 17, 2014",Delaware,Wilmington,"22nd and Pine Streets",0,1,N/A
+159225,"July 14, 2014",Delaware,Dover,"Kentwood Drive",0,0,N/A
+158065,"July 13, 2014",Delaware,Wilmington,"100 block of North Van Buren Street",0,1,N/A
+159207,"July 13, 2014",Delaware,"New Castle","260 Christiana Road",0,1,N/A
+159238,"July 12, 2014",Delaware,Middletown,"300 block of Marldale Drive",0,0,N/A
+157809,"July 11, 2014",Delaware,Wilmington,"West 24th and North Market Streets",0,1,N/A
+157139,"July 9, 2014",Delaware,Wilmington,"15 West Lea Boulevard",0,0,N/A
+157130,"July 9, 2014",Delaware,Wilmington,"100 block of East 22nd Street",1,0,N/A
+162229,"July 8, 2014",Delaware,Wilmington,N/A,0,0,N/A
+156237,"July 7, 2014",Delaware,Wilmington,"West 35th and North Market Streets",0,0,N/A
+156253,"July 7, 2014",Delaware,Wilmington,"West 7th and North Adams Streets",1,0,N/A
+155281,"July 6, 2014",Delaware,Dover,"217 N Kirkwood St",0,2,N/A
+155273,"July 6, 2014",Delaware,Wilmington,"West Fifth and North Madison",0,1,N/A
+155275,"July 5, 2014",Delaware,Felton,"2000 block of Vernon Road",0,0,N/A
+156255,"July 5, 2014",Delaware,Wilmington,"200 block of North Van Buren Street",0,0,N/A
+155277,"July 4, 2014",Delaware,Wilmington,"100 block of West 27th Street",0,1,N/A
+156257,"July 4, 2014",Delaware,Wilmington,"300 block of North Monroe Street",0,0,N/A
+154580,"July 4, 2014",Delaware,Dover,"Norway Drive",0,1,N/A
+153849,"July 1, 2014",Delaware,Newark,"300 block of Sandburg Place",1,1,N/A
+153860,"June 30, 2014",Delaware,Middletown,"2111 Dupont Hwy",0,0,N/A
+153864,"June 30, 2014",Delaware,Newark,"50 block of Heron Ct",1,0,N/A
+197887,"June 30, 2014",Delaware,Newark,"Heron Court",1,0,N/A
+153873,"June 30, 2014",Delaware,Wilmington,"Pine and Taylor Streets",1,0,N/A
+152502,"June 29, 2014",Delaware,Townsend,"6300 block of Summit Bridge Road",0,1,N/A
+152565,"June 28, 2014",Delaware,Elsmere,"1950 Maryland Avenue",0,0,N/A
+151856,"June 28, 2014",Delaware,Wilmington,"Maryland Avenue",0,0,N/A
+151840,"June 27, 2014",Delaware,Bear,"1800 block of Pulaski Highway",0,0,N/A
+150623,"June 25, 2014",Delaware,Magnolia,"Bay Hill  Ln and W Birdie Ln",1,1,N/A
+151845,"June 25, 2014",Delaware,Wilmington,"10th Street and Jackson",0,1,N/A
+150732,"June 23, 2014",Delaware,Wilmington,"500 block of West Sixth Street",0,1,N/A
+151037,"June 23, 2014",Delaware,"New Castle","DuPont Highway",0,1,N/A
+149868,"June 22, 2014",Delaware,Wilmington,"700 block of North Spruce Street",0,2,N/A
+149875,"June 21, 2014",Delaware,Wilmington,"800 block of North Pine Street",1,0,N/A
+148764,"June 19, 2014",Delaware,Wilmington,"300 block of North Pine Street",0,0,N/A
+148777,"June 18, 2014",Delaware,Townsend,"6300 block of Summit Bridge Road",0,1,N/A
+148770,"June 17, 2014",Delaware,Newark,"Stanton-Ogletown Road and Churchmans Road",0,0,N/A
+146828,"June 16, 2014",Delaware,Dover,"100 block of Vera Way",0,0,N/A
+147433,"June 15, 2014",Delaware,Wilmington,"200 block of Murphy Road",0,0,N/A
+146826,"June 13, 2014",Delaware,Bear,"Rivers End Drive",0,1,N/A
+145616,"June 11, 2014",Delaware,Dover,"Becky Lane",0,1,N/A
+145620,"June 10, 2014",Delaware,Newark,"Harlech Hall",1,2,N/A
+148603,"June 10, 2014",Delaware,Newark,"50 block of Harlech Hall",1,2,N/A
+148609,"June 10, 2014",Delaware,Wilmington,"400 block of North Broom Street",0,1,N/A
+145946,"June 10, 2014",Delaware,Wilmington,"100 block of West 31st Street",0,1,N/A
+144691,"June 10, 2014",Delaware,Claymont,"Ridge Road",0,0,N/A
+144674,"June 8, 2014",Delaware,Dover,"Voshells Mill Star Hill Road",0,0,N/A
+144671,"June 7, 2014",Delaware,Dover,"51 Webbs Lane",1,0,N/A
+144677,"June 6, 2014",Delaware,Newark,"Martell Rd and Matthews Rd",0,1,N/A
+222141,"June 6, 2014",Delaware,Wilmington,"1601 Kirkwood Hwy",0,1,N/A
+143246,"June 5, 2014",Delaware,Claymont,"700 block of Peachtree Road",1,0,N/A
+143241,"June 4, 2014",Delaware,Newark,"100 Continental Dr",0,0,N/A
+144189,"June 4, 2014",Delaware,"New Castle","713 East Basin Road",0,0,N/A
+143248,"June 4, 2014",Delaware,Bear,"Printz Drive",0,0,N/A
+143244,"June 3, 2014",Delaware,Bridgeville,"Chaplins Chapel Road",0,0,N/A
+142442,"June 1, 2014",Delaware,Wilmington,"200 block of North Broom Street",0,1,N/A
+140958,"May 30, 2014",Delaware,Dover,"Barnsley Ct",0,0,N/A
+140961,"May 29, 2014",Delaware,Wilmington,"2700 block of Bowers Street",0,1,N/A
+140964,"May 29, 2014",Delaware,"Delaware City","100 block of Fifth Street",0,1,N/A
+140966,"May 29, 2014",Delaware,"Delaware City","Clinton Street",0,0,N/A
+140954,"May 29, 2014",Delaware,Wilmington,"1000 block of North Madison Street",0,1,N/A
+140894,"May 28, 2014",Delaware,Smyrna,"Sugar Maple Ln",1,0,N/A
+140474,"May 28, 2014",Delaware,Smyrna,"500 block of West Commerce Street",0,0,N/A
+140495,"May 27, 2014",Delaware,Wilmington,"1100 block of Conrad St",1,0,N/A
+139563,"May 27, 2014",Delaware,Dover,"200 block of South Governors Avenue",0,1,N/A
+140501,"May 27, 2014",Delaware,Townsend,"200 block of Aberdeen Way",0,0,N/A
+140891,"May 26, 2014",Delaware,Camden,"7000 block of Willow Grove Road",1,0,N/A
+140469,"May 25, 2014",Delaware,Dover,"North New and Division Streets",0,1,N/A
+139552,"May 22, 2014",Delaware,Wilmington,"500 block of North Jefferson Street",1,0,N/A
+136562,"May 19, 2014",Delaware,Selbyville,N/A,2,0,N/A
+136576,"May 19, 2014",Delaware,Harrington,"2000 block of Bloomfield Drive",0,1,N/A
+136571,"May 18, 2014",Delaware,Dover,"200 block of Presidents Drive",0,0,N/A
+136833,"May 17, 2014",Delaware,Dover,"New Castle Avenue and East Water Street",0,1,N/A
+136820,"May 16, 2014",Delaware,Wilmington,"500 block of North Broom Street",0,1,N/A
+135215,"May 15, 2014",Delaware,Wilmington,"400 Claymont Street",0,1,N/A
+136811,"May 14, 2014",Delaware,Wilmington,"610 East 17th Street",0,0,N/A
+136841,"May 14, 2014",Delaware,Wilmington,"1800 block of West Third Street",0,0,N/A
+136554,"May 13, 2014",Delaware,Wilmington,"300 block of Linden Street",0,0,N/A
+134927,"May 12, 2014",Delaware,Bear,"200 block of Deep Creek Terrace",0,2,N/A
+134128,"May 9, 2014",Delaware,"New Castle","50 block of Chaddwyck Blvd",0,0,N/A
+134130,"May 8, 2014",Delaware,Wilmington,"East 10th and North Spruce Streets",1,0,N/A
+134135,"May 8, 2014",Delaware,Wilmington,"1600 block of West Fifth Street",0,1,N/A
+134140,"May 8, 2014",Delaware,Seaford,"Sussex Avenue and Stein Highway",0,0,N/A
+227394,"May 8, 2014",Delaware,Dover,"6 W. Lebanon Road",0,0,N/A
+132827,"May 6, 2014",Delaware,Wilmington,"1000 block of South Market Street",0,1,N/A
+132831,"May 6, 2014",Delaware,Dover,"1210 White Oak Road",0,0,N/A
+132836,"May 6, 2014",Delaware,Dover,"1019 Walker Road",0,0,N/A
+132483,"May 5, 2014",Delaware,Wilmington,"400 block West 25th Street",0,1,N/A
+131856,"May 4, 2014",Delaware,Newark,"15 Fox Hall",0,1,N/A
+131867,"May 1, 2014",Delaware,Wilmington,"200 block of North Rodney Street",0,0,N/A
+131863,"May 1, 2014",Delaware,Wilmington,"East 24th and Market Streets",1,0,N/A
+133508,"May 1, 2014",Delaware,Seaford,"24000 Jewell St",0,0,N/A
+131018,"April 30, 2014",Delaware,Dover,"700 block of North West Street",0,0,N/A
+131865,"April 30, 2014",Delaware,Wilmington,"Sherman and Lombard Streets",0,0,N/A
+131789,"April 28, 2014",Delaware,Lewes,"33000 block of Camilla Drive",0,0,N/A
+129996,"April 27, 2014",Delaware,Wilmington,"2700 block of Lancaster Avenue",0,1,N/A
+130000,"April 27, 2014",Delaware,Elsmere,"2110 Kirkwood Highway",0,0,N/A
+129277,"April 25, 2014",Delaware,Wilmington,"3100 New  Castle",1,0,N/A
+129920,"April 24, 2014",Delaware,Dover,"12th and Melrose",1,0,N/A
+130009,"April 22, 2014",Delaware,"New Castle","3100 block of New Castle Ave",1,0,N/A
+130022,"April 21, 2014",Delaware,Dover,"145 Haman Dr",0,0,N/A
+127175,"April 20, 2014",Delaware,Wilmington,"500 block of Clayton Street",0,1,N/A
+127169,"April 18, 2014",Delaware,Wilmington,"400 block of W 31st Street",0,1,N/A
+125874,"April 14, 2014",Delaware,Wilmington,"W. 2nd and N. Van Buren streets",0,1,N/A
+125876,"April 13, 2014",Delaware,Wilmington,"West 25th and Washington",0,1,N/A
+127225,"April 11, 2014",Delaware,Claymont,"Everett Ave",0,1,N/A
+127165,"April 9, 2014",Delaware,Milford,"100 block of Montgomery Street",0,1,N/A
+123983,"April 8, 2014",Delaware,"New Castle","1627 New Jersey Ave",0,3,N/A
+123969,"April 8, 2014",Delaware,Newark,"S Chapel Street",0,0,N/A
+123307,"April 8, 2014",Delaware,"Wilmington Manor","1600 New Jersey Avenue",0,2,N/A
+121613,"April 3, 2014",Delaware,Wilmington,"Elm and South Harrison ",1,0,N/A
+121619,"April 3, 2014",Delaware,Dover,"100 block of Spruance Road",0,1,N/A
+121616,"April 2, 2014",Delaware,Wilmington,"East 28th Street and Claymont Street",1,0,N/A
+121905,"April 2, 2014",Delaware,Dover,"S State Street",0,1,N/A
+121913,"April 2, 2014",Delaware,Wilmington,"Eighth and Pine Streets",0,1,N/A
+121942,"March 31, 2014",Delaware,Wilmington,"6th and Madison Streets",0,1,N/A
+121975,"March 30, 2014",Delaware,Claymont,"200 block of Harbor Drive",0,0,N/A
+120067,"March 29, 2014",Delaware,Middletown,"2111 Dupont Hwy",0,1,N/A
+121951,"March 27, 2014",Delaware,Talleyville,"4800 block of Governor Printz Boulevard",0,1,N/A
+119326,"March 27, 2014",Delaware,Wilmington,"600 Naamans Road",0,1,N/A
+118541,"March 24, 2014",Delaware,Seaford,"23000 block of East Middlecord Circle",0,0,N/A
+118125,"March 23, 2014",Delaware,Newark,"17 New London Rd",0,0,N/A
+118222,"March 23, 2014",Delaware,Wilmington,"1030 S. Market St. ",0,1,N/A
+115105,"March 14, 2014",Delaware,Wilmington,"West 23rd Street",0,1,N/A
+121997,"March 7, 2014",Delaware,Wilmington,"2100 N Jefferson Street",0,1,N/A
+121993,"March 6, 2014",Delaware,Wilmington,"1200 Lancaster Avenue",0,1,N/A
+121988,"March 4, 2014",Delaware,Wilmington,"700 N Pine Street",0,1,N/A
+121982,"February 24, 2014",Delaware,Wilmington,"E 35th and N Church Street",1,0,N/A
+109921,"February 22, 2014",Delaware,Wilmington,"1300 block of Vandever Avenue ",0,0,N/A
+109923,"February 22, 2014",Delaware,Wilmington,"North Union Street",0,0,N/A
+121980,"February 18, 2014",Delaware,Wilmington,"500 N Madison Street",0,1,N/A
+110994,"February 16, 2014",Delaware,Wilmington,"South Market Street ",0,1,N/A
+107556,"February 16, 2014",Delaware,Wilmington,"500 block of N. Rodney Street",1,0,N/A
+121973,"February 11, 2014",Delaware,Wilmington,"600 N Lincoln Street",0,1,N/A
+104222,"February 4, 2014",Delaware,Newark,"750 East Delaware Avenue",0,0,N/A
+103866,"February 3, 2014",Delaware,Laurel,"Johnson Road",0,0,N/A
+104228,"February 3, 2014",Delaware,Wilmington,"500 block of S. Harrison Street",0,0,N/A
+105155,"February 2, 2014",Delaware,Dover,"800 block of Woodcrest Dr",0,1,N/A
+105157,"February 1, 2014",Delaware,Wilmington,"2100 block of N. Spruce Street",0,0,N/A
+104233,"January 30, 2014",Delaware,Georgetown,"U.S. 113 and County Seat Highway",0,0,N/A
+102235,"January 27, 2014",Delaware,Felton,"700 block of Walnut Shade Rd",0,0,N/A
+101162,"January 25, 2014",Delaware,Dover,"Division Street and New Street",0,0,N/A
+100297,"January 24, 2014",Delaware,Wilmington,"Harpers Place",0,2,N/A
+98543,"January 20, 2014",Delaware,Dover,"200 block of N Wilson Dr",0,0,N/A
+98532,"January 18, 2014",Delaware,Wilmington,"700 block of South Broom Street",1,0,N/A
+98548,"January 18, 2014",Delaware,Wilmington,"500 block of Springer Street",0,0,N/A
+98545,"January 17, 2014",Delaware,Wilmington,"200 block of N. Van Buren Street",0,0,N/A
+98555,"January 16, 2014",Delaware,Wilmington,"900 block of E. 12th Street",0,0,N/A
+97886,"January 16, 2014",Delaware,Wilmington,"26th and Monroe Streets",0,0,N/A
+96780,"January 14, 2014",Delaware,Millsboro,"28000 block of Harmons Hill Rd",2,0,N/A
+95581,"January 13, 2014",Delaware,Felton,"US 13 and Walnut Shade Rd",0,0,N/A
+98530,"January 13, 2014",Delaware,Dover,"2 Capitol Ave",0,0,N/A
+97636,"January 13, 2014",Delaware,Wilmington,"1300 block of Vandever Ave. ",0,1,N/A
+109204,"January 10, 2014",Delaware,Wilmington,N/A,0,1,N/A
+95594,"January 9, 2014",Delaware,Magnolia,"200 block of Lambert Dr",0,0,N/A
+94419,"January 7, 2014",Delaware,Wilmington,"200 block of N Broom St",0,1,N/A
+94408,"January 7, 2014",Delaware,Wilmington,"1500 block of W 5th St",0,1,N/A
+94431,"January 7, 2014",Delaware,Wilmington,"1200 block of Forrest Drive",0,0,N/A
+94439,"January 6, 2014",Delaware,Dover,"McDaniel Dr",0,1,N/A
+93215,"January 5, 2014",Delaware,Wilmington,N/A,0,2,N/A
+93013,"January 4, 2014",Delaware,Wilmington,"2400 block of Carter Street",1,0,N/A
+93223,"January 4, 2014",Delaware,Wilmington,"2100 block of Washington Street",0,1,N/A
+92357,"January 1, 2014",Delaware,Wilmington,"1400 block of West 3rd",1,0,N/A
+495374,"December 7, 2013",Delaware,Wilmington,"3421 Kirkwood Hwy",0,4,N/A
+491729,"August 10, 2013",Delaware,Wilmington,"1200 block of Second Street",0,4,N/A
+480327,"February 11, 2013",Delaware,Wilmington,"500 North King St",3,2,N/A

--- a/data/2017-03-12 - 2021-10-27.csv
+++ b/data/2017-03-12 - 2021-10-27.csv
@@ -1,0 +1,2001 @@
+"Incident ID","Incident Date",State,"City Or County",Address,"# Killed","# Injured",Operations
+2150868,"October 25, 2021",Delaware,Wilmington,"W 7th St and N West St",0,1,N/A
+2149624,"October 24, 2021",Delaware,Seaford,"11000 block of Hastings Farm Rd",1,0,N/A
+2150863,"October 24, 2021",Delaware,Wilmington,"50 block of W 27th St",1,0,N/A
+2149069,"October 23, 2021",Delaware,Wilmington,"200 block of W 30th St",1,0,N/A
+2148037,"October 21, 2021",Delaware,Wilmington,"W 5th St and N Madison St",0,2,N/A
+2147180,"October 21, 2021",Delaware,"Ocean View","30000 block of Bethany Crest",1,0,N/A
+2147193,"October 20, 2021",Delaware,Wilmington,"1300 block of Maryland Ave",0,1,N/A
+2146675,"October 19, 2021",Delaware,Dover,"1 Dover High Dr",0,0,N/A
+2143658,"October 17, 2021",Delaware,Wilmington,"W 3rd St and N Clayton St",1,0,N/A
+2143706,"October 16, 2021",Delaware,Dover,"S Little Creek Rd and Barrister Place",0,1,N/A
+2142937,"October 15, 2021",Delaware,Wilmington,"300 block of W 6th St",0,1,N/A
+2140692,"October 12, 2021",Delaware,Wilmington,"1000 block of Kirkwood St",1,0,N/A
+2140677,"October 11, 2021",Delaware,Middletown,"600 block of Schoonover Ln",0,1,N/A
+2137555,"October 10, 2021",Delaware,Dover,"1500 block of Nathaniel Mitchell Rd",1,4,N/A
+2137081,"October 9, 2021",Delaware,Newark,"100 block of Madison Dr",0,1,N/A
+2131722,"October 2, 2021",Delaware,Wilmington,"3800 block of Governor Printz Blvd",1,0,N/A
+2131027,"October 1, 2021",Delaware,Clayton,"4700 block of Wheatleys Pond Rd",0,1,N/A
+2130857,"October 1, 2021",Delaware,Clayton,"3900 block of Wheatleys Pond Rd",0,1,N/A
+2127124,"September 26, 2021",Delaware,Wilmington,"2200 block of North Spruce St",1,0,N/A
+2126191,"September 26, 2021",Delaware,Wilmington,"700 block of N Washington St",0,1,N/A
+2125521,"September 25, 2021",Delaware,Wilmington,"400 block of N Monroe St",1,0,N/A
+2123714,"September 23, 2021",Delaware,Wilmington,"1300 block of E 29th St",1,0,N/A
+2122753,"September 22, 2021",Delaware,Wilmington,"E 28th and Jessup St",0,1,N/A
+2121877,"September 20, 2021",Delaware,Wilmington,"Taylor St and Bennett St",0,1,N/A
+2120221,"September 19, 2021",Delaware,Wilmington,"800 block of 7½ St",0,1,N/A
+2120145,"September 19, 2021",Delaware,Dover,"New Castle Ave and E Water St",0,1,N/A
+2120219,"September 18, 2021",Delaware,Wilmington,"100 block of S Harrison St",0,1,N/A
+2118566,"September 17, 2021",Delaware,Wilmington,"4737 Concord Pike",0,1,N/A
+2117121,"September 14, 2021",Delaware,Wilmington,"Pleasant St and Van Buren St",0,1,N/A
+2115508,"September 12, 2021",Delaware,Wilmington,"Chestnut St and S Harrison St",1,1,N/A
+2113721,"September 11, 2021",Delaware,"New Castle","N Dupont Hwy and E Hazeldell Ave",0,1,N/A
+2115513,"September 11, 2021",Delaware,Newark,"104 Sandburg Pl",0,1,N/A
+2112913,"September 9, 2021",Delaware,Newark,"1901 S College Ave",0,0,N/A
+2112063,"September 9, 2021",Delaware,Wilmington,"200 block of N Van Buren St",0,1,N/A
+2110346,"September 7, 2021",Delaware,Wilmington,"A St and New Castle Ave",0,4,N/A
+2110581,"September 7, 2021",Delaware,Wilmington,"3rd St and Harrison St",0,1,N/A
+2107997,"September 3, 2021",Delaware,Smyrna,"100 Block of Lincoln St",0,0,N/A
+2105883,"August 31, 2021",Delaware,"New Castle","100 block of Freedom Trail",1,0,N/A
+2104121,"August 29, 2021",Delaware,Smyrna,"50 Block of N Howard St",0,1,N/A
+2104117,"August 29, 2021",Delaware,Wilmington,"2500 block of West St",0,1,N/A
+2102435,"August 27, 2021",Delaware,Seaford,"US-13 and Concord Rd",0,1,N/A
+2100952,"August 26, 2021",Delaware,Wilmington,"1950 Maryland Ave",1,0,N/A
+2098235,"August 22, 2021",Delaware,Dover,"1001 White Oak Rd",0,1,N/A
+2097383,"August 21, 2021",Delaware,Wilmington,"1700 block of W 5th St",0,1,N/A
+2097346,"August 21, 2021",Delaware,Dover,"2000 Block of Dyke Branch Rd",1,0,N/A
+2097381,"August 21, 2021",Delaware,Wilmington,"300 block of S Broom St",0,1,N/A
+2092512,"August 16, 2021",Delaware,Wilmington,"200 block of S Broom St",0,1,N/A
+2091874,"August 15, 2021",Delaware,Middletown,"67 New St",0,1,N/A
+2091870,"August 15, 2021",Delaware,Newark,"I-95 and Churchmans Rd",0,1,N/A
+2092519,"August 15, 2021",Delaware,Wilmington,"500 block of E 9th St",0,1,N/A
+2091862,"August 14, 2021",Delaware,Wilmington,"2700 block of Bowers St",1,0,N/A
+2092514,"August 14, 2021",Delaware,Dover,"107 W Loockerman St",0,2,N/A
+2089390,"August 12, 2021",Delaware,Wilmington,"1200 block of W 4th St",1,0,N/A
+2086646,"August 9, 2021",Delaware,Dover,"995 Whatcoat Dr",0,0,N/A
+2085741,"August 8, 2021",Delaware,Dover,"295 S DuPont Hwy",0,1,N/A
+2086622,"August 8, 2021",Delaware,Wilmington,"700 block of E 10th St",0,2,N/A
+2084999,"August 7, 2021",Delaware,Wilmington,"Conrad St and N Scott St",0,1,N/A
+2084996,"August 7, 2021",Delaware,Wilmington,"400 block of W 29th St",1,0,N/A
+2084994,"August 6, 2021",Delaware,Wilmington,"800 block of N West St",0,1,N/A
+2083672,"August 4, 2021",Delaware,Wilmington,"100 block of N Harrison St",0,1,N/A
+2082128,"August 2, 2021",Delaware,"New Castle","Glen Ave and Dyer Ave",0,1,N/A
+2080257,"August 1, 2021",Delaware,Dover,"50 block of Stevenson Dr",0,1,N/A
+2079475,"July 30, 2021",Delaware,Newark,"1000 Churchmans Rd",0,1,N/A
+2079471,"July 30, 2021",Delaware,Bear,"Korean War Veterans Memorial Hwy and Pulaski Hwy",0,1,N/A
+2079464,"July 30, 2021",Delaware,Wilmington,"1000 block of N Pine St",0,1,N/A
+2075608,"July 26, 2021",Delaware,Wilmington,"1100 block of W 2nd St",3,1,N/A
+2075612,"July 26, 2021",Delaware,Wilmington,"2400 block of Jessup St",1,1,N/A
+2075914,"July 26, 2021",Delaware,Wilmington,"600 block of N Monroe St",1,1,N/A
+2074026,"July 24, 2021",Delaware,Dover,"400 block of Barrister Pl",0,1,N/A
+2073267,"July 24, 2021",Delaware,Dover,"995 Whatcoat Dr",0,1,N/A
+2071674,"July 22, 2021",Delaware,Middletown,"60 block of E Cole Blvd",0,0,N/A
+2071668,"July 22, 2021",Delaware,Wilmington,"200 block of N Clayton St",0,1,N/A
+2069972,"July 20, 2021",Delaware,Newark,"400 block of Wollaston Ave",1,0,N/A
+2074984,"July 20, 2021",Delaware,Seaford,"900 Woodland Mills Dr",0,1,N/A
+2074983,"July 20, 2021",Delaware,Seaford,"400 block of North St",0,0,N/A
+2067329,"July 19, 2021",Delaware,Dover,"1156 S Bay Rd",0,2,N/A
+2068807,"July 19, 2021",Delaware,Wilmington,"50 block of W 27th St",0,1,N/A
+2066503,"July 18, 2021",Delaware,Dover,"1200 block of Harrison Dr",0,1,N/A
+2067325,"July 18, 2021",Delaware,Bridgeville,"8000 block of Cannon Rd",0,0,N/A
+2065996,"July 15, 2021",Delaware,Milford,"East St and NE 4th St",0,1,N/A
+2063394,"July 14, 2021",Delaware,Claymont,"50 block of Balfour Ave",2,2,N/A
+2061091,"July 13, 2021",Delaware,Dover,"100 block of W Loockerman St",0,1,N/A
+2061420,"July 13, 2021",Delaware,Wilmington,"1300 block of W 6th St",0,1,N/A
+2059116,"July 9, 2021",Delaware,Dover,"200 block of Cecil St",0,1,N/A
+2067345,"July 9, 2021",Delaware,"New Castle","1600 block of Coleman St",1,0,N/A
+2057890,"July 8, 2021",Delaware,Wilmington,"1200 block of W Fourth St",0,0,N/A
+2055236,"July 6, 2021",Delaware,Wilmington,"1300 block of Read St",0,1,N/A
+2055776,"July 6, 2021",Delaware,"New Castle","600 block of Moores Ln",0,1,N/A
+2053609,"July 5, 2021",Delaware,Wilmington,"700 block of Elbert Pl",1,0,N/A
+2052792,"July 3, 2021",Delaware,Newark,"100 block of Madison Dr",0,1,N/A
+2051906,"July 2, 2021",Delaware,Wilmington,"2300 block of N West St",0,1,N/A
+2051904,"July 2, 2021",Delaware,Wilmington,"2500 block of N Tatnall St",0,1,N/A
+2051902,"July 2, 2021",Delaware,Wilmington,"900 block of Lombard St",1,0,N/A
+2050709,"July 1, 2021",Delaware,Newark,"13 Salem Village Square",0,1,N/A
+2050707,"July 1, 2021",Delaware,Wilmington,"7th St and N Jefferson St",0,1,N/A
+2049255,"June 30, 2021",Delaware,Wilmington,"600 block of N Madison St",0,1,N/A
+2050167,"June 30, 2021",Delaware,Dover,"100 block of S New St",1,3,N/A
+2048058,"June 28, 2021",Delaware,Newark,"132 Christiana Mall",1,0,N/A
+2047079,"June 27, 2021",Delaware,Wilmington,"700 block of N Jefferson St",0,3,N/A
+2046182,"June 27, 2021",Delaware,Newark,"1 Louis Ct",1,2,N/A
+2057886,"June 27, 2021",Delaware,Wilmington,"200 block of N Harrison St",0,0,N/A
+2045750,"June 25, 2021",Delaware,"Fenwick Island","W Atlantic St",0,0,N/A
+2046240,"June 25, 2021",Delaware,"Fenwick Island","50 block of W Atlantic St",0,0,N/A
+2044061,"June 24, 2021",Delaware,Wilmington,"200 block of N Rodney St",0,1,N/A
+2044776,"June 24, 2021",Delaware,Dover,"Bicentennial Blvd and Declaration Dr",0,0,N/A
+2044074,"June 23, 2021",Delaware,Dover,"400 block of River Rd",0,1,N/A
+2044059,"June 23, 2021",Delaware,Wilmington,"Pleasant St and Franklin St",0,1,N/A
+2044055,"June 23, 2021",Delaware,Wilmington,"2300 block of Bowers St",0,1,N/A
+2042972,"June 22, 2021",Delaware,Wilmington,"500 block of W 35th St",1,0,N/A
+2044780,"June 22, 2021",Delaware,Middletown,"Greenlawn Blvd and Janvier Dr",0,0,N/A
+2042267,"June 22, 2021",Delaware,Dover,"Garfield Dr and Frear Dr",0,1,N/A
+2042274,"June 21, 2021",Delaware,Dover,"400 block of New Castle Ave",0,0,N/A
+2040709,"June 20, 2021",Delaware,"Seaford (Blades)","E 4th St",1,0,N/A
+2040679,"June 20, 2021",Delaware,Wilmington,"2300 block of Lamotte St",0,1,N/A
+2040693,"June 20, 2021",Delaware,Dover,"1426 N Dupont Hwy",0,1,N/A
+2041306,"June 20, 2021",Delaware,Dover,"700 block of Simon Cir",0,0,N/A
+2040682,"June 19, 2021",Delaware,Wilmington,"700 block of W 5th St",0,1,N/A
+2039641,"June 19, 2021",Delaware,Wilmington,"2400 block of N Market St",0,1,N/A
+2037484,"June 17, 2021",Delaware,Wilmington,"200 block of N Connell St",0,1,N/A
+2037510,"June 16, 2021",Delaware,Dover,"Fairway Lakes Dr",0,1,N/A
+2036297,"June 14, 2021",Delaware,Felton,"Indian Runner Rd",0,0,N/A
+2029754,"June 9, 2021",Delaware,Dover,"W North St and Simon Cir",1,0,N/A
+2030585,"June 9, 2021",Delaware,Wilmington,"2900 block of N Madison St",0,2,N/A
+2029756,"June 9, 2021",Delaware,"Wilmington (Newport)","1025 Boxwood Rd",0,0,N/A
+2029763,"June 9, 2021",Delaware,Millsboro,"Circle Dr",0,0,N/A
+2037407,"June 9, 2021",Delaware,Wilmington,"200 block of Garden Ct",0,1,N/A
+2029752,"June 8, 2021",Delaware,Wilmington,"1300 block of Wilson St",0,1,N/A
+2029152,"June 8, 2021",Delaware,Wilmington,"2200 block of N Washington St",0,2,N/A
+2028715,"June 8, 2021",Delaware,Newark,"50 block of Ethan Allen Ct",1,1,N/A
+2028725,"June 7, 2021",Delaware,Dover,"Lingo Dr",0,0,N/A
+2027560,"June 6, 2021",Delaware,Wilmington,"300 block of W 9th St",0,1,N/A
+2027558,"June 6, 2021",Delaware,Wilmington,"1200 block of W Third St",1,0,N/A
+2023288,"June 3, 2021",Delaware,Wilmington,"2400 block of N Market St",1,3,N/A
+2024574,"June 3, 2021",Delaware,Dover,"900 block of Woodcrest Dr",0,1,N/A
+2030594,"June 2, 2021",Delaware,Belvedere,"300 block of Cedar Ave",1,0,N/A
+2022697,"June 1, 2021",Delaware,Seaford,"500 block of Clearbrooke Blvd",0,0,N/A
+2022693,"June 1, 2021",Delaware,Wilmington,"600 block of E 10th St",0,1,N/A
+2022691,"June 1, 2021",Delaware,Wilmington,"1100 block of B St",0,1,N/A
+2022700,"May 30, 2021",Delaware,Dover,"50 block of Ann Ave",0,0,N/A
+2019471,"May 28, 2021",Delaware,"Wilmington (Edgemoor)","Gordan Ave and Beeson Ave",0,1,N/A
+2016301,"May 26, 2021",Delaware,Delmar,"36000 block of Providence Church Rd",0,0,N/A
+2017496,"May 26, 2021",Delaware,Hartly,"700 block of Proctors Purchase Rd",1,0,N/A
+2016305,"May 25, 2021",Delaware,"New Castle","50 block of Meehan Ave",1,0,N/A
+2015075,"May 24, 2021",Delaware,Wilmington,"201 S Heald St",0,1,N/A
+2013338,"May 22, 2021",Delaware,"New Castle","3900 N DuPont Hwy",0,1,N/A
+2012345,"May 22, 2021",Delaware,Wilmington,"800 block of N Pine St",0,4,N/A
+2028723,"May 22, 2021",Delaware,Milton,"W Springside Dr",0,0,N/A
+2014357,"May 22, 2021",Delaware,Laurel,"30739 Sussex Hwy",0,0,N/A
+2037507,"May 22, 2021",Delaware,Dover,"1014 S Little Creek Rd",0,1,N/A
+2009979,"May 19, 2021",Delaware,"Wilmington (Edgemoor)","50 block of Le Parc Dr",0,1,N/A
+2007888,"May 18, 2021",Delaware,Frankford,"50 block of Honolulu Rd",1,0,N/A
+2006778,"May 16, 2021",Delaware,Milford,"500 block of Truitt Ave",0,2,N/A
+2005697,"May 15, 2021",Delaware,"Wilmington (Elsmere)","900 block of Kirkwood Hwy",1,0,N/A
+2003986,"May 14, 2021",Delaware,Bear,"700 Mill Creek Ct",2,0,N/A
+2005127,"May 14, 2021",Delaware,Dover,"1534 S Governors Ave",1,0,N/A
+2003250,"May 12, 2021",Delaware,Wilmington,"400 block of W 28th St",0,1,N/A
+2000315,"May 9, 2021",Delaware,Dover,"100 block of S New St",0,1,N/A
+2002219,"May 6, 2021",Delaware,Dover,N/A,0,0,N/A
+1995551,"May 3, 2021",Delaware,Harrington,"Mill St",0,0,N/A
+1993485,"May 2, 2021",Delaware,Wilmington,"W 26th St and N Madison St",0,1,N/A
+1992127,"May 1, 2021",Delaware,Wilmington,"800 block of N Pine St",0,4,N/A
+1990150,"April 28, 2021",Delaware,Seaford,"700 block of Collins Ave",0,0,N/A
+1988701,"April 27, 2021",Delaware,Wilmington,"50 block of W 27th St",0,1,N/A
+2023794,"April 27, 2021",Delaware,Dover,"Kenton Rd and Walker Rd",0,0,N/A
+1988475,"April 27, 2021",Delaware,Smyrna,"700 Duck Creek Pkwy",3,0,N/A
+1989264,"April 26, 2021",Delaware,Milford,"6000 block of Slaughter Beach Rd",0,0,N/A
+1989269,"April 26, 2021",Delaware,Knollwood,"50 block of Denham Ave",0,1,N/A
+1989265,"April 26, 2021",Delaware,"New Castle","133 S DuPont Hwy",0,0,N/A
+1988036,"April 26, 2021",Delaware,Wilmington,"2200 block of N Pine St",0,1,N/A
+1986755,"April 25, 2021",Delaware,Clayton,"392 Hopewell Dr",3,0,N/A
+1986773,"April 25, 2021",Delaware,Wilmington,"600 block of E 10th St",0,1,N/A
+1987140,"April 24, 2021",Delaware,Bear,"Saint Georges Terrace",0,1,N/A
+1986177,"April 24, 2021",Delaware,Wilmington,"300 block of W 26th St",1,0,N/A
+1985222,"April 23, 2021",Delaware,Wilmington,"300 block of Concord Ave",2,0,N/A
+1984879,"April 22, 2021",Delaware,Seaford,"27000 block of Daisy Ln",0,0,N/A
+1984090,"April 20, 2021",Delaware,Wilmington,"50 block of Saint John Dr",0,1,N/A
+1980360,"April 17, 2021",Delaware,Wilmington,"I-95 and Martin Luther King Jr Blvd",0,1,N/A
+1980364,"April 15, 2021",Delaware,Millsboro,"34000 block of Sports Dr",0,1,N/A
+1979235,"April 15, 2021",Delaware,Wilmington,"400 block of Buttonwood St",0,2,N/A
+1978026,"April 14, 2021",Delaware,Dover,"S Little Creek Rd",0,2,N/A
+1978021,"April 14, 2021",Delaware,Wilmington,"2300 block of Carter St",0,2,N/A
+1976484,"April 13, 2021",Delaware,Wilmington,"940 N Pine St",1,2,N/A
+1983392,"April 12, 2021",Delaware,Wilmington,"600 block of Concord Ave",0,0,N/A
+1976422,"April 12, 2021",Delaware,Dover,"400 block of Sussex Ave",1,0,N/A
+1974762,"April 11, 2021",Delaware,Newark,"19 Chestnut Hill Plaza",0,0,N/A
+1973041,"April 7, 2021",Delaware,Laurel,"Daniel St and Wilson St",0,1,N/A
+1969048,"April 4, 2021",Delaware,Harrington,"100 block of Fox Hunters Rd",0,0,N/A
+1968260,"April 2, 2021",Delaware,Wilmington,"200 block of W 19th St",1,0,N/A
+1967612,"April 1, 2021",Delaware,Houston,"3600 block of Williamsville Rd",0,0,N/A
+1966757,"March 31, 2021",Delaware,Milford,"300 Aurora Pl",0,1,N/A
+1966766,"March 31, 2021",Delaware,Milford,"Sandbox Rd and Milford Harrington Hwy",1,0,N/A
+1965376,"March 30, 2021",Delaware,Wilmington,"200 block of Maryland Ave",0,1,N/A
+1965383,"March 29, 2021",Delaware,Wilmington,"Lancaster Ave and Clayton St",0,1,N/A
+1965374,"March 29, 2021",Delaware,Newark,"190 Salem Church Rd",0,0,N/A
+1964496,"March 29, 2021",Delaware,Wilmington,"400 block of Bradford St",0,1,N/A
+1982393,"March 26, 2021",Delaware,Dover,"200 block of Greenwich Dr",0,1,N/A
+1962391,"March 25, 2021",Delaware,Seaford,"Danny Dr",1,0,N/A
+1955007,"March 16, 2021",Delaware,Wilmington,"700 block of N Washington St",1,0,N/A
+1954079,"March 15, 2021",Delaware,Wilmington,"W 4th St and N Adams St",0,1,N/A
+1954091,"March 13, 2021",Delaware,Newark,"Prospect Ave",0,0,N/A
+1950073,"March 10, 2021",Delaware,Dover,"100 block of Duet Ct",0,1,N/A
+1947974,"March 8, 2021",Delaware,Wilmington,"1300 block of E 27th St",0,1,N/A
+1955611,"March 7, 2021",Delaware,Wilmington,"200 block of Cherry St",0,0,N/A
+1941772,"March 1, 2021",Delaware,Wilmington,"W 26th St and Northeast Blvd",0,1,N/A
+1940787,"February 28, 2021",Delaware,Dover,"4115 N DuPont Hwy",0,1,N/A
+1940791,"February 28, 2021",Delaware,Dover,"21 S Little Creek Rd",0,4,N/A
+1940380,"February 26, 2021",Delaware,Wilmington,"101 Clifton Park Cir",1,0,N/A
+1939211,"February 26, 2021",Delaware,Wilmington,"600 block of E 22nd St",1,1,N/A
+1937421,"February 23, 2021",Delaware,Dover,"100 block of Mifflin Rd",0,0,N/A
+1937417,"February 23, 2021",Delaware,Georgetown,"Tranquility Ln",0,0,N/A
+1935308,"February 21, 2021",Delaware,Wilmington,"500 block of E 6th St",0,1,N/A
+1935302,"February 21, 2021",Delaware,Wilmington,"2900 block of Bowers St",0,1,N/A
+1944387,"February 19, 2021",Delaware,Middletown,"Naughty Ln and Vincent Cir",0,0,N/A
+1932819,"February 18, 2021",Delaware,Milford,"400 block of North St",0,1,N/A
+1932825,"February 18, 2021",Delaware,Seaford,"Woodland Dr",0,0,N/A
+1930137,"February 16, 2021",Delaware,"Newark (Christiana)","1200 block of Flanders Way",1,0,N/A
+1930132,"February 15, 2021",Delaware,Wilmington,"W 10th St and N Madison St",0,2,N/A
+1929126,"February 13, 2021",Delaware,Dover,"400 block of River Rd",0,1,N/A
+1927208,"February 12, 2021",Delaware,Newark,"50 block of Carlisle Rd",2,0,N/A
+1924236,"February 8, 2021",Delaware,Wilmington,"800 block of W 4th St",0,1,N/A
+1923253,"February 7, 2021",Delaware,Wilmington,"C St and Townsend St",0,1,N/A
+1922120,"February 6, 2021",Delaware,Newark,"1119 S College Ave",0,1,N/A
+1922651,"February 6, 2021",Delaware,Newark,"240 Chapman Rd",0,0,N/A
+1921356,"February 4, 2021",Delaware,Wilmington,"600 block of W 27th St",0,1,N/A
+1921358,"February 4, 2021",Delaware,Wilmington,"2800 block of N Claymont St",0,1,N/A
+1920143,"February 2, 2021",Delaware,"New Castle","50 block of Birkshire Rd",0,1,N/A
+1917231,"January 30, 2021",Delaware,Milford,"300 block of Milford-Harrington Hwy",0,0,N/A
+1915767,"January 30, 2021",Delaware,Claymont,"50 block of 3rd Ave",1,0,N/A
+1915872,"January 29, 2021",Delaware,Wilmington,"900 block of N Spruce St",1,0,N/A
+1914024,"January 27, 2021",Delaware,Felton,"3100 block of Abec Ln",0,0,N/A
+1913139,"January 25, 2021",Delaware,Wilmington,"Concord Plaza and Silverside Rd",0,1,N/A
+1911064,"January 24, 2021",Delaware,"New Castle","50 block of Highland Blvd",1,2,N/A
+1910110,"January 24, 2021",Delaware,Wilmington,"100 block of E 24th St",0,1,N/A
+1911057,"January 23, 2021",Delaware,Newark,"41 Winterhaven Dr",0,2,N/A
+1910103,"January 23, 2021",Delaware,Seaford,"Park Cir",1,0,N/A
+1907082,"January 20, 2021",Delaware,Wilmington,"E 8th St and N Pine St",0,3,N/A
+1906779,"January 19, 2021",Delaware,Ellendale,"12000 block of N Old State Rd",0,0,N/A
+1905862,"January 18, 2021",Delaware,"New Castle","1213 West Ave",0,0,N/A
+1903466,"January 16, 2021",Delaware,Wilmington,"1100 block of W 5th St",0,1,N/A
+1902350,"January 14, 2021",Delaware,Wilmington,"800 block of W 8th St",0,1,N/A
+1901650,"January 13, 2021",Delaware,Wilmington,"800 block of N Monroe St",1,1,N/A
+1901039,"January 13, 2021",Delaware,Wilmington,"Rosemont Ave and E 24th St",1,0,N/A
+1901043,"January 12, 2021",Delaware,Newark,"132 Christiana Mall",0,1,N/A
+1900087,"January 11, 2021",Delaware,Wilmington,"2800 block of N Claymont St",1,0,N/A
+1900094,"January 10, 2021",Delaware,Wilmington,"1050 S Market St",0,0,N/A
+1897109,"January 7, 2021",Delaware,Newark,"402 Ogletown Rd",0,2,N/A
+1898028,"January 7, 2021",Delaware,Felton,"Sandtown Rd",0,0,N/A
+1895841,"January 5, 2021",Delaware,Dover,"1100 block of White Oak Rd",0,0,N/A
+1895026,"January 4, 2021",Delaware,Wilmington,"W 7th St and Washington St",0,1,N/A
+1895033,"January 4, 2021",Delaware,Dover,"2600 block of Stevenson Dr",0,1,N/A
+1893263,"January 3, 2021",Delaware,Dover,"1426 N DuPont Hwy",0,1,N/A
+1893103,"January 2, 2021",Delaware,Wilmington,"2900 block of Northeast Blvd",0,1,N/A
+1891749,"January 1, 2021",Delaware,Newark,"415 Stanton Christiana Rd",0,1,N/A
+1891332,"December 31, 2020",Delaware,Wilmington,"E 8th St and N Pine St",0,1,N/A
+1891753,"December 31, 2020",Delaware,Milton,"506 Union St",0,1,N/A
+1892450,"December 31, 2020",Delaware,Dover,"100 block of Spruance Rd",0,1,N/A
+1890937,"December 30, 2020",Delaware,Viola,"201 E Evens Dr",0,1,N/A
+1890728,"December 30, 2020",Delaware,Wilmington,"500 block of E 8th St",0,1,N/A
+1889074,"December 28, 2020",Delaware,Dover,"E Water St and River Rd",0,0,N/A
+1888022,"December 27, 2020",Delaware,Dover,"50 block of S New St",0,0,N/A
+1887422,"December 27, 2020",Delaware,Dover,"100 block of S New St",0,1,N/A
+1887416,"December 26, 2020",Delaware,Wilmington,"E 35th St and N Locust St",1,0,N/A
+1886670,"December 25, 2020",Delaware,Houston,"Williamsville Rd",0,0,N/A
+1886676,"December 25, 2020",Delaware,Dover,"820 Carvel Dr",1,0,N/A
+1887419,"December 24, 2020",Delaware,"Rehoboth Beach","100 block of Beachfield Dr",0,1,N/A
+1884690,"December 22, 2020",Delaware,Dover,"Willis Branch Dr and Beaufort Ct",0,0,N/A
+1883616,"December 21, 2020",Delaware,"New Castle","3000 block of New Castle Ave",0,2,N/A
+1884691,"December 21, 2020",Delaware,"Camden Wyoming (Camden)","500 block of Cow Marsh Creek Rd",0,0,N/A
+1883216,"December 21, 2020",Delaware,Wilmington,"200 block of N Dupont St",1,0,N/A
+1881469,"December 19, 2020",Delaware,Dover,"S Queen St and Reed St",0,1,N/A
+1882849,"December 19, 2020",Delaware,Dover,"461 N DuPont Hwy",0,0,N/A
+1881471,"December 18, 2020",Delaware,Townsend,"Union Church Rd",0,0,N/A
+1881988,"December 18, 2020",Delaware,"New Castle","1 Delaware St",0,0,N/A
+1880495,"December 17, 2020",Delaware,Newark,"200 block of E Main St",0,0,N/A
+1878430,"December 14, 2020",Delaware,Wilmington,"300 block of W 29th St",0,0,N/A
+1878169,"December 14, 2020",Delaware,"New Castle","50 block of Bristol Way",1,0,N/A
+1876603,"December 13, 2020",Delaware,Newark,"50 block of Todd Ln",0,1,N/A
+1876561,"December 13, 2020",Delaware,Middletown,"E Lake St and Jefferson St",1,0,N/A
+1876565,"December 12, 2020",Delaware,"Wilmington (Edgemoor)","Polk Rd and S Rodney Dr",0,1,N/A
+1876607,"December 12, 2020",Delaware,Claymont,"I-95 and Harvey Rd",0,1,N/A
+1876600,"December 12, 2020",Delaware,Newark,"39 Fairway Rd",2,0,N/A
+1876563,"December 11, 2020",Delaware,"New Castle","117 Wilton Blvd",0,1,N/A
+1874794,"December 10, 2020",Delaware,"Rehoboth Beach","19540 Coastal Hwy",1,1,N/A
+1874888,"December 10, 2020",Delaware,"New Castle","Boulden Blvd and Boulden Cir",0,3,N/A
+1874165,"December 10, 2020",Delaware,Wilmington,"300 block of E 23rd St",1,0,N/A
+1874917,"December 10, 2020",Delaware,"New Castle","100 block of Rose Ln",1,1,N/A
+1874898,"December 9, 2020",Delaware,Newark,"I-95 and Churchmans Rd",0,1,N/A
+1874049,"December 9, 2020",Delaware,Wilmington,"100 block of Stroud St",0,1,N/A
+1872377,"December 7, 2020",Delaware,Newark,"800 block of Library Ave",0,1,N/A
+1881982,"December 6, 2020",Delaware,Newark,"Church St",0,0,N/A
+1874055,"December 5, 2020",Delaware,Seaford,"400 block of North St",0,1,N/A
+1898018,"December 4, 2020",Delaware,Bridgeville,"21000 block of Mill Park Dr",0,1,N/A
+1869852,"December 3, 2020",Delaware,Seaford,"400 block of North St",0,2,N/A
+1868047,"December 2, 2020",Delaware,Wilmington,"W 6th St and Willing St",0,0,N/A
+1866281,"November 30, 2020",Delaware,Wilmington,"1700 block of Conrad St",0,1,N/A
+1865249,"November 29, 2020",Delaware,"New Castle","Arbor Ave and Chesterfield Dr",1,1,N/A
+1864920,"November 29, 2020",Delaware,Wilmington,"2700 block of Northeast Blvd",0,1,N/A
+1863930,"November 28, 2020",Delaware,Dagsboro,"31000 block of Country Gardens",1,0,N/A
+1864496,"November 28, 2020",Delaware,Wilmington,"600 block of New Castle Ave",0,1,N/A
+1863924,"November 27, 2020",Delaware,Georgetown,"14000 block of Old Furnace Rd",1,0,N/A
+1864503,"November 26, 2020",Delaware,"New Castle","1500 block of Stonebridge Blvd",0,1,N/A
+1862919,"November 26, 2020",Delaware,Wilmington,"500 block of E 9th St",0,1,N/A
+1869397,"November 25, 2020",Delaware,Wilmington,"600 block of N Jefferson St",0,0,N/A
+1859794,"November 22, 2020",Delaware,Dover,"800 block of S Little Creek Rd",0,1,N/A
+1858587,"November 21, 2020",Delaware,Middletown,"New St and Cole Blvd",1,0,N/A
+1857805,"November 20, 2020",Delaware,Wilmington,"9th St and Kirkwood St",0,1,N/A
+1868045,"November 18, 2020",Delaware,Wilmington,"2400 block of N Market St",0,0,N/A
+1853230,"November 15, 2020",Delaware,"New Castle","Ashley Dr",1,0,N/A
+1852592,"November 14, 2020",Delaware,"New Castle","Estates Dr and Conlin Ct",1,0,N/A
+1852270,"November 13, 2020",Delaware,Dover,"Stevenson Dr",0,1,N/A
+1850965,"November 12, 2020",Delaware,Bear,"3601 Wrangle Hill Rd",0,0,N/A
+1849970,"November 11, 2020",Delaware,Wilmington,"100 block of W 23rd St",0,1,N/A
+1845749,"November 6, 2020",Delaware,Bear,"Buckley Blvd and Pulaski Hwy",0,1,N/A
+1843500,"November 4, 2020",Delaware,"New Castle","50 block of Rose Ln",0,2,N/A
+1843498,"November 4, 2020",Delaware,Wilmington,"800 block of N Pine St",0,1,N/A
+1840050,"October 31, 2020",Delaware,Georgetown,"22518 Lewes-Georgetown Hwy",0,0,N/A
+1839559,"October 31, 2020",Delaware,Dover,"100 block of Cherry St",0,0,N/A
+1838831,"October 29, 2020",Delaware,Wilmington,"1300 block of E 24th St",0,1,N/A
+1839560,"October 28, 2020",Delaware,Selbyville,"Lincoln St",0,0,N/A
+1838296,"October 28, 2020",Delaware,Dover,"W Division St and S West St",0,0,N/A
+1836033,"October 27, 2020",Delaware,Wilmington,"300 block of W 7th St",0,1,N/A
+1834687,"October 25, 2020",Delaware,Wilmington,"1100 block of N Heald St",1,0,N/A
+1834689,"October 25, 2020",Delaware,Wilmington,"2300 block of N Pine St",1,0,N/A
+1835620,"October 25, 2020",Delaware,Smyrna,"Kristin Ct",0,0,N/A
+1833798,"October 24, 2020",Delaware,Wilmington,"900 block of N Pine St",0,1,N/A
+1833796,"October 24, 2020",Delaware,Wilmington,"700 block of N Madison St",0,1,N/A
+1833033,"October 24, 2020",Delaware,Newark,"22 Marrows Rd",1,1,N/A
+1842677,"October 22, 2020",Delaware,Wilmington,"1400 block of N Harrison St",0,0,N/A
+1830271,"October 20, 2020",Delaware,Bear,"1100 Pulaski Hwy",1,0,N/A
+1835621,"October 20, 2020",Delaware,"Wilmington (Edgemoor)","1000 block of Westlawn Ct",0,0,N/A
+1830273,"October 20, 2020",Delaware,Laurel,"701 Little Creek Dr",0,1,N/A
+1828677,"October 16, 2020",Delaware,Milford,"200 block of SE 2nd St",0,0,N/A
+1825851,"October 15, 2020",Delaware,Dover,"Steel Rd",0,0,N/A
+1824886,"October 14, 2020",Delaware,Wilmington,"N 22nd St and E Church St",0,1,N/A
+1821977,"October 11, 2020",Delaware,Wilmington,"700 block of E 10th St",1,0,N/A
+1821393,"October 10, 2020",Delaware,Townsend,"Harvey Straughn Rd",0,0,N/A
+1819842,"October 9, 2020",Delaware,"Wilmington (Edgemoor)","Haines Ave",0,1,N/A
+1824101,"October 9, 2020",Delaware,Smyrna,"Wheatleys Pond Rd",0,0,N/A
+1819835,"October 9, 2020",Delaware,Wilmington,"1300 block of E 29th St",0,3,N/A
+1821391,"October 9, 2020",Delaware,Millsboro,"Screenhouse Ln",0,0,N/A
+1821389,"October 9, 2020",Delaware,Milton,"20800 block of W Springside Dr",0,0,N/A
+1819230,"October 8, 2020",Delaware,Milford,"902 N Dupont Blvd",0,0,N/A
+1819223,"October 7, 2020",Delaware,Wilmington,"E 24th St and Lamotte St",0,2,N/A
+1817069,"October 6, 2020",Delaware,Wilmington,"2300 block of Jessup St",0,1,N/A
+1815273,"October 4, 2020",Delaware,Wilmington,"1300 block of W 5th St",0,1,N/A
+1812377,"October 2, 2020",Delaware,"New Castle","4010 N Dupont Hwy",2,0,N/A
+1813254,"October 2, 2020",Delaware,Newark,"140 Pencader Plaza",0,0,N/A
+1814041,"October 2, 2020",Delaware,Dover,"200 block of David Hall Rd",1,0,N/A
+1810423,"September 30, 2020",Delaware,Wilmington,"400 block of Morehouse Dr",0,1,N/A
+1811423,"September 30, 2020",Delaware,"Newark (Christiana)","410 Eagle Run Rd",0,1,N/A
+1809197,"September 28, 2020",Delaware,Wilmington,"1200 block of Pleasant St",0,1,N/A
+1808267,"September 27, 2020",Delaware,Dover,"100 block of Willis Rd",0,0,N/A
+1808223,"September 27, 2020",Delaware,Dover,"100 Electric Ave",1,1,N/A
+1808282,"September 26, 2020",Delaware,Dover,"700 block of Forest St",0,0,N/A
+1806184,"September 26, 2020",Delaware,Wilmington,"50 block of 9th Ave",1,0,N/A
+1805684,"September 24, 2020",Delaware,Wilmington,"3408 Lancaster Pike",0,0,N/A
+1804599,"September 24, 2020",Delaware,Wilmington,"1100 block of Maryland Ave",0,1,N/A
+1804593,"September 23, 2020",Delaware,Wilmington,"1022 Delaware Ave",1,0,N/A
+1804591,"September 23, 2020",Delaware,Wilmington,"800 block of W 7th St",0,1,N/A
+1804585,"September 23, 2020",Delaware,Wilmington,"4817 Governor Printz Blvd",0,3,N/A
+1802884,"September 22, 2020",Delaware,Wilmington,"2400 block of N Tatnall St",0,2,N/A
+1800875,"September 20, 2020",Delaware,"Wilmington (Elsmere)","50 block of Tamarack Ave",0,2,N/A
+1801848,"September 19, 2020",Delaware,Smyrna,"Woodland Beach Rd",0,0,N/A
+1801831,"September 19, 2020",Delaware,Newark,"N Thistle Way",0,0,N/A
+1799930,"September 18, 2020",Delaware,Newark,"900 Churchmans Rd",0,0,N/A
+1798207,"September 16, 2020",Delaware,Milford,"300 Aurora Pl",1,0,N/A
+1796595,"September 15, 2020",Delaware,Wilmington,"600 block of N Lincoln St",0,2,N/A
+1798211,"September 14, 2020",Delaware,Milford,"900 blocks of N Church St",0,0,N/A
+1795377,"September 14, 2020",Delaware,Wilmington,"Vandever Ave and N Locust St",1,0,N/A
+1794462,"September 13, 2020",Delaware,Wilmington,"1700 block of Tulip St",1,0,N/A
+1793315,"September 12, 2020",Delaware,Wilmington,"Pine St and Taylor St",0,1,N/A
+1793310,"September 12, 2020",Delaware,Wilmington,"200 block of S Harrison St",1,0,N/A
+1793312,"September 12, 2020",Delaware,Wilmington,"500 block of S Locust St",0,1,N/A
+1793317,"September 12, 2020",Delaware,Wilmington,"E 23rd St and Pine St",0,1,N/A
+1793618,"September 12, 2020",Delaware,Smyrna,"100 block of Lincoln St",0,2,N/A
+1797032,"September 10, 2020",Delaware,Dover,"100 block of Willis Rd",0,0,N/A
+1790898,"September 9, 2020",Delaware,Wilmington,"4800 block of Governor Printz Blvd",1,0,N/A
+1790568,"September 9, 2020",Delaware,Wilmington,"3400 block of Church St",2,0,N/A
+1789507,"September 8, 2020",Delaware,Wilmington,"1000 block of W 7th St",0,1,N/A
+1789505,"September 8, 2020",Delaware,Wilmington,"500 block of Pine St",1,0,N/A
+1787350,"September 6, 2020",Delaware,Felton,"5000 block of Canterbury Rd",0,0,N/A
+1789708,"September 6, 2020",Delaware,Dover,"1210 White Oak Rd",0,1,N/A
+1786009,"September 5, 2020",Delaware,Wilmington,"600 block of W 5th St",0,1,N/A
+1784829,"September 3, 2020",Delaware,Wilmington,"100 block of W 40th St",0,2,N/A
+1784824,"September 3, 2020",Delaware,Smyrna,"E Redbrook Pl",0,0,N/A
+1782654,"September 2, 2020",Delaware,Wilmington,"200 block of N Madison St",0,1,N/A
+1783862,"September 2, 2020",Delaware,Dover,"300 block of Simon Cir",0,0,N/A
+1784841,"September 2, 2020",Delaware,Bear,"711 Pulaski Hwy",0,0,N/A
+1794983,"September 1, 2020",Delaware,Wilmington,"1500 block of W 7th St",0,0,N/A
+1782659,"September 1, 2020",Delaware,Dover,"300 Isabelle Isle",0,1,N/A
+1780857,"August 31, 2020",Delaware,Wilmington,"700 block of Jefferson St",0,1,N/A
+1782664,"August 31, 2020",Delaware,Dover,"100 block of Willis Rd",0,0,N/A
+1780438,"August 30, 2020",Delaware,Wilmington,"1500 block of W 3rd St",0,2,N/A
+1780374,"August 30, 2020",Delaware,Claymont,"50 block of N Avon Dr",0,1,N/A
+1780443,"August 30, 2020",Delaware,Wilmington,"800 block of N Monroe St",0,1,N/A
+1779104,"August 28, 2020",Delaware,Wilmington,"1100 block of W 2nd St",0,1,N/A
+1797020,"August 28, 2020",Delaware,Wilmington,"1000 block of Shallcross Ave",0,0,N/A
+1777922,"August 27, 2020",Delaware,Ellendale,"12000 block of N Old State Rd",1,0,N/A
+1777934,"August 27, 2020",Delaware,Newark,"2275 Pulaski Hwy",0,0,N/A
+1777910,"August 27, 2020",Delaware,Wilmington,"800 block of Tatnall St",0,1,N/A
+1777907,"August 27, 2020",Delaware,Wilmington,"3209 Miller Rd",0,2,N/A
+1776812,"August 26, 2020",Delaware,Dover,"642 S Queen St",0,0,N/A
+1774611,"August 24, 2020",Delaware,Wilmington,"Edgemoor Rd and Marsh Rd",0,1,N/A
+1773035,"August 23, 2020",Delaware,Wilmington,"50 block of E 24th St",0,2,N/A
+1772323,"August 23, 2020",Delaware,Wilmington,"700 block of E 10th St",0,1,N/A
+1773207,"August 23, 2020",Delaware,Wilmington,"W 7th St and West St",0,0,N/A
+1772162,"August 22, 2020",Delaware,Newark,"240 Chapman Rd",0,1,N/A
+1772157,"August 21, 2020",Delaware,Seaford,"700 block of Collins Ave",0,2,N/A
+1772155,"August 21, 2020",Delaware,Dover,"805 S Governors Ave",0,0,N/A
+1770813,"August 21, 2020",Delaware,Wilmington,"700 block of N Washington St",0,1,N/A
+1768610,"August 19, 2020",Delaware,"Wilmington (Edgemoor)","Rysing Dr and Polk Rd",1,1,N/A
+1766660,"August 15, 2020",Delaware,Dover,"411 S Queen St",0,0,N/A
+1775617,"August 15, 2020",Delaware,Wilmington,"1300 block of E 29th St",0,0,N/A
+1765441,"August 15, 2020",Delaware,Wilmington,"2500 block of N Tatnall St",0,1,N/A
+1761555,"August 11, 2020",Delaware,Wilmington,"2400 block of Washington St",0,1,N/A
+1763290,"August 11, 2020",Delaware,"New Castle","1515 N DuPont Pkwy",0,0,N/A
+1763981,"August 11, 2020",Delaware,Magnolia,"50 block of Cherry Dr W",0,0,N/A
+1761552,"August 10, 2020",Delaware,Wilmington,"800 block of N Pine St",1,1,N/A
+1762483,"August 10, 2020",Delaware,Newark,"100 block of W Main St",0,0,N/A
+1758683,"August 8, 2020",Delaware,Seaford,"22588 Bridgeville Hwy",1,0,N/A
+1761550,"August 8, 2020",Delaware,Newark,"240 Chapman Rd",0,0,N/A
+1761549,"August 8, 2020",Delaware,Dover,"200 block of N Governors Blvd",0,0,N/A
+1758208,"August 7, 2020",Delaware,Wilmington,"E 24th St and Carter St",0,1,N/A
+1758692,"August 7, 2020",Delaware,Wilmington,"W 29th St and Washington St",0,1,N/A
+1757482,"August 6, 2020",Delaware,Wilmington,"2300 block of Carter St",0,2,N/A
+1756451,"August 5, 2020",Delaware,Wilmington,"2700 block of N Market St",0,2,N/A
+1755601,"August 4, 2020",Delaware,Dover,"S New St and Reed St",0,0,N/A
+1755598,"August 4, 2020",Delaware,Wilmington,"2300 block of Carter St",0,1,N/A
+1749288,"July 29, 2020",Delaware,Wilmington,"900 block of N Lombard St",1,0,N/A
+1750157,"July 29, 2020",Delaware,Wilmington,"5209 Concord Pike",0,0,N/A
+1749281,"July 28, 2020",Delaware,Wilmington,"1100 block of Beech St",2,2,N/A
+1748298,"July 28, 2020",Delaware,Milford,"9 Pennsylvania Ave",1,0,N/A
+1747874,"July 27, 2020",Delaware,Wilmington,"E 12th St and N Walnut St",0,1,N/A
+1748307,"July 26, 2020",Delaware,Millsboro,"Golden Arrow Ct",0,0,N/A
+1747604,"July 26, 2020",Delaware,Wilmington,"100 block of N Franklin St",0,1,N/A
+1748347,"July 25, 2020",Delaware,Dover,"N Governors Blvd",0,0,N/A
+1745374,"July 24, 2020",Delaware,Wilmington,"50 block of Jensen Dr",0,2,N/A
+1746056,"July 24, 2020",Delaware,Dover,"1440 N Dupont Hwy",0,0,N/A
+1743660,"July 23, 2020",Delaware,Wilmington,"E 25th St and Jessup St",0,1,N/A
+1741219,"July 19, 2020",Delaware,Lincoln,"22000 block of Pine Haven Rd",0,0,N/A
+1740167,"July 19, 2020",Delaware,"Wilmington (Elsmere)","Court Dr and Lancaster Ave",0,0,N/A
+1738829,"July 18, 2020",Delaware,Wilmington,"50 block of E 13th St",0,1,N/A
+1739407,"July 18, 2020",Delaware,Milford,"Betsy Ross Cir",0,0,N/A
+1738837,"July 18, 2020",Delaware,Wilmington,"70 Court Dr",0,1,N/A
+1737948,"July 16, 2020",Delaware,Dover,"100 N DuPont Hwy",0,0,N/A
+1737489,"July 16, 2020",Delaware,Wilmington,"2800 block of Northeast Blvd",0,1,N/A
+1737956,"July 15, 2020",Delaware,Milford,"Aurora Pl and Allen Way",0,0,N/A
+1735761,"July 15, 2020",Delaware,Wilmington,"500 block of Homestead Rd",0,1,N/A
+1736610,"July 15, 2020",Delaware,Milford,"Betsy Ross Cir",0,1,N/A
+1735758,"July 14, 2020",Delaware,Wilmington,"Bedford Dr",0,0,N/A
+1735747,"July 14, 2020",Delaware,Dover,"400 block of E Water St",0,0,N/A
+1735736,"July 14, 2020",Delaware,Wilmington,"400 block of N Madison St",0,1,N/A
+1735756,"July 14, 2020",Delaware,Wilmington,"S Clifton Ave and Sylvan Ave",0,1,N/A
+1791699,"July 14, 2020",Delaware,Smyrna,"Locust St and E Commerce St",0,1,N/A
+1733289,"July 13, 2020",Delaware,Wilmington,"700 block of W 4th St",0,1,N/A
+1733301,"July 13, 2020",Delaware,Milton,"28000 block of Fisher Rd",0,0,N/A
+1733287,"July 12, 2020",Delaware,Wilmington,"800 block of W 23rd St",0,1,N/A
+1732317,"July 12, 2020",Delaware,Felton,"50 block of Skinner Ln",0,0,N/A
+1732321,"July 11, 2020",Delaware,Wilmington,"600 block of N Pine St",0,5,N/A
+1729647,"July 9, 2020",Delaware,Wilmington,"600 block of N Madison St",0,1,N/A
+1730504,"July 9, 2020",Delaware,Bridgeville,"21000 block of Mill Park Dr",0,0,N/A
+1728752,"July 8, 2020",Delaware,Dover,"S DuPont Hwy and Loockerman St",1,0,N/A
+1729649,"July 8, 2020",Delaware,Dover,"100 block of Mast Cir",0,1,N/A
+1729660,"July 7, 2020",Delaware,Dover,"N New St and Fulton St",0,0,N/A
+1728744,"July 7, 2020",Delaware,Wilmington,"100 block of N Franklin St",0,2,N/A
+1727881,"July 6, 2020",Delaware,Dover,"100 block of S New St",1,0,N/A
+1727884,"July 6, 2020",Delaware,Dover,"400 block of E Water St",0,0,N/A
+1726544,"July 6, 2020",Delaware,Wilmington,"800 block of N Pine St",1,0,N/A
+1727859,"July 6, 2020",Delaware,Wilmington,"800 block of E 13th St",1,0,N/A
+1725306,"July 5, 2020",Delaware,Wilmington,"300 block of N Clayton St",1,1,N/A
+1727874,"July 5, 2020",Delaware,Middletown,"400 block of Flower Hall Dr",0,2,N/A
+1732348,"July 4, 2020",Delaware,"New Castle","50 block of Thorn Ct",1,2,N/A
+1725030,"July 4, 2020",Delaware,Wilmington,"W 29th St and Washington St",0,1,N/A
+1723563,"July 3, 2020",Delaware,Wilmington,"200 block of N Rodney St",0,1,N/A
+1726551,"July 2, 2020",Delaware,Millsboro,"Main St and Daisey Rd",0,0,N/A
+1732345,"June 29, 2020",Delaware,Newark,"50 block of Madison Dr",0,0,N/A
+1720640,"June 29, 2020",Delaware,Dover,"100 block of S New St",0,0,N/A
+1719813,"June 28, 2020",Delaware,Wilmington,"200 block of E 25th St",0,1,N/A
+1719025,"June 27, 2020",Delaware,Wilmington,"1000 block of W 8th St",0,1,N/A
+1717493,"June 26, 2020",Delaware,Wilmington,"E 7th St and N Spruce St",0,1,N/A
+1716264,"June 25, 2020",Delaware,Wilmington,"300 block of E 13th St",1,1,N/A
+1715123,"June 23, 2020",Delaware,Wilmington,"100 block of N Rodney St",0,1,N/A
+1713999,"June 23, 2020",Delaware,Magnolia,"Lambert Dr",0,1,N/A
+1711566,"June 21, 2020",Delaware,Wilmington,"100 block of S Dupont St",0,2,N/A
+1712517,"June 21, 2020",Delaware,Magnolia,"800 block of Millchop Ln",0,0,N/A
+1711563,"June 20, 2020",Delaware,Greenwood,"10000 block of Memory Rd",0,1,N/A
+1711080,"June 19, 2020",Delaware,Dover,"5485 S Dupont Hwy",0,0,N/A
+1709640,"June 19, 2020",Delaware,Dover,"200 block of N New St",0,0,N/A
+1709631,"June 19, 2020",Delaware,Wilmington,"900 block of Vandever Ave",0,3,N/A
+1709623,"June 18, 2020",Delaware,Wilmington,"100 block of E 24th St",0,1,N/A
+1709621,"June 18, 2020",Delaware,Wilmington,"2300 block of N Washington St",0,1,N/A
+1707796,"June 16, 2020",Delaware,Wilmington,"1700 block of Locust St",1,0,N/A
+1707799,"June 16, 2020",Delaware,Wilmington,"W 3rd St and N Clayton St",0,2,N/A
+1712532,"June 16, 2020",Delaware,Harrington,"50 block of Clark St",0,0,N/A
+1706957,"June 15, 2020",Delaware,Millsboro,"34000 block of Lynch Rd",0,0,N/A
+1706953,"June 14, 2020",Delaware,Harrington,"700 block of Messicks Rd",0,0,N/A
+1706406,"June 14, 2020",Delaware,Seaford,"400 block of Pine St",0,1,N/A
+1703265,"June 11, 2020",Delaware,Milton,"Springside Dr",0,0,N/A
+1700681,"June 9, 2020",Delaware,Dover,"50 block of S New St",0,2,N/A
+1700669,"June 8, 2020",Delaware,Dover,"Becky Ln",0,0,N/A
+1700687,"June 8, 2020",Delaware,Harrington,"1259 Corn Crib Rd",0,0,N/A
+1698799,"June 6, 2020",Delaware,Lewes,"33000 block of Sandy Bay Dr",0,1,N/A
+1699078,"June 6, 2020",Delaware,Wilmington,"2900 block of N Washington St",0,1,N/A
+1698763,"June 5, 2020",Delaware,Dover,"400 block of Barrister Pl",0,2,N/A
+1698759,"June 5, 2020",Delaware,Wilmington,"900 block of Bennett St",1,0,N/A
+1697492,"June 4, 2020",Delaware,Wilmington,"500 block of E 3rd St",0,1,N/A
+1695841,"June 3, 2020",Delaware,Dover,"100 block of Hampton Dr",0,0,N/A
+1694963,"June 2, 2020",Delaware,Wilmington,"B St and Townsend St",0,1,N/A
+1695844,"June 2, 2020",Delaware,Dover,N/A,0,1,N/A
+1694983,"June 1, 2020",Delaware,Dover,"800 block of Woodcrest Turn",0,0,N/A
+1694973,"June 1, 2020",Delaware,Dover,"300 block of Kesselring Ave",1,0,N/A
+1697502,"May 31, 2020",Delaware,Newark,"2644 Capitol Trail",0,0,N/A
+1693175,"May 31, 2020",Delaware,Newark,"500 block of Capitol Trail",0,1,N/A
+1694995,"May 31, 2020",Delaware,Dover,"Cecil St and N Governors Ave",0,1,N/A
+1693532,"May 30, 2020",Delaware,Wilmington,"600 block of W 5th St",0,1,N/A
+1693527,"May 30, 2020",Delaware,Wilmington,"600 block of W 7th St",0,2,N/A
+1693523,"May 30, 2020",Delaware,Wilmington,"400 block of W 31st St",0,1,N/A
+1695001,"May 30, 2020",Delaware,Seaford,"9000 block of Middleford Rd",0,0,N/A
+1694067,"May 30, 2020",Delaware,Dover,"Simon Cir",0,1,N/A
+1694062,"May 30, 2020",Delaware,Dover,"2600 block of Kenton Rd",0,0,N/A
+1694075,"May 29, 2020",Delaware,Milton,"28000 block of W Springside Dr",0,0,N/A
+1692301,"May 29, 2020",Delaware,Wilmington,"800 block of Tatnall St",0,1,N/A
+1691857,"May 28, 2020",Delaware,Felton,"Cattle Dr",0,0,N/A
+1690535,"May 27, 2020",Delaware,Newark,"520 JFK Memorial Hwy",0,1,N/A
+1690542,"May 26, 2020",Delaware,Milford,"100 block of Pritchett Rd",0,0,N/A
+1688573,"May 26, 2020",Delaware,Milton,"400 block of S Lake Dr",0,0,N/A
+1688880,"May 26, 2020",Delaware,Wilmington,"2200 block of Washington St",0,1,N/A
+1688578,"May 25, 2020",Delaware,Dover,"400 block of Barrister Pl",0,0,N/A
+1688499,"May 25, 2020",Delaware,Newark,"300 block of Kemper Dr",0,1,N/A
+1688554,"May 24, 2020",Delaware,Dover,"1300 S Farmview Dr",0,1,N/A
+1685797,"May 21, 2020",Delaware,Dover,"200 block of N Queen St",0,0,N/A
+1684741,"May 21, 2020",Delaware,Wilmington,"E 9th St and N Church St",0,1,N/A
+1690544,"May 17, 2020",Delaware,Wilmington,"50 block of S Clayton St",0,0,N/A
+1681741,"May 17, 2020",Delaware,Wilmington,"1800 block of W 3rd St",0,1,N/A
+1682224,"May 17, 2020",Delaware,Wilmington,"2300 block of Carter St",0,2,N/A
+1684109,"May 16, 2020",Delaware,Wilmington,"200 block of W 22nd St",0,0,N/A
+1681814,"May 16, 2020",Delaware,Claymont,"4th Ave",0,1,N/A
+1681528,"May 16, 2020",Delaware,Lincoln,"21000 block of Mayhew Dr",0,0,N/A
+1679607,"May 14, 2020",Delaware,Wilmington,"2400 block of Jefferson St",0,1,N/A
+1681538,"May 14, 2020",Delaware,Ellendale,"18000 block of S Old State Rd",0,0,N/A
+1677150,"May 10, 2020",Delaware,Dover,"4000 block of Vermont Dr",0,0,N/A
+1676853,"May 10, 2020",Delaware,Dover,"100 Block of Willis Rd",0,1,N/A
+1676857,"May 9, 2020",Delaware,Dover,"150 N DuPont Hwy",0,0,N/A
+1675072,"May 8, 2020",Delaware,Bear,"2465 Chesapeake City Rd",3,0,N/A
+1675033,"May 7, 2020",Delaware,Wilmington,"600 block of Maryland Ave",0,1,N/A
+1673467,"May 2, 2020",Delaware,Wilmington,"3602 Miller Rd",0,0,N/A
+1670879,"May 1, 2020",Delaware,Wilmington,"117 Washington Ave",0,0,N/A
+1668508,"April 28, 2020",Delaware,Wilmington,"100 block of Ashton St",1,0,N/A
+1674329,"April 28, 2020",Delaware,Wilmington,"1700 block of Lancaster Ave",0,0,N/A
+1668253,"April 28, 2020",Delaware,"Wilmington (Edgemoor)","S Rodney Dr and Bedford Dr",0,2,N/A
+1673484,"April 28, 2020",Delaware,Bear,"900 block of Red Lion Rd",0,0,N/A
+1672805,"April 27, 2020",Delaware,Ellendale,"Beaver Dam Rd",0,0,N/A
+1666788,"April 26, 2020",Delaware,Georgetown,"Briarwood Rd",0,0,N/A
+1666348,"April 25, 2020",Delaware,Wilmington,"800 block of W 5th St",0,1,N/A
+1664334,"April 22, 2020",Delaware,"Camden Wyoming (Camden)","9000 block of Willow Grove Rd",0,0,N/A
+1663043,"April 20, 2020",Delaware,Magnolia,"300 block of Millchop Ln",0,0,N/A
+1662333,"April 19, 2020",Delaware,"New Castle","100 block of Carvel Ave",0,0,N/A
+1662231,"April 19, 2020",Delaware,Wilmington,"7th St and Washington St",0,2,N/A
+1661534,"April 18, 2020",Delaware,Wilmington,"50 block of S Rodney Dr",0,2,N/A
+1661668,"April 18, 2020",Delaware,Milton,"2000 block of Pickwick Dr",0,1,N/A
+1660540,"April 17, 2020",Delaware,Claymont,"3000 block of Green St",0,2,N/A
+1661291,"April 17, 2020",Delaware,Felton,"8953 S Dupont Hwy",0,0,N/A
+1663052,"April 14, 2020",Delaware,Wilmington,"400 block of Vandever Ave",0,0,N/A
+1658614,"April 13, 2020",Delaware,Newark,"50 block of New London Ave",0,0,N/A
+1657330,"April 12, 2020",Delaware,Wilmington,"E 11th St and N Walnut St",0,1,N/A
+1657326,"April 11, 2020",Delaware,Dover,"Presidents Dr and N Governors Blvd",0,0,N/A
+1656144,"April 10, 2020",Delaware,Wilmington,"600 block of N Franklin St",0,1,N/A
+1654511,"April 7, 2020",Delaware,Wilmington,"300 block of W 20th St",0,0,N/A
+1653795,"April 7, 2020",Delaware,Wilmington,"200 block of N Madison St",1,0,N/A
+1654498,"April 7, 2020",Delaware,Wilmington,"400 block of W 30th St",0,2,N/A
+1654399,"April 7, 2020",Delaware,Wilmington,"W 7th St and N Monroe St",0,1,N/A
+1654490,"April 6, 2020",Delaware,Newark,"2000 block of Sunset Lake Rd",0,1,N/A
+1653780,"April 6, 2020",Delaware,Millsboro,"Rd 413 and Daisey Rd",0,1,N/A
+1653770,"April 6, 2020",Delaware,Felton,"1300 block of Barney Jenkins Rd",0,0,N/A
+1652343,"April 4, 2020",Delaware,Wilmington,"50 block of W 27th St",0,1,N/A
+1649636,"March 31, 2020",Delaware,Wilmington,"300 block of W 26th St",0,1,N/A
+1648874,"March 30, 2020",Delaware,Newark,"69 Greenridge Dr",0,1,N/A
+1646539,"March 26, 2020",Delaware,Wilmington,"3000 block of N Monroe St",0,1,N/A
+1646543,"March 25, 2020",Delaware,Millsboro,"28000 block of Delaware Ave",0,1,N/A
+1645381,"March 24, 2020",Delaware,"New Castle (Minquadale)","Hazeldell Ave and Milford St",0,1,N/A
+1646031,"March 23, 2020",Delaware,Newark,"50 block of Plymouth Dr",0,0,N/A
+1643570,"March 21, 2020",Delaware,Bear,"700 block of N Huckleberry Ave",0,1,N/A
+1642932,"March 17, 2020",Delaware,Wilmington,"2500 block of N West St",0,0,N/A
+1641536,"March 17, 2020",Delaware,Wilmington,"300 block of W 37th St",0,1,N/A
+1641533,"March 16, 2020",Delaware,Smyrna,"100 block of Blackbird Greenspring Rd",0,0,N/A
+1637858,"March 10, 2020",Delaware,Milford,"Bennetts Pier Rd",0,1,N/A
+1642113,"March 7, 2020",Delaware,Wilmington,"500 block of W 7th St",0,0,N/A
+1635468,"March 6, 2020",Delaware,Seaford,"22588 Bridgeville Hwy",0,1,N/A
+1634822,"March 5, 2020",Delaware,Wilmington,"3200 block of W 2nd St",0,1,N/A
+1634156,"March 4, 2020",Delaware,Wilmington,"2501 Ebright Rd",0,0,N/A
+1633495,"March 2, 2020",Delaware,Dover,"400 block of Ann Moore St",0,0,N/A
+1631625,"February 28, 2020",Delaware,Lincoln,"8000 block of Virginia Pine Rd",0,0,N/A
+1629970,"February 27, 2020",Delaware,Lincoln,"Virginia Pine Ln and Johnson Rd",0,0,N/A
+1629327,"February 25, 2020",Delaware,Dover,"Pine Cabin Rd and Lemay Ln",1,0,N/A
+1627204,"February 23, 2020",Delaware,"Rehoboth Beach","19178 Coastal Highway",0,0,N/A
+1626971,"February 22, 2020",Delaware,Frederica,"102 S Flack Ave",2,0,N/A
+1626974,"February 22, 2020",Delaware,Wilmington,"2200 block of Washington St",0,1,N/A
+1629978,"February 22, 2020",Delaware,Wilmington,"2700 block of W 5th St",0,0,N/A
+1628623,"February 21, 2020",Delaware,Dover,"1400 block of Garfield Dr",0,0,N/A
+1625863,"February 20, 2020",Delaware,Harrington,"100 block of Central Park Dr",0,0,N/A
+1625734,"February 20, 2020",Delaware,Wilmington,"1601 N Spruce St",0,1,N/A
+1624883,"February 19, 2020",Delaware,Wilmington,"E 7th St and N Pine St",0,3,N/A
+1627216,"February 19, 2020",Delaware,Wilmington,"300 block of Concord Ave",0,0,N/A
+1624360,"February 18, 2020",Delaware,Wilmington,"1800 block of W 6th St",0,1,N/A
+1623621,"February 18, 2020",Delaware,Wilmington,"1100 block of Chestnut St",0,1,N/A
+1624390,"February 18, 2020",Delaware,Newark,"600 block of S Old Baltimore Pike",0,0,N/A
+1625061,"February 18, 2020",Delaware,Dover,"W North St and Simon Cir",0,1,N/A
+1623625,"February 16, 2020",Delaware,Milford,"8000 block of Slaughter Beach Rd",0,0,N/A
+1622875,"February 16, 2020",Delaware,Wilmington,"800 block of N Adams St",2,0,N/A
+1622475,"February 15, 2020",Delaware,"Wilmington (Newport)","100 Bennett Ct",1,0,N/A
+1622957,"February 15, 2020",Delaware,Dover,"900 block of Carvel Dr",0,0,N/A
+1622947,"February 15, 2020",Delaware,Wilmington,"1706 Philadelphia Pike",0,0,N/A
+1622249,"February 15, 2020",Delaware,Wilmington,"2300 block of Pine St",0,1,N/A
+1622247,"February 15, 2020",Delaware,Newark,"4000 block of Ogletown Stanton Rd",0,1,N/A
+1622478,"February 14, 2020",Delaware,Seaford,"700 block of Norman Eskridge Hwy",0,0,N/A
+1628625,"February 13, 2020",Delaware,Wilmington,"1000 block of N Pine St",0,0,N/A
+1625865,"February 13, 2020",Delaware,Lincoln,"300 block of Cedar Dr",0,0,N/A
+1619792,"February 11, 2020",Delaware,Wilmington,"300 block of N Broom St",0,1,N/A
+1619794,"February 11, 2020",Delaware,Seaford,"24000 block of Middlecord Circle",0,0,N/A
+1619076,"February 11, 2020",Delaware,Wilmington,"800 block of N Adams St",0,1,N/A
+1619529,"February 10, 2020",Delaware,"New Castle","4060 N DuPont Hwy",0,0,N/A
+1619064,"February 10, 2020",Delaware,Dover,"200 block of W Reed St",1,4,N/A
+1618050,"February 7, 2020",Delaware,Magnolia,"100 block of Terry Dr",0,0,N/A
+1614929,"February 5, 2020",Delaware,Wilmington,"2212 N Market St",1,0,N/A
+1613761,"February 4, 2020",Delaware,Dover,"100 block of Creekbend Dr",0,0,N/A
+1677146,"February 2, 2020",Delaware,Magnolia,"50 block of Terry Dr",0,0,N/A
+1612664,"February 2, 2020",Delaware,Wilmington,"50 block of W 27th St",0,1,N/A
+1611891,"February 1, 2020",Delaware,Georgetown,"100 block of Garden Cir",0,1,N/A
+1617010,"January 31, 2020",Delaware,Milford,"900 block of SE Front St",0,0,N/A
+1608208,"January 29, 2020",Delaware,Frederica,"100 block of Maple Dr",0,0,N/A
+1610154,"January 29, 2020",Delaware,Dover,"500 Persimmon Tree Ln",0,0,N/A
+1609298,"January 29, 2020",Delaware,Dover,"400 block of Sussex Ave",0,0,N/A
+1609050,"January 29, 2020",Delaware,Wilmington,"600 block of E 6th St",0,1,N/A
+1609296,"January 28, 2020",Delaware,Dover,"200 block of Nob Hill Rd",0,0,N/A
+1608233,"January 27, 2020",Delaware,Dover,"400 block of Collins Dr",0,0,N/A
+1607534,"January 27, 2020",Delaware,Milton,"18000 block of Hudson Rd",0,0,N/A
+1605747,"January 26, 2020",Delaware,Magnolia,"100 block of Terry Dr",0,1,N/A
+1605749,"January 25, 2020",Delaware,Wilmington,"800 block of N West St",0,1,N/A
+1605643,"January 24, 2020",Delaware,Dover,"70 Greenway Square",1,0,N/A
+1604433,"January 23, 2020",Delaware,Wilmington,"100 block of S Van Buren St",0,0,N/A
+1604432,"January 23, 2020",Delaware,Wilmington,"1200 block of N French St",0,0,N/A
+1604423,"January 23, 2020",Delaware,Wilmington,"300 block of Woodlawn Ave",0,1,N/A
+1602702,"January 22, 2020",Delaware,Dover,"100 block of Alonzo Dr",0,0,N/A
+1603561,"January 22, 2020",Delaware,Wilmington,"500 block of N Monroe St",0,0,N/A
+1604430,"January 22, 2020",Delaware,Ellendale,"12000 block of Ponder Rd",0,0,N/A
+1602696,"January 21, 2020",Delaware,"Camden Wyoming (Camden)","239 Old North Rd",0,0,N/A
+1601952,"January 21, 2020",Delaware,Dover,"50 block of Steele Rd",0,0,N/A
+1601970,"January 20, 2020",Delaware,Wilmington,"1251 Centerville Rd",0,0,N/A
+1600937,"January 19, 2020",Delaware,Wilmington,"400 block of N Spruce St",0,1,N/A
+1600935,"January 19, 2020",Delaware,Wilmington,"1200 block of Chestnut St",0,1,N/A
+1600934,"January 19, 2020",Delaware,Felton,"1300 block of Barney Jenkins Rd",0,1,N/A
+1600085,"January 18, 2020",Delaware,Wilmington,"2700 block of N Claymont St",0,1,N/A
+1599460,"January 17, 2020",Delaware,Dover,"N Farmview Dr",0,0,N/A
+1598852,"January 16, 2020",Delaware,Dover,"S Bay Rd and President Dr",0,0,N/A
+1598845,"January 16, 2020",Delaware,Wilmington,"400 block of Queen St",0,1,N/A
+1597877,"January 14, 2020",Delaware,Dover,"500 Persimmon Tree Ln",0,0,N/A
+1595786,"January 14, 2020",Delaware,Wilmington,"300 block of W 6th St",1,0,N/A
+1595788,"January 13, 2020",Delaware,Harbeson,"22000 block of Danfield Dr",0,0,N/A
+1596840,"January 13, 2020",Delaware,Newark,"50 block of Salem Village Square",0,0,N/A
+1608220,"January 12, 2020",Delaware,Wilmington,"W 25th St and N West St",0,0,N/A
+1595066,"January 12, 2020",Delaware,Dover,"900 block of W North St",0,1,N/A
+1594209,"January 11, 2020",Delaware,Wilmington,"700 block of N Spruce St",0,1,N/A
+1595070,"January 10, 2020",Delaware,Dover,"50 block of S New St",0,0,N/A
+1592050,"January 8, 2020",Delaware,Delmar,"11000 block of Buckingham Dr",0,1,N/A
+1590434,"January 6, 2020",Delaware,Dover,"Paul St and Davis Cir",1,0,N/A
+1590437,"January 6, 2020",Delaware,Dover,"S Governors Blvd",0,0,N/A
+1589355,"January 5, 2020",Delaware,Milford,"5 Linstone Ln",1,0,N/A
+1588815,"January 2, 2020",Delaware,Dover,"S Governors Blvd",0,0,N/A
+1585283,"January 1, 2020",Delaware,Dover,"400 block of Collins Dr",0,2,N/A
+1586464,"December 31, 2019",Delaware,Bear,"Taylor Dr and Emerson Pl",1,0,N/A
+1585153,"December 31, 2019",Delaware,Wilmington,"2400 block of N Market St",0,1,N/A
+1585267,"December 31, 2019",Delaware,Dover,"100 block of Haman Dr",0,1,N/A
+1585264,"December 31, 2019",Delaware,"New Castle","700 block of Willings Way",1,0,N/A
+1585155,"December 31, 2019",Delaware,Wilmington,"2200 block of N Market St",0,1,N/A
+1585271,"December 30, 2019",Delaware,Dover,"400 block of Barrister Pl",0,1,N/A
+1584285,"December 30, 2019",Delaware,Dover,"100 block of S New St",0,2,N/A
+1582217,"December 28, 2019",Delaware,"New Castle","Liborio Ln",0,2,N/A
+1582175,"December 28, 2019",Delaware,Dover,"50 block of State Circle",0,0,N/A
+1582176,"December 28, 2019",Delaware,Dover,"50 block of Kentwood Dr",0,0,N/A
+1582179,"December 28, 2019",Delaware,Wilmington,"1300 block of E 29th St",1,0,N/A
+1581748,"December 27, 2019",Delaware,Dover,"50 block of S New St",0,0,N/A
+1581743,"December 27, 2019",Delaware,Seaford,"14000 block of County Seat Hwy",0,0,N/A
+1581746,"December 27, 2019",Delaware,Dover,"200 block of S Governors Blvd",0,1,N/A
+1580545,"December 26, 2019",Delaware,Wilmington,"1300 block of Cedar St",0,1,N/A
+1579814,"December 25, 2019",Delaware,Wilmington,"900 block of Vandever Ave",1,0,N/A
+1608218,"December 25, 2019",Delaware,Wilmington,"N DuPont St and W 4th St",0,0,N/A
+1579477,"December 24, 2019",Delaware,Wilmington,"200 block of Cityview Ave",0,1,N/A
+1579479,"December 24, 2019",Delaware,Wilmington,"500 block of New Castle Ave",0,1,N/A
+1579490,"December 24, 2019",Delaware,Dover,"S DuPont Hwy and Webbs Ln",0,0,N/A
+1580547,"December 24, 2019",Delaware,Dover,"S New St and Reed St",0,0,N/A
+1578931,"December 23, 2019",Delaware,Newark,"801 Christiana Rd",0,1,N/A
+1578165,"December 23, 2019",Delaware,Dover,"N Governors Blvd",0,1,N/A
+1577568,"December 21, 2019",Delaware,Hartly,"Myers Dr",0,0,N/A
+1577187,"December 20, 2019",Delaware,Seaford,"700 block of Collins Ave",0,1,N/A
+1575399,"December 18, 2019",Delaware,Milford,"200 block of North St",0,0,N/A
+1574623,"December 17, 2019",Delaware,Wilmington,"1800 Block of Conrad St",0,1,N/A
+1573639,"December 16, 2019",Delaware,Wilmington,"2700 block of N West St",0,1,N/A
+1573642,"December 14, 2019",Delaware,Newark,"Briar Ln",0,0,N/A
+1573643,"December 14, 2019",Delaware,Newark,"W Main St",0,0,N/A
+1572606,"December 14, 2019",Delaware,Wilmington,"100 block of N Harrison St",0,1,N/A
+1571876,"December 12, 2019",Delaware,Dover,"Mast Cir",0,0,N/A
+1570875,"December 12, 2019",Delaware,Wilmington,"3400 block of Lancaster Pike",1,0,N/A
+1569970,"December 11, 2019",Delaware,Harrington,"50 block of Diamond Ct",1,0,N/A
+1568169,"December 7, 2019",Delaware,Selbyville,"29000 block of Poplar Ct",0,0,N/A
+1566384,"December 6, 2019",Delaware,Dover,"125 Haman Dr",0,1,N/A
+1564587,"December 4, 2019",Delaware,Dover,"400 block of E Water St",0,1,N/A
+1564593,"December 3, 2019",Delaware,Dover,"125 Haman Dr",0,0,N/A
+1563767,"December 3, 2019",Delaware,Wilmington,"100 block of E 24th St",1,0,N/A
+1561845,"December 1, 2019",Delaware,Wilmington,"200 block of N Market St",0,2,N/A
+1563087,"December 1, 2019",Delaware,Wilmington,"300 block of Barrett St",0,0,N/A
+1561617,"November 29, 2019",Delaware,Lewes,"300 block of E Savannah Rd",1,0,N/A
+1559948,"November 27, 2019",Delaware,Bridgeville,"11000 block of Evans Dr",1,0,N/A
+1558134,"November 26, 2019",Delaware,Dover,"500 block of Roberta Ave",0,0,N/A
+1558129,"November 25, 2019",Delaware,Wilmington,"2300 block of Washington St",1,1,N/A
+1556436,"November 23, 2019",Delaware,Wilmington,"2300 block of Bowers St",0,2,N/A
+1566389,"November 20, 2019",Delaware,Wilmington,"S Maryland Ave and E Newport Pike",0,0,N/A
+1555099,"November 20, 2019",Delaware,Delmar,"14122 Oak Branch Rd",0,0,N/A
+1554338,"November 20, 2019",Delaware,Dover,"400 block of Sussex Ave",0,0,N/A
+1552044,"November 18, 2019",Delaware,Wilmington,"100 block of E 24th St",0,1,N/A
+1550877,"November 16, 2019",Delaware,Dover,"S State St and Lake Land Ave",0,1,N/A
+1550513,"November 15, 2019",Delaware,"Wilmington (Edgemoor)","Polk Rd and Rysing Dr",0,0,N/A
+1550511,"November 15, 2019",Delaware,Wilmington,"100 block of W 27th St",0,1,N/A
+1549492,"November 13, 2019",Delaware,Dover,"50 block of Carlisle Dr",0,0,N/A
+1547234,"November 11, 2019",Delaware,Wilmington,"1300 block of Chesnut St",1,0,N/A
+1547244,"November 11, 2019",Delaware,Harrington,"100 block of Wolcott St",0,0,N/A
+1547231,"November 11, 2019",Delaware,Wilmington,"301 W 29th St",0,2,N/A
+1545820,"November 9, 2019",Delaware,Seaford,"24000 block of E Middlecord Circle",0,0,N/A
+1553580,"November 8, 2019",Delaware,Wilmington,"700 block of N Franklin St",0,0,N/A
+1545755,"November 7, 2019",Delaware,Dover,"Karen Pl",0,0,N/A
+1562463,"November 5, 2019",Delaware,"Camden Wyoming","400 block of Jebb Rd",0,0,N/A
+1542040,"November 3, 2019",Delaware,Dover,"100 block of Old Forge Dr",0,0,N/A
+1540742,"November 2, 2019",Delaware,Wilmington,"3800 block of N Market St",0,1,N/A
+1540739,"November 2, 2019",Delaware,Wilmington,"3000 block of Washington St",0,1,N/A
+1541276,"November 1, 2019",Delaware,Millsboro,"24000 block of Shoreline Dr",0,0,N/A
+1540290,"November 1, 2019",Delaware,Wilmington,"900 block of S Broom St",0,1,N/A
+1540755,"October 29, 2019",Delaware,Smyrna,"Chestnut St",0,0,N/A
+1539387,"October 29, 2019",Delaware,Dover,"100 block of Spruance Rd",0,0,N/A
+1538362,"October 29, 2019",Delaware,Wilmington,"400 Foulk Rd",1,0,N/A
+1537060,"October 29, 2019",Delaware,Wilmington,"600 block of N West St",0,1,N/A
+1537827,"October 28, 2019",Delaware,Newark,"2360 Pulaski Hwy",0,0,N/A
+1537058,"October 28, 2019",Delaware,Wilmington,"2500 block of Thatcher St",1,0,N/A
+1537821,"October 28, 2019",Delaware,"New Castle","465 Marina Ln",0,2,N/A
+1537063,"October 28, 2019",Delaware,Newark,"50 block of Kings Cir",0,1,N/A
+1536732,"October 27, 2019",Delaware,Milton,"24000 block of Milton Ellendale Hwy",0,0,N/A
+1534190,"October 24, 2019",Delaware,Dover,"50 block of Harmony Hill Dr",0,0,N/A
+1532971,"October 23, 2019",Delaware,Bear,"600 block of Parkman Ct",0,1,N/A
+1533699,"October 23, 2019",Delaware,Middletown,"1800 block of Choptank Rd",1,0,N/A
+1532981,"October 22, 2019",Delaware,Harrington,"N West St",0,0,N/A
+1532964,"October 22, 2019",Delaware,Seaford,"24000 block of Concord Pond Rd",0,0,N/A
+1531564,"October 21, 2019",Delaware,Hockessin,"4000 block of Newport Gap Pike",0,0,N/A
+1532189,"October 21, 2019",Delaware,Smyrna,"500 block of Owens Brook Dr",0,1,N/A
+1531560,"October 20, 2019",Delaware,Dover,"50 block of S New St",0,1,N/A
+1530935,"October 20, 2019",Delaware,Wilmington,"300 block of N Franklin St",1,0,N/A
+1531563,"October 19, 2019",Delaware,Dover,"100 block of Cherry St",0,0,N/A
+1533696,"October 19, 2019",Delaware,Laurel,"1000 Holly Brook Apartments",0,0,N/A
+1530934,"October 19, 2019",Delaware,Lincoln,"10000 block of Heritage Rd",0,0,N/A
+1530483,"October 18, 2019",Delaware,Wilmington,"2200 block of N Spruce St",0,1,N/A
+1530485,"October 17, 2019",Delaware,Hartly,"200 block of Will Scarlet Ln",0,0,N/A
+1530106,"October 17, 2019",Delaware,"Wilmington (Edgemoor)","Bedford Dr",0,1,N/A
+1528462,"October 16, 2019",Delaware,Dover,"200 block of W Division St",0,1,N/A
+1532980,"October 16, 2019",Delaware,Milford,"300 Aurora Pl",0,0,N/A
+1528888,"October 16, 2019",Delaware,"Wilmington (Edgemoor)","S Cannon Dr",0,1,N/A
+1525767,"October 12, 2019",Delaware,Wilmington,"900 block of N Lombard St",0,1,N/A
+1523146,"October 8, 2019",Delaware,Seaford,"24000 block of German Rd",0,0,N/A
+1521896,"October 5, 2019",Delaware,Dover,"200 block of S Dupont Hwy",0,0,N/A
+1520418,"October 3, 2019",Delaware,Dover,"Saxton Rd and Steele Rd",0,0,N/A
+1520413,"October 3, 2019",Delaware,Greenwood,"6200 block of Hickman Rd",0,0,N/A
+1526994,"September 30, 2019",Delaware,Wilmington,"700 block of N Washington St",0,0,N/A
+1516407,"September 29, 2019",Delaware,Newark,"300 block of Terrace Dr",0,0,N/A
+1516405,"September 29, 2019",Delaware,"New Castle","Briarcliff Dr",0,0,N/A
+1514997,"September 27, 2019",Delaware,Wilmington,"2500 block of N Monroe St",1,0,N/A
+1513711,"September 26, 2019",Delaware,Laurel,"2708 Daniel St",0,0,N/A
+1513722,"September 26, 2019",Delaware,Bear,"108 Mario Dr",0,1,N/A
+1512147,"September 25, 2019",Delaware,Dover,"865 N DuPont Hwy",0,3,N/A
+1511226,"September 23, 2019",Delaware,Harrington,"1259 Corn Crib Rd",0,1,N/A
+1511161,"September 23, 2019",Delaware,Seaford,"23000 block of German Rd",0,1,N/A
+1511223,"September 22, 2019",Delaware,Dover,"1210 White Oak Rd",0,2,N/A
+1510354,"September 22, 2019",Delaware,Newark,"200 block of King William St",0,0,N/A
+1521898,"September 21, 2019",Delaware,Wilmington,"600 block of N Monroe St",0,0,N/A
+1508100,"September 20, 2019",Delaware,Milford,"Bay Rd",0,0,N/A
+1508987,"September 20, 2019",Delaware,Seaford,"700 block of Atlanta Rd",0,0,N/A
+1507188,"September 18, 2019",Delaware,Newark,"457 Stanton Christiana Rd",0,0,N/A
+1505574,"September 16, 2019",Delaware,Dover,"3100 block of Forrest Ave",0,1,N/A
+1505564,"September 16, 2019",Delaware,Wilmington,"W 7th St and N Monroe St",0,1,N/A
+1505566,"September 16, 2019",Delaware,Wilmington,"1000 block of N Van Buren St",1,0,N/A
+1504704,"September 15, 2019",Delaware,Bear,"3800 block of Wrangle Hill Rd",0,0,N/A
+1504699,"September 15, 2019",Delaware,Wilmington,"1900 block of N Washington St",0,1,N/A
+1518447,"September 14, 2019",Delaware,Wilmington,"900 block of E 4th St",0,0,N/A
+1502937,"September 13, 2019",Delaware,Wilmington,"900 block of Bennett St",1,0,N/A
+1503276,"September 13, 2019",Delaware,Wilmington,"N Monroe St and W 5th St",2,0,N/A
+1502939,"September 12, 2019",Delaware,Dover,"200 block of Harmony Ln",1,0,N/A
+1513707,"September 12, 2019",Delaware,Wilmington,"600 block of Concord Ave",0,0,N/A
+1512144,"September 11, 2019",Delaware,Wilmington,"200 block of N Harrison St",0,0,N/A
+1510349,"September 11, 2019",Delaware,Wilmington,"E 10th St and Wilson St",0,0,N/A
+1500661,"September 10, 2019",Delaware,Wilmington,"700 block of N Monroe St",0,1,N/A
+1532708,"September 9, 2019",Delaware,Wilmington,"700 block of N Monroe St",0,1,N/A
+1508484,"September 7, 2019",Delaware,Wilmington,"2600 block of N Tatnall St",0,0,N/A
+1499336,"September 5, 2019",Delaware,"New Castle","New Castle Ave",0,0,N/A
+1500673,"September 5, 2019",Delaware,Milford,"Old Shawnee Rd",0,0,N/A
+1498193,"September 5, 2019",Delaware,Harrington,"Mill St",0,0,N/A
+1515074,"September 4, 2019",Delaware,Dover,"50 block of Stevenson Dr",0,0,N/A
+1497402,"September 3, 2019",Delaware,Magnolia,"Walnut Shade Rd",0,0,N/A
+1496513,"September 3, 2019",Delaware,Wilmington,"400 block of E 35th St",1,0,N/A
+1495137,"September 3, 2019",Delaware,Wilmington,"600 block of N Scott St",0,1,N/A
+1494461,"September 1, 2019",Delaware,Smyrna,"5000 block of Smyrna Leipsic Rd",0,0,N/A
+1494458,"September 1, 2019",Delaware,Wilmington,"1000 block of Spruce St",0,1,N/A
+1493414,"August 31, 2019",Delaware,Bridgeville,"1st St and Vine St",0,1,N/A
+1506402,"August 31, 2019",Delaware,Wilmington,"400 block of S Van Buren St",0,0,N/A
+1503280,"August 30, 2019",Delaware,Wilmington,"300 block of S Jackson St",0,0,N/A
+1492958,"August 30, 2019",Delaware,Wilmington,"2700 block of Washington St",1,0,N/A
+1506400,"August 30, 2019",Delaware,Wilmington,"600 block of N Van Buren St",0,0,N/A
+1492962,"August 29, 2019",Delaware,Dagsboro,"Main St and Iron Branch Rd",0,0,N/A
+1496518,"August 29, 2019",Delaware,"Wilmington (Stanton)","50 block of Cypress Ave",0,0,N/A
+1491467,"August 28, 2019",Delaware,Wilmington,N/A,0,0,N/A
+1491463,"August 27, 2019",Delaware,Wilmington,"DE-2 and Limestone Rd",0,0,N/A
+1500663,"August 27, 2019",Delaware,Wilmington,"400 block of N Church St",0,0,N/A
+1489720,"August 26, 2019",Delaware,Dover,"Tollhouse Pl",0,0,N/A
+1488582,"August 25, 2019",Delaware,Claymont,"50 block of Balfour Ave",0,1,N/A
+1487186,"August 24, 2019",Delaware,Dover,"2000 block of Generals Way",0,0,N/A
+1488156,"August 24, 2019",Delaware,Milton,"100 block of Bangor Ln",0,0,N/A
+1496515,"August 23, 2019",Delaware,Wilmington,"1700 block of W 4th St",0,0,N/A
+1487502,"August 21, 2019",Delaware,Newark,"500 block of Salem Church Rd",0,0,N/A
+1486085,"August 21, 2019",Delaware,Milton,"Coastal Hwy and Broadkill Rd",0,0,N/A
+1485244,"August 21, 2019",Delaware,Seaford,"22681 Eskridge Rd",0,0,N/A
+1484027,"August 20, 2019",Delaware,Newark,"1119 S College Ave",0,0,N/A
+1489004,"August 20, 2019",Delaware,Wilmington,"300 block of N Connell St",0,0,N/A
+1497801,"August 19, 2019",Delaware,Wilmington,"900 block of N Church St",0,0,N/A
+1489001,"August 19, 2019",Delaware,Wilmington,"200 block of N Harrison St",0,0,N/A
+1484480,"August 19, 2019",Delaware,Hartly,"50 block of Hazlettville Rd",0,0,N/A
+1482116,"August 18, 2019",Delaware,Newark,"1119 S College Ave",1,1,N/A
+1483614,"August 18, 2019",Delaware,Dover,"300 block of Simon Cir",0,0,N/A
+1482702,"August 18, 2019",Delaware,"Wilmington (Newport)","3000 block of Valley Brook Dr",0,0,N/A
+1482700,"August 18, 2019",Delaware,Wilmington,"2200 block of N Locust St",0,1,N/A
+1482707,"August 17, 2019",Delaware,Dover,"S New St and Reed St",0,1,N/A
+1481856,"August 16, 2019",Delaware,Wilmington,"13th St and Thatcher St",0,1,N/A
+1480718,"August 16, 2019",Delaware,Wilmington,"1300 block of Banning St",0,1,N/A
+1480039,"August 15, 2019",Delaware,Wilmington,"E 23rd St and Pine St",0,1,N/A
+1487495,"August 15, 2019",Delaware,Wilmington,"2000 block of W 6th St",0,0,N/A
+1489021,"August 15, 2019",Delaware,Frankford,"Star Ln and Peppers Corner Rd",0,0,N/A
+1480716,"August 15, 2019",Delaware,Wilmington,"2200 block of Locust St",0,1,N/A
+1479495,"August 14, 2019",Delaware,Wilmington,"800 block of N Pine St",0,1,N/A
+1485242,"August 14, 2019",Delaware,Wilmington,"2100 block of Locust St",0,0,N/A
+1478615,"August 13, 2019",Delaware,Wilmington,"E 23rd St and Lamotte St",0,1,N/A
+1476576,"August 12, 2019",Delaware,Wilmington,"3000 block of N West St",0,1,N/A
+1475954,"August 11, 2019",Delaware,Dover,"50 block of S New St",0,1,N/A
+1475434,"August 10, 2019",Delaware,Wilmington,"600 block of Tatnall St",0,1,N/A
+1485251,"August 10, 2019",Delaware,Newark,"Bellevue Rd",0,0,N/A
+1477027,"August 9, 2019",Delaware,Smyrna,"Kent Way and Owens Brook Dr",0,0,N/A
+1473260,"August 8, 2019",Delaware,Wilmington,"W 30th St and Washington St",0,0,N/A
+1483605,"August 8, 2019",Delaware,Wilmington,"50 block of Race St",0,0,N/A
+1478627,"August 7, 2019",Delaware,Wilmington,"800 block of W 3rd St",0,0,N/A
+1482114,"August 7, 2019",Delaware,Wilmington,"200 block of W St",0,0,N/A
+1472173,"August 6, 2019",Delaware,Wilmington,"50 block of Lower Oak St",0,1,N/A
+1471237,"August 6, 2019",Delaware,Wilmington,"600 block of E 10th St",0,1,N/A
+1474332,"August 6, 2019",Delaware,Dover,"2000 block of Generals Way",0,0,N/A
+1470173,"August 5, 2019",Delaware,Wilmington,"200 block of N Harrison St",0,2,N/A
+1468604,"August 3, 2019",Delaware,Newark,"101 Geoffrey Dr",0,0,N/A
+1466809,"August 3, 2019",Delaware,Wilmington,"600 block of Taylor St",0,1,N/A
+1468599,"August 3, 2019",Delaware,Dover,"6 W Lebanon Rd",0,1,N/A
+1483603,"August 3, 2019",Delaware,Delmar,"37000 block of Marsha St",0,0,N/A
+1467469,"August 2, 2019",Delaware,Dover,"Rockford Crossing",0,0,N/A
+1465263,"August 1, 2019",Delaware,Wilmington,"200 block of N Rodney St",0,0,N/A
+1466814,"August 1, 2019",Delaware,Dover,"200 block of E Sheldrake Cir",0,0,N/A
+1462362,"July 29, 2019",Delaware,Milton,"Fisher Rd",0,0,N/A
+1464120,"July 28, 2019",Delaware,Wilmington,"700 block of W 5th St",0,1,N/A
+1505593,"July 28, 2019",Delaware,Harrington,"100 block of Dorman St",0,0,N/A
+1458314,"July 25, 2019",Delaware,Wilmington,"700 block of W 4th St",1,0,N/A
+1457193,"July 23, 2019",Delaware,Ellendale,"16979 Beach Hwy",0,0,N/A
+1455196,"July 23, 2019",Delaware,Wilmington,"1700 block of W 4th St",0,1,N/A
+1454814,"July 22, 2019",Delaware,Wilmington,"1800 block of W 2nd St",1,1,N/A
+1454810,"July 21, 2019",Delaware,Dover,"S New St",0,0,N/A
+1455204,"July 21, 2019",Delaware,Dover,"S New St and W Reed St",0,1,N/A
+1463692,"July 20, 2019",Delaware,Wilmington,"1600 block of N Market St",0,0,N/A
+1453080,"July 20, 2019",Delaware,Wilmington,"500 Delaware Ave",1,0,N/A
+1453033,"July 20, 2019",Delaware,Wilmington,"700 Foulk Rd",2,0,N/A
+1455201,"July 19, 2019",Delaware,Dover,"805 Forest Ave",0,0,N/A
+1451689,"July 18, 2019",Delaware,Dover,"Autumnwood Ct",0,0,N/A
+1450431,"July 17, 2019",Delaware,Wilmington,"4304 N Market St",0,2,N/A
+1450429,"July 16, 2019",Delaware,Dover,"S New St and W Reed St",0,0,N/A
+1463690,"July 15, 2019",Delaware,Wilmington,"1300 block of Beech St",0,0,N/A
+1449856,"July 15, 2019",Delaware,Newark,"50 block of Waltham St",0,0,N/A
+1461149,"July 15, 2019",Delaware,Wilmington,"3000 block of Lancaster Ave",0,0,N/A
+1449304,"July 15, 2019",Delaware,Smyrna,"White Rabbit Dr and Groundhog Ln",0,0,N/A
+1448904,"July 14, 2019",Delaware,Magnolia,"S Draper Cir",0,0,N/A
+1446818,"July 12, 2019",Delaware,Wilmington,"600 block of W 5th St",0,1,N/A
+1447255,"July 11, 2019",Delaware,Milford,"200 block of Charles St",0,0,N/A
+1444898,"July 10, 2019",Delaware,Lincoln,"15866 Winners Cir",1,0,N/A
+1444913,"July 9, 2019",Delaware,Seaford,"800 block of Clementine Ct",0,0,N/A
+1450794,"July 9, 2019",Delaware,Wilmington,"2500 block of Baynard Blvd",0,0,N/A
+1444119,"July 9, 2019",Delaware,Seaford,"N Paula Lynne Dr",0,0,N/A
+1449858,"July 6, 2019",Delaware,Wilmington,"W 5th St and N Bancroft Pkwy",0,0,N/A
+1442062,"July 6, 2019",Delaware,Dover,"6000 block of N DuPont Hwy",0,0,N/A
+1442415,"July 5, 2019",Delaware,Newark,"164 Aspen Dr",0,0,N/A
+1439630,"July 5, 2019",Delaware,Wilmington,"600 block of N West St",0,1,N/A
+1465267,"July 4, 2019",Delaware,Dover,"100 block of Katrina Way",0,1,N/A
+1439021,"July 4, 2019",Delaware,Magnolia,"50 block of Woodville Dr",0,1,N/A
+1444923,"July 3, 2019",Delaware,Wilmington,"700 block of 4th St",0,0,N/A
+1448906,"July 3, 2019",Delaware,Wilmington,"600 block of 5th St",0,0,N/A
+1443039,"July 1, 2019",Delaware,Wilmington,"600 block of W 5th St",0,0,N/A
+1435655,"June 29, 2019",Delaware,Wilmington,"50 block of Gordon St",0,1,N/A
+1435114,"June 28, 2019",Delaware,"Rehoboth Beach","35567 Big Oaks Ln",0,0,N/A
+1434109,"June 26, 2019",Delaware,Harrington,"7250 Milford Harrington Hwy",0,0,N/A
+1432974,"June 25, 2019",Delaware,Dover,"50 block of N Kirkwood St",0,0,N/A
+1431890,"June 25, 2019",Delaware,Dover,"50 block of Howe Dr",0,0,N/A
+1430747,"June 24, 2019",Delaware,"Camden Wyoming","700 block of Green Winged Trail",0,0,N/A
+1428721,"June 21, 2019",Delaware,Seaford,"500 Findley Way",0,0,N/A
+1428718,"June 21, 2019",Delaware,Felton,"50 block of Appalachian Dr",0,0,N/A
+1426618,"June 19, 2019",Delaware,Bridgeville,"Meadowlark Dr",0,0,N/A
+1434564,"June 18, 2019",Delaware,Wilmington,"1100 block of W 4th St",0,0,N/A
+1424974,"June 16, 2019",Delaware,Dover,"Barrister Pl",0,1,N/A
+1424001,"June 15, 2019",Delaware,Smyrna,"DE 1",0,0,N/A
+1431894,"June 15, 2019",Delaware,Wilmington,"1100 block of W 5th St",0,0,N/A
+1421796,"June 12, 2019",Delaware,Dover,"100 block of Willis Rd",0,0,N/A
+1418229,"June 7, 2019",Delaware,Smyrna,"N Albright Dr",0,0,N/A
+1416432,"June 6, 2019",Delaware,Dover,"300 block of Frear Dr",0,0,N/A
+1415354,"June 5, 2019",Delaware,Laurel,"36000 block of Waycross Rd",0,0,N/A
+1420102,"June 4, 2019",Delaware,Wilmington,"100 block of S Harrison St",0,0,N/A
+1421124,"June 4, 2019",Delaware,Wilmington,"1900 block of N Market St",0,0,N/A
+1412329,"June 2, 2019",Delaware,Dover,"865 N Dupont Hwy",0,1,N/A
+1418699,"June 2, 2019",Delaware,Wilmington,"2300 block of Baynard Blvd",0,0,N/A
+1412825,"June 2, 2019",Delaware,Wilmington,"1000 block of E 27th St",0,1,N/A
+1412341,"June 1, 2019",Delaware,Dover,"492 Walnut Shade Rd",0,0,N/A
+1412323,"June 1, 2019",Delaware,Wilmington,"1100 block of E 13th St",0,2,N/A
+1416425,"June 1, 2019",Delaware,Wilmington,"1200 block of N Walnut St",0,0,N/A
+1411569,"June 1, 2019",Delaware,Ellendale,"12327 DuPont Blvd",0,1,N/A
+1412326,"June 1, 2019",Delaware,Dover,"211 W Loockerman St",1,0,N/A
+1412827,"June 1, 2019",Delaware,Claymont,"Fourth Ave",0,1,N/A
+1411571,"May 31, 2019",Delaware,Wilmington,"24th St and Market St",0,1,N/A
+1412338,"May 31, 2019",Delaware,Seaford,"20000 block of Mellin Rd",0,0,N/A
+1421126,"May 30, 2019",Delaware,Wilmington,"1700 block of Lancaster Ave",0,0,N/A
+1412346,"May 29, 2019",Delaware,Bear,"Wicklow Rd",0,0,N/A
+1415349,"May 29, 2019",Delaware,Wilmington,"Cedar St and Wright St",0,0,N/A
+1418703,"May 29, 2019",Delaware,Wilmington,"900 block of E 17th St",0,0,N/A
+1405293,"May 26, 2019",Delaware,Dover,"Courtside Dr and Forrest Ave",0,0,N/A
+1405059,"May 24, 2019",Delaware,Wilmington,"600 block of Taylor St",0,1,N/A
+1508097,"May 24, 2019",Delaware,Wilmington,"300 block of Concord Ave",0,0,N/A
+1413713,"May 24, 2019",Delaware,Wilmington,"700 block of S Van Buren St",0,0,N/A
+1403568,"May 23, 2019",Delaware,Dover,"400 block of S Governors Ave",0,1,N/A
+1413711,"May 23, 2019",Delaware,Wilmington,"100 block of N Van Buren St",0,0,N/A
+1403949,"May 23, 2019",Delaware,Dover,"50 block of Stevenson Dr",0,2,N/A
+1403154,"May 22, 2019",Delaware,Newark,"2400 block of Millstone Dr",0,0,N/A
+1410136,"May 22, 2019",Delaware,Wilmington,"1100 block of W 4th St",0,0,N/A
+1405082,"May 21, 2019",Delaware,Lewes,"22971 Suburban Blvd",0,0,N/A
+1409286,"May 21, 2019",Delaware,Wilmington,"9th St and Tatnall St",0,0,N/A
+1400759,"May 20, 2019",Delaware,Wilmington,"400 block of Tatnall St",0,1,N/A
+1401642,"May 20, 2019",Delaware,Dover,"White Oak Rd and Stevenson Dr",0,0,N/A
+1399984,"May 19, 2019",Delaware,Dover,"Barrister Pl and S Little Creek Rd",0,1,N/A
+1399978,"May 19, 2019",Delaware,Magnolia,"500 block of Millchop Ln",0,1,N/A
+1399272,"May 19, 2019",Delaware,Wilmington,"800 block of E 13th St",0,1,N/A
+1399983,"May 18, 2019",Delaware,Dover,"400 block of Barrister Pl",0,0,N/A
+1399269,"May 18, 2019",Delaware,"New Castle","1213 West Ave",0,0,N/A
+1398808,"May 17, 2019",Delaware,Wilmington,"800 block of Towne Ct",0,1,N/A
+1409281,"May 17, 2019",Delaware,Wilmington,"16th St and Jessup St",0,0,N/A
+1397558,"May 16, 2019",Delaware,Wilmington,N/A,0,1,N/A
+1403564,"May 16, 2019",Delaware,Wilmington,"300 block of E 7th St",0,0,N/A
+1397003,"May 16, 2019",Delaware,Bear,"700 block of Pulaski Hwy",0,0,N/A
+1403562,"May 16, 2019",Delaware,Wilmington,"400 block of Delamore Pl",0,0,N/A
+1402623,"May 15, 2019",Delaware,Wilmington,"700 block of W 4th St",0,0,N/A
+1397560,"May 15, 2019",Delaware,Lincoln,"8000 block of Clendaniel Pond Rd",0,0,N/A
+1400761,"May 15, 2019",Delaware,Wilmington,"2800 block of N Tatnall St",0,0,N/A
+1395531,"May 14, 2019",Delaware,Cheswold,"DE 13 and DE 42",0,0,N/A
+1395529,"May 14, 2019",Delaware,Harrington,"S DuPont Hwy and Center St",0,0,N/A
+1410140,"May 13, 2019",Delaware,Wilmington,N/A,0,0,N/A
+1396704,"May 10, 2019",Delaware,Wilmington,"300 block of E 23rd St",0,0,N/A
+1391650,"May 9, 2019",Delaware,Wilmington,"6th St and N Madison St",0,1,N/A
+1390493,"May 8, 2019",Delaware,Wilmington,"100 block of N Rodney St",0,1,N/A
+1395662,"May 8, 2019",Delaware,Wilmington,"500 block of Washington St",0,0,N/A
+1390714,"May 8, 2019",Delaware,Newark,"50 block of Westerly St",0,1,N/A
+1389837,"May 7, 2019",Delaware,Seaford,"8700 block of Garden Ln",0,0,N/A
+1386575,"May 4, 2019",Delaware,Wilmington,"W 27th St and Tatnall St",0,4,N/A
+1386623,"May 4, 2019",Delaware,Dover,"865 N Dupont Hwy",0,1,N/A
+1386612,"May 3, 2019",Delaware,Wilmington,"4737 Concord Pike",0,0,N/A
+1388254,"May 3, 2019",Delaware,Dover,"400 block of Barrister Pl",0,0,N/A
+1386615,"May 3, 2019",Delaware,"New Castle (Wilmington Manor)","50 block of McMullen Ave",0,1,N/A
+1384862,"May 1, 2019",Delaware,Dover,"50 block of S New St",0,0,N/A
+1384855,"May 1, 2019",Delaware,Wilmington,"2400 block of Pine St",1,2,N/A
+1384860,"April 30, 2019",Delaware,Seaford,"9817 Spotless St",0,0,N/A
+1384859,"April 30, 2019",Delaware,Newark,"Brookmont Dr and Flamingo Dr",0,0,N/A
+1388251,"April 29, 2019",Delaware,Wilmington,"1300 block of Pennsylvania Ave",0,0,N/A
+1385631,"April 26, 2019",Delaware,Wilmington,"500 block of Willing St",0,0,N/A
+1379825,"April 25, 2019",Delaware,Greenwood,"2400 block of Hickman Rd",0,0,N/A
+1379817,"April 24, 2019",Delaware,Georgetown,"21306 Legal Dr",0,1,N/A
+1392996,"April 24, 2019",Delaware,Wilmington,"E 22nd St and N Spruce St",0,0,N/A
+1384162,"April 23, 2019",Delaware,Wilmington,"1900 block of Maryland Ave",0,0,N/A
+1390720,"April 23, 2019",Delaware,Wilmington,"5th Ave and Duncan St",0,0,N/A
+1489727,"April 22, 2019",Delaware,Wilmington,"W 29th St",0,0,N/A
+1376899,"April 20, 2019",Delaware,Hockessin,"50 block of Robin Dr",0,0,N/A
+1421789,"April 19, 2019",Delaware,Bridgeville,"Craft Rd",0,0,N/A
+1375703,"April 18, 2019",Delaware,Smyrna,"600 block of Dairy Dr",0,0,N/A
+1379833,"April 17, 2019",Delaware,Wilmington,"400 block of W 7th St",0,0,N/A
+1379830,"April 16, 2019",Delaware,Wilmington,"500 block of W 26th St",0,0,N/A
+1370172,"April 12, 2019",Delaware,"New Castle","3125 New Castle Ave",0,2,N/A
+1377626,"April 9, 2019",Delaware,Wilmington,"900 block of Vandever Ave",0,0,N/A
+1365173,"April 7, 2019",Delaware,Wilmington,"940 N Pine St",0,6,N/A
+1362672,"April 3, 2019",Delaware,Wilmington,"1400 block of W 3rd St",1,0,N/A
+1361184,"April 1, 2019",Delaware,Georgetown,"100 Charles Way",0,0,N/A
+1362681,"March 31, 2019",Delaware,"Delaware City","Canal St",0,0,N/A
+1359179,"March 30, 2019",Delaware,Dover,"50 block of Weston Dr",1,0,N/A
+1361178,"March 30, 2019",Delaware,Wilmington,"1800 block of Pennsylvania Ave",0,0,N/A
+1360145,"March 30, 2019",Delaware,"Rehoboth Beach","Rehoboth Ave and Columbia Ave",0,0,N/A
+1357624,"March 27, 2019",Delaware,Dagsboro,"Irons Ln and Old Mill Rd",0,1,N/A
+1358510,"March 27, 2019",Delaware,Claymont,"3000 block of 4th Ave",0,0,N/A
+1356535,"March 27, 2019",Delaware,Seaford,"1 Chandler St",0,0,N/A
+1357187,"March 27, 2019",Delaware,Dover,"480 Country Dr",0,1,N/A
+1357175,"March 26, 2019",Delaware,Hartly,"3000 block of Halltown Rd",0,0,N/A
+1374648,"March 26, 2019",Delaware,Wilmington,"2400 block of Tatnall St",0,1,N/A
+1356411,"March 20, 2019",Delaware,Wilmington,"500 block of Madison St",0,0,N/A
+1348605,"March 16, 2019",Delaware,Wilmington,"2200 block of Baynard Blvd",0,1,N/A
+1377730,"March 15, 2019",Delaware,Wilmington,"2900 block of Tatnall St",0,0,N/A
+1348070,"March 14, 2019",Delaware,Millsboro,"29000 block of Colonial Estates Ave",0,0,N/A
+1346534,"March 13, 2019",Delaware,Wilmington,"104 Richards Dr",1,0,N/A
+1349089,"March 13, 2019",Delaware,Wilmington,"400 block of W 7th St",0,0,N/A
+1346203,"March 12, 2019",Delaware,Wilmington,"300 block of S Union St",0,0,N/A
+1357184,"March 12, 2019",Delaware,Wilmington,"1100 block of E 14th St",0,0,N/A
+1345425,"March 11, 2019",Delaware,Townsend,"200 block of Saw Mill Rd",0,0,N/A
+1343790,"March 11, 2019",Delaware,Wilmington,"50 block of W 26th St",2,0,N/A
+1343798,"March 10, 2019",Delaware,Bridgeville,"11000 block of 5th St",0,0,N/A
+1346529,"March 9, 2019",Delaware,Laurel,"S Shell Bridge Rd and Holly Branch Dr",1,0,N/A
+1345451,"March 9, 2019",Delaware,Newark,"W Main St and Hillside Rd",0,0,N/A
+1346531,"March 9, 2019",Delaware,Wilmington,"400 block of W 8th St",0,0,N/A
+1342073,"March 7, 2019",Delaware,Wilmington,"800 block of N Grant Ave",0,1,N/A
+1342945,"March 7, 2019",Delaware,Marydel,"300 block of Grygo Rd",0,0,N/A
+1342075,"March 7, 2019",Delaware,Wilmington,"3500 block of Washington St",1,1,N/A
+1341741,"March 6, 2019",Delaware,Wilmington,"700 block of Tatnall St",1,1,N/A
+1341145,"March 6, 2019",Delaware,Dover,"400 block of Barrister Pl",0,0,N/A
+1341142,"March 6, 2019",Delaware,Dover,"Primrose Dr",0,0,N/A
+1341500,"March 6, 2019",Delaware,Newark,"50 block of Raven Turn",1,0,N/A
+1340792,"March 4, 2019",Delaware,Dover,"50 Block of Village Dr",0,0,N/A
+1339265,"March 2, 2019",Delaware,Smyrna,"699 S Carter Rd",0,0,N/A
+1361952,"March 1, 2019",Delaware,Milton,"28000 block of Carpenter Rd",0,0,N/A
+1337624,"March 1, 2019",Delaware,"Wilmington (Stanton)","106 Main St",0,0,N/A
+1335932,"February 26, 2019",Delaware,Wilmington,"Northeast Blvd and Thatcher St",0,1,N/A
+1335153,"February 25, 2019",Delaware,Wilmington,"600 block of N Jefferson St",0,1,N/A
+1335941,"February 23, 2019",Delaware,Seaford,"20300 block of Wesley Church Rd",0,0,N/A
+1333456,"February 22, 2019",Delaware,Frederica,"200 block of Market St",0,0,N/A
+1335161,"February 22, 2019",Delaware,Dover,"55 Loockerman Plaza",0,0,N/A
+1342439,"February 21, 2019",Delaware,"New Castle",N/A,0,0,N/A
+1332304,"February 21, 2019",Delaware,Bear,"13 S Cedar Creek Ct",0,1,N/A
+1331707,"February 21, 2019",Delaware,Seaford,"300 block of N Pine St",0,0,N/A
+1332484,"February 21, 2019",Delaware,Smyrna,"1069 McQuail Rd",0,0,N/A
+1330901,"February 18, 2019",Delaware,Dover,"400 block of New Castle Ave",0,0,N/A
+1329491,"February 17, 2019",Delaware,Dagsboro,"29000 block of Colony Dr",0,0,N/A
+1329512,"February 16, 2019",Delaware,Felton,"11 S Lombard St",0,0,N/A
+1329067,"February 16, 2019",Delaware,Lewes,"32000 block of Spruce Ct",0,0,N/A
+1329054,"February 16, 2019",Delaware,"Ocean View","50 block of Dorothy Cir",0,0,N/A
+1327969,"February 14, 2019",Delaware,Harrington,"8700 block of Park Brown Rd",1,0,N/A
+1330898,"February 14, 2019",Delaware,Wilmington,"2nd St and Van Buren St",0,0,N/A
+1330896,"February 14, 2019",Delaware,Wilmington,"1100 block of Kirkwood St",0,0,N/A
+1325867,"February 13, 2019",Delaware,Dover,"200 block of S Governors Blvd",0,0,N/A
+1325747,"February 12, 2019",Delaware,"Rehoboth Beach","36179 Palace Ln",0,0,N/A
+1325746,"February 12, 2019",Delaware,Seaford,"9000 block of Concord Rd",0,0,N/A
+1323286,"February 8, 2019",Delaware,Wilmington,"400 block of Heald St",0,1,N/A
+1323293,"February 7, 2019",Delaware,Bear,"50 block of Wildfields Ct",0,0,N/A
+1321271,"February 7, 2019",Delaware,Dover,"383 N DuPont Hwy",0,0,N/A
+1322847,"February 6, 2019",Delaware,Wilmington,"50 block of Jensen Dr",0,1,N/A
+1321261,"February 5, 2019",Delaware,Newark,N/A,0,1,N/A
+1327975,"February 4, 2019",Delaware,Wilmington,"1400 block of N Walnut St",0,0,N/A
+1318846,"February 3, 2019",Delaware,Wilmington,"DE 4 and Champlain Ave",0,1,N/A
+1318850,"February 2, 2019",Delaware,Dover,"President Dr",0,0,N/A
+1318843,"February 2, 2019",Delaware,Dover,"51 Webbs Ln",0,1,N/A
+1318096,"February 2, 2019",Delaware,Wilmington,"W 27th St and Moore St",0,1,N/A
+1320335,"February 2, 2019",Delaware,Wilmington,"2500 block of Bowers St",0,0,N/A
+1318090,"February 1, 2019",Delaware,"New Castle","Christiana Rd and Catherine St",0,0,N/A
+1317235,"January 31, 2019",Delaware,Wilmington,"1100 block of Pleasant St",1,0,N/A
+1322859,"January 31, 2019",Delaware,Wilmington,"W 7th St and N Monroe St",0,0,N/A
+1316954,"January 30, 2019",Delaware,Dover,"3600 block of S Little Creek Rd",0,0,N/A
+1314957,"January 28, 2019",Delaware,Seaford,"400 block of N Pine St",0,0,N/A
+1314954,"January 28, 2019",Delaware,Wilmington,"700 block of N Madison St",0,1,N/A
+1313326,"January 26, 2019",Delaware,Wilmington,"3700 block of N Van Buren St",0,3,N/A
+1312701,"January 25, 2019",Delaware,Wilmington,"W 39th St and Shipley St",0,1,N/A
+1312670,"January 25, 2019",Delaware,Bridgeville,"11000 block of Fisher Cir",0,0,N/A
+1312667,"January 25, 2019",Delaware,Dagsboro,"30000 block of Squirrel Ln",0,0,N/A
+1310822,"January 24, 2019",Delaware,Wilmington,"2702 Jacqueline Dr",1,0,N/A
+1308473,"January 22, 2019",Delaware,Wilmington,"2300 block of Pine St",1,0,N/A
+1306900,"January 20, 2019",Delaware,Seaford,"Coverdale Rd and Hastings Farm Rd",0,0,N/A
+1306901,"January 19, 2019",Delaware,Bridgeville,"50 block of Mill Park Dr",0,0,N/A
+1305534,"January 18, 2019",Delaware,Bear,"1551 Pulaski Highway",0,1,N/A
+1441352,"January 17, 2019",Delaware,Millville,"Railway Rd",0,0,N/A
+1304290,"January 17, 2019",Delaware,Wilmington,"400 block of E 11th St",0,1,N/A
+1303213,"January 16, 2019",Delaware,Wilmington,"600 block of E 5th St",0,2,N/A
+1302086,"January 15, 2019",Delaware,Wilmington,"1200 block of Conrad St",1,0,N/A
+1300930,"January 13, 2019",Delaware,Dover,"300 block of Frear Dr",0,0,N/A
+1299266,"January 10, 2019",Delaware,Dover,"35 E Loockerman St",0,0,N/A
+1295337,"January 7, 2019",Delaware,Wilmington,"700 block of N Dupont St",0,1,N/A
+1294448,"January 6, 2019",Delaware,Frederica,"50 block of 3rd St",0,0,N/A
+1293776,"January 5, 2019",Delaware,Dover,"200 block of Kentwood Dr",1,0,N/A
+1300926,"January 3, 2019",Delaware,"Kent (county)",N/A,0,0,N/A
+1291069,"January 2, 2019",Delaware,Newark,"1120 S College Ave",0,0,N/A
+1290568,"January 2, 2019",Delaware,Felton,"100 block of Gelden Rd",0,0,N/A
+1289624,"January 1, 2019",Delaware,Wilmington,"1101 E 8th St",0,1,N/A
+1288595,"December 30, 2018",Delaware,Wilmington,"500 block of W 11th St",0,0,N/A
+1288592,"December 29, 2018",Delaware,Newark,"91 Thorn Ln",0,1,N/A
+1288591,"December 29, 2018",Delaware,Seaford,"26000 block of Bethel Concord Rd",0,0,N/A
+1287842,"December 28, 2018",Delaware,Wilmington,"600 block of W 7th St",0,2,N/A
+1284677,"December 25, 2018",Delaware,Lincoln,"19000 block of Pine St",0,2,N/A
+1284435,"December 24, 2018",Delaware,"Rehoboth Beach","Munchy Branch Rd and Coastal Hwy",0,0,N/A
+1283593,"December 23, 2018",Delaware,Wilmington,"800 block of E 13th St",0,1,N/A
+1283595,"December 23, 2018",Delaware,Milford,"300 Aurora Pl",0,1,N/A
+1283591,"December 23, 2018",Delaware,Wilmington,"2300 block of West St",0,1,N/A
+1283281,"December 23, 2018",Delaware,Wilmington,"100 block of N Harrison St",0,1,N/A
+1281662,"December 20, 2018",Delaware,Millsboro,"28000 block of Mount Joy Rd",0,0,N/A
+1280929,"December 19, 2018",Delaware,Dover,"3000 block of William St",0,0,N/A
+1280214,"December 18, 2018",Delaware,Wilmington,"50 Hillside Rd",0,0,N/A
+1279321,"December 17, 2018",Delaware,Newark,"41 Winterhaven Dr",0,1,N/A
+1280215,"December 17, 2018",Delaware,Dagsboro,"30000 block of Iron Branch Rd",0,0,N/A
+1277491,"December 12, 2018",Delaware,Dover,"700 block of Bacon Ave",0,0,N/A
+1275707,"December 11, 2018",Delaware,Millsboro,N/A,0,0,N/A
+1272664,"December 7, 2018",Delaware,Seaford,"23450 Sussex Hwy",0,0,N/A
+1271216,"December 6, 2018",Delaware,Seaford,"300 block of 3rd St",0,0,N/A
+1272661,"December 5, 2018",Delaware,Harrington,"101 W Center St",0,0,N/A
+1269676,"December 5, 2018",Delaware,Dover,"4400 block of Vermont Dr",0,0,N/A
+1269009,"November 29, 2018",Delaware,Milford,"S DuPont Blvd and Lakeview Ave",0,0,N/A
+1265656,"November 28, 2018",Delaware,Dover,"89 Kings Hwy",0,0,N/A
+1266486,"November 28, 2018",Delaware,Dagsboro,"32000 block of Swamp Rd",0,0,N/A
+1266484,"November 28, 2018",Delaware,Dover,"200 block of N Kirkwood St",0,0,N/A
+1264968,"November 27, 2018",Delaware,Wilmington,"900 block of N Pine St",0,1,N/A
+1263645,"November 25, 2018",Delaware,"Wilmington (Edgemoor)","E Salisbury Dr and Bedford Dr",0,1,N/A
+1263976,"November 23, 2018",Delaware,Wilmington,"Centerville Rd and Boxwood Rd",0,0,N/A
+1264970,"November 23, 2018",Delaware,Harrington,"S Rehoboth Blvd",0,0,N/A
+1262246,"November 22, 2018",Delaware,Milton,"18647 Rd 281",0,0,N/A
+1259982,"November 20, 2018",Delaware,Smyrna,"South St and East St",0,1,N/A
+1259979,"November 20, 2018",Delaware,Wilmington,"2300 block of Jessup St",0,2,N/A
+1259978,"November 18, 2018",Delaware,Seaford,"Park Dr",0,0,N/A
+1259157,"November 18, 2018",Delaware,Dover,"400 block of E Water St",0,0,N/A
+1257781,"November 17, 2018",Delaware,Dover,"100 block of Willis Rd",0,0,N/A
+1258294,"November 16, 2018",Delaware,"Wilmington (Newport)","500 block of Essex Ave",0,0,N/A
+1256468,"November 16, 2018",Delaware,"Camden Wyoming (Camden)","155 S West St",2,0,N/A
+1256588,"November 15, 2018",Delaware,Middletown,"US 13 and DE 1",0,0,N/A
+1256586,"November 14, 2018",Delaware,Townsend,"100 block of Esch St",0,0,N/A
+1253826,"November 12, 2018",Delaware,Wilmington,"W 5th St and N Franklin St",0,0,N/A
+1253151,"November 11, 2018",Delaware,Dover,"400 block of Barrister Pl",0,1,N/A
+1252420,"November 10, 2018",Delaware,Wilmington,"N Lake St and Matthes Ave",0,1,N/A
+1251108,"November 8, 2018",Delaware,Claymont,"50 block of New York Ave",1,0,N/A
+1251111,"November 8, 2018",Delaware,Dover,"200 block of W Reed St",0,0,N/A
+1249490,"November 6, 2018",Delaware,"New Castle","4000 N DuPont Hwy",0,0,N/A
+1248794,"November 5, 2018",Delaware,Smyrna,"400 block of Baldwin Dr",0,2,N/A
+1248371,"November 5, 2018",Delaware,Harrington,N/A,0,0,N/A
+1248309,"November 5, 2018",Delaware,Wilmington,"300 block of W 7th St",0,1,N/A
+1245221,"November 1, 2018",Delaware,Wilmington,"200 block of S Franklin St",1,1,N/A
+1243937,"October 29, 2018",Delaware,Wilmington,"2300 block of N Washington St",0,1,N/A
+1244207,"October 29, 2018",Delaware,Seaford,"24000 block of German Rd",0,1,N/A
+1243210,"October 29, 2018",Delaware,Dover,"W Division St and S New St",0,0,N/A
+1242657,"October 28, 2018",Delaware,Wilmington,"1701 Delaware Ave",0,0,N/A
+1247119,"October 28, 2018",Delaware,Newark,"900 block of Harmony Rd",0,0,N/A
+1242411,"October 26, 2018",Delaware,Wilmington,"600 block of W 6th St",1,0,N/A
+1240694,"October 25, 2018",Delaware,Wilmington,"900 block of Spruce St",1,0,N/A
+1240697,"October 23, 2018",Delaware,Dover,"400 block of E Water St",0,0,N/A
+1240695,"October 23, 2018",Delaware,"New Castle","111 S DuPont Hwy",0,0,N/A
+1238899,"October 22, 2018",Delaware,Wilmington,"100 block of 24th St",0,1,N/A
+1237767,"October 19, 2018",Delaware,Wilmington,"900 block of Linden St",0,1,N/A
+1237761,"October 18, 2018",Delaware,Wilmington,"400 block of E 2nd St",0,0,N/A
+1236174,"October 18, 2018",Delaware,Dover,"200 block of N Governor Blvd",0,0,N/A
+1238355,"October 18, 2018",Delaware,Wilmington,"300 N Walnut St",0,0,N/A
+1236007,"October 18, 2018",Delaware,Wilmington,"400 block of N Clayton St",0,1,N/A
+1234605,"October 17, 2018",Delaware,Wilmington,"2300 block of N Market St",1,0,N/A
+1234602,"October 16, 2018",Delaware,Seaford,"24000 block of Concord Pond Rd",0,0,N/A
+1234609,"October 16, 2018",Delaware,Newark,"800 block of Coventry Ln",0,1,N/A
+1233849,"October 15, 2018",Delaware,Dover,"Bay Tree Rd",0,0,N/A
+1232850,"October 14, 2018",Delaware,Dover,"428 N DuPont Hwy",0,1,N/A
+1231484,"October 11, 2018",Delaware,Lewes,"19000 block of Ward Rd",0,0,N/A
+1230241,"October 11, 2018",Delaware,Wilmington,"600 block of W 8th St",0,1,N/A
+1230943,"October 11, 2018",Delaware,Dover,"800 S Governors Ave",0,0,N/A
+1230519,"October 11, 2018",Delaware,Wilmington,"1300 block of Lancaster Ave",0,1,N/A
+1521012,"October 10, 2018",Delaware,Dover,"1492 N Little Creek Rd",0,0,N/A
+1228207,"October 8, 2018",Delaware,Milford,"Lassen Ct",0,0,N/A
+1230957,"October 8, 2018",Delaware,Smyrna,"DE 9 and Lighthouse Rd",0,0,N/A
+1226956,"October 6, 2018",Delaware,Clayton,"Lion Hope Rd",0,0,N/A
+1227745,"October 6, 2018",Delaware,Milton,"27000 block of Martins Farm Rd",0,0,N/A
+1225947,"October 5, 2018",Delaware,Wilmington,"1000 Bennett St",0,0,N/A
+1225406,"October 4, 2018",Delaware,"New Castle","235 Christiana Rd",0,0,N/A
+1224518,"October 3, 2018",Delaware,Wilmington,"700 block of W 5th St",0,1,N/A
+1224520,"October 3, 2018",Delaware,Wilmington,"Taylor St and N Spruce St",0,1,N/A
+1223118,"October 2, 2018",Delaware,Dover,"50 Webbs Ln",0,1,N/A
+1223612,"October 2, 2018",Delaware,Wilmington,"200 block of N Clayton St",1,0,N/A
+1223609,"October 2, 2018",Delaware,"Camden Wyoming","Pony Track Rd",0,1,N/A
+1222046,"September 30, 2018",Delaware,Seaford,"26000 block of Kelly Cir",0,0,N/A
+1222058,"September 30, 2018",Delaware,Dover,"298 S DuPont Hwy",0,0,N/A
+1221606,"September 29, 2018",Delaware,Harrington,"200 block of Delaware Ave",0,1,N/A
+1222068,"September 28, 2018",Delaware,Dover,"915 S DuPont Hwy",0,0,N/A
+1219355,"September 26, 2018",Delaware,Magnolia,"900 block of Peachtree Run",0,0,N/A
+1219353,"September 26, 2018",Delaware,Laurel,"Portsville Rd and Dogwood Ln",1,0,N/A
+1218200,"September 24, 2018",Delaware,Harrington,"5000 block of Milford Harrington Hwy",0,0,N/A
+1215729,"September 20, 2018",Delaware,Dover,"100 block of S Governors Blvd",0,1,N/A
+1215726,"September 20, 2018",Delaware,Harrington,"200 block of Hanley St",0,0,N/A
+1215713,"September 20, 2018",Delaware,Magnolia,N/A,0,1,N/A
+1230239,"September 20, 2018",Delaware,Seaford,"22588 Bridgeville Hwy",0,0,N/A
+1213945,"September 20, 2018",Delaware,Wilmington,"400 block of N Adams St",0,1,N/A
+1214556,"September 19, 2018",Delaware,Dover,"SR 1",0,0,N/A
+1213343,"September 18, 2018",Delaware,Milford,"7000 block of Elgin Dr",0,0,N/A
+1212695,"September 17, 2018",Delaware,Dover,"428 DuPont Hwy",0,0,N/A
+1212056,"September 15, 2018",Delaware,Marydel,"300 block of Grygo Rd",0,0,N/A
+1211673,"September 15, 2018",Delaware,Dover,"51 Webbs Ln",0,0,N/A
+1210251,"September 13, 2018",Delaware,Milford,"900 Block of N Walnut St",0,0,N/A
+1207610,"September 10, 2018",Delaware,Harrington,"966 Jackson Ditch Rd",0,0,N/A
+1206327,"September 8, 2018",Delaware,Bridgeville,"Mill Park Dr and Coverdale Rd",0,0,N/A
+1206304,"September 8, 2018",Delaware,Dover,"50 block of Nicholas Dr",0,2,N/A
+1207614,"September 8, 2018",Delaware,Seaford,"400 Block of Phillips St",0,0,N/A
+1205637,"September 7, 2018",Delaware,Bear,"1800 block of Pulaski Hwy",0,0,N/A
+1206325,"September 6, 2018",Delaware,Wilmington,"500 block of Vandever Ave",1,0,N/A
+1205273,"September 5, 2018",Delaware,Middletown,"100 block of Rosie Dr",0,0,N/A
+1203975,"September 4, 2018",Delaware,Wilmington,"50 block of 6th Ave",0,1,N/A
+1202370,"September 3, 2018",Delaware,Hartly,"2000 block of Slaughter Station Rd",0,0,N/A
+1202373,"August 31, 2018",Delaware,Harbeson,"18000 block of Indian Mission Rd",0,0,N/A
+1200322,"August 31, 2018",Delaware,Wilmington,"1100 block of Conrad St",1,0,N/A
+1200739,"August 30, 2018",Delaware,"Wilmington (Edgemoor)","Rysing Dr and Polk Rd",0,1,N/A
+1201590,"August 30, 2018",Delaware,Middletown,"2111 Dupont Hwy",0,0,N/A
+1200324,"August 29, 2018",Delaware,Bridgeville,"Evans Dr and Iris Field Ln",0,0,N/A
+1200326,"August 29, 2018",Delaware,Claymont,"50 block of Balfour Ave",0,0,N/A
+1199586,"August 29, 2018",Delaware,Greenwood,"100 block of Unity Ln",0,1,N/A
+1197884,"August 28, 2018",Delaware,Harbeson,"22000 block of Harbeson Rd",1,0,N/A
+1198785,"August 28, 2018",Delaware,Dover,"629 Buckson Dr",1,0,N/A
+1199124,"August 27, 2018",Delaware,"New Castle","2034 New Castle Ave",0,0,N/A
+1195978,"August 26, 2018",Delaware,Selbyville,"W McCabe St and Rodgers Ave",0,0,N/A
+1196878,"August 24, 2018",Delaware,Dover,"S State St and Webbs Ln",0,0,N/A
+1198787,"August 23, 2018",Delaware,"New Castle","4000 N DuPont Hwy",0,0,N/A
+1194226,"August 22, 2018",Delaware,Smyrna,"400 block of S Carter Rd",0,0,N/A
+1193906,"August 22, 2018",Delaware,Wilmington,"Philadelphia Pike",0,0,N/A
+1193471,"August 21, 2018",Delaware,Dover,"Reed St and New St",0,1,N/A
+1192586,"August 21, 2018",Delaware,Wilmington,"2400 block of Lamotte St",0,1,N/A
+1192048,"August 21, 2018",Delaware,Wilmington,"3800 block of N Madison St",0,1,N/A
+1192050,"August 20, 2018",Delaware,Wilmington,"2000 block of N Jefferson St",0,1,N/A
+1190363,"August 17, 2018",Delaware,"New Castle","1 block of Revelle St",0,0,N/A
+1190366,"August 17, 2018",Delaware,Dover,"1300 block of Rose Valley School Rd",0,1,N/A
+1188911,"August 16, 2018",Delaware,"New Castle","Second Ave and Valley Rd",0,0,N/A
+1188913,"August 15, 2018",Delaware,Dover,"63 Stoney Dr",0,0,N/A
+1186511,"August 13, 2018",Delaware,Wilmington,"200 block of N Lincoln St",0,1,N/A
+1182945,"August 8, 2018",Delaware,Dover,"900 block of Simon Cir",0,0,N/A
+1181911,"August 7, 2018",Delaware,Newark,"6 N Skyward Dr",2,0,N/A
+1180585,"August 5, 2018",Delaware,Dagsboro,"30000 block of Power Plant Rd",0,0,N/A
+1182098,"August 5, 2018",Delaware,"New Castle","1200 West Ave",0,0,N/A
+1267758,"August 4, 2018",Delaware,Smyrna,"300 block of Southern View Dr",0,0,N/A
+1181365,"August 4, 2018",Delaware,Bear,"1607 Pulaski Hwy",0,0,N/A
+1178703,"August 3, 2018",Delaware,Wilmington,"1300 block of E 27th St",1,0,N/A
+1178288,"August 2, 2018",Delaware,"Rehoboth Beach","37000 of Johnson St",0,0,N/A
+1175413,"July 30, 2018",Delaware,"New Castle","I-95 and Airport Rd",0,1,N/A
+1173955,"July 27, 2018",Delaware,Georgetown,"20000 block of Donovans Rd",0,0,N/A
+1172781,"July 25, 2018",Delaware,"New Castle","West Ave and New Castle Ave",0,0,N/A
+1171648,"July 24, 2018",Delaware,Dover,"Cherry St and Lincoln St",0,0,N/A
+1183789,"July 21, 2018",Delaware,Georgetown,"Old Furnace Rd",0,0,N/A
+1169708,"July 20, 2018",Delaware,Milton,"Coastal Hwy",0,0,N/A
+1168798,"July 20, 2018",Delaware,Wilmington,"W 5th St and Delamore Pl",0,1,N/A
+1169710,"July 20, 2018",Delaware,Dover,"S Old Mill Rd",0,0,N/A
+1166074,"July 18, 2018",Delaware,Wilmington,"800 block of W 5th St",1,0,N/A
+1167737,"July 18, 2018",Delaware,"New Castle",N/A,0,0,N/A
+1164455,"July 15, 2018",Delaware,Seaford,"Chandler St",0,0,N/A
+1163386,"July 13, 2018",Delaware,"New Castle","1200 West Ave",0,1,N/A
+1161827,"July 12, 2018",Delaware,Wilmington,"500 block of E 10th St",0,2,N/A
+1161825,"July 12, 2018",Delaware,Wilmington,"2100 block of Lamotte St",0,1,N/A
+1160253,"July 9, 2018",Delaware,Wilmington,"2709 Ferris Rd",5,0,N/A
+1162491,"July 9, 2018",Delaware,Laurel,"801 Daniel St",1,0,N/A
+1159638,"July 8, 2018",Delaware,Wilmington,"2600 block of Jessup St",1,0,N/A
+1163388,"July 6, 2018",Delaware,Newark,"1 block of Hanna Dr",0,0,N/A
+1159640,"July 6, 2018",Delaware,Georgetown,"S DuPont Blvd and Old Laurel Rd",0,0,N/A
+1157039,"July 5, 2018",Delaware,Wilmington,"200 block of S Harrison St",0,1,N/A
+1158928,"July 5, 2018",Delaware,Smyrna,"US 13 and Hickory Ridge Rd",0,0,N/A
+1156502,"July 5, 2018",Delaware,Dover,"S Governors Ave and Reed St",0,1,N/A
+1156504,"July 4, 2018",Delaware,Frankford,"Jones Church Rd",0,0,N/A
+1155007,"July 2, 2018",Delaware,Wilmington,"400 block of W 6th St",0,1,N/A
+1154076,"July 1, 2018",Delaware,Middletown,"38 E Main St",0,0,N/A
+1154068,"June 30, 2018",Delaware,Wilmington,"I-495 and E 12th St",0,0,N/A
+1149154,"June 25, 2018",Delaware,"Wilmington (Edgemoor)","50 block of Polk Rd",0,0,N/A
+1152434,"June 25, 2018",Delaware,Lewes,"30000 block of Pine Town Rd",0,0,N/A
+1149981,"June 25, 2018",Delaware,Millsboro,"34000 block of Tugboat Ct",0,0,N/A
+1149152,"June 24, 2018",Delaware,Wilmington,"700 block of Broom St",1,0,N/A
+1148383,"June 23, 2018",Delaware,Wilmington,"5th St and Monroe St",0,1,N/A
+1148381,"June 23, 2018",Delaware,Wilmington,"200 block of W 26th St",0,1,N/A
+1147913,"June 22, 2018",Delaware,Dover,"1289 Walker Rd",1,0,N/A
+1146730,"June 20, 2018",Delaware,Dover,"100 block of President Dr",0,1,N/A
+1142893,"June 17, 2018",Delaware,Wilmington,"50 block of Lloyd St",2,1,N/A
+1140641,"June 13, 2018",Delaware,"New Castle","50 block of Rambo Terrace",0,2,N/A
+1140345,"June 12, 2018",Delaware,Dover,"Periwinkle Dr and Caroline Pl",0,0,N/A
+1139382,"June 12, 2018",Delaware,"New Castle","117 Wilton Blvd",0,0,N/A
+1140341,"June 11, 2018",Delaware,Wilmington,"1100 block of Flint Hill Rd",1,0,N/A
+1139385,"June 11, 2018",Delaware,Greenwood,"10900 block of Webb Farm Rd",0,0,N/A
+1187476,"June 10, 2018",Delaware,Clayton,"Sudlersville Rd",0,0,N/A
+1140353,"June 10, 2018",Delaware,Wilmington,"200 block of W 29th St",0,1,N/A
+1135733,"June 7, 2018",Delaware,Dover,"50 block of Village Dr",0,1,N/A
+1135731,"June 7, 2018",Delaware,Wilmington,"Northeast Blvd and E 28th St",0,1,N/A
+1135056,"June 6, 2018",Delaware,Dover,"50 block of Stevenson Dr",0,1,N/A
+1130411,"May 31, 2018",Delaware,Wilmington,"E 23rd St and Lamotte St",1,0,N/A
+1129746,"May 30, 2018",Delaware,Wilmington,"1400 block of Lancaster Ave",0,2,N/A
+1130601,"May 30, 2018",Delaware,"New Castle","200 block of Christiana Rd",0,0,N/A
+1128763,"May 30, 2018",Delaware,Newark,"400 block of Wollaston Ave",0,0,N/A
+1128747,"May 29, 2018",Delaware,Wilmington,"35th St and Church St",0,1,N/A
+1128779,"May 29, 2018",Delaware,Dover,"S Bradford St and Loockerman St",0,0,N/A
+1540191,"May 29, 2018",Delaware,Hartly,"4000 block of Arthursville Rd",2,0,N/A
+1127918,"May 27, 2018",Delaware,Dover,"300 block of W Division St",0,0,N/A
+1126056,"May 26, 2018",Delaware,Wilmington,"2300 block of Lamotte St",0,1,N/A
+1128771,"May 25, 2018",Delaware,Laurel,"N Poplar St and Maryland Ave",0,0,N/A
+1125085,"May 24, 2018",Delaware,Wilmington,"500 block of Madison St",1,0,N/A
+1124143,"May 24, 2018",Delaware,Wilmington,"Kiamensi Rd and Rothwell Dr",2,0,N/A
+1124146,"May 23, 2018",Delaware,Dover,"900 block of Whatcoat Dr",0,0,N/A
+1124137,"May 23, 2018",Delaware,Wilmington,"2800 block of N Claymont St",1,0,N/A
+1123422,"May 22, 2018",Delaware,Dover,"Vera Way and College Rd",0,0,N/A
+1121277,"May 19, 2018",Delaware,Wilmington,"2600 block of Moore St",0,1,N/A
+1121852,"May 19, 2018",Delaware,Seaford,"122 Seaford Meadows Dr",0,0,N/A
+1120647,"May 18, 2018",Delaware,Middletown,"120 Silver Lake Rd",0,0,N/A
+1117748,"May 16, 2018",Delaware,Dover,"100 block of Chatham Ct",0,0,N/A
+1118764,"May 16, 2018",Delaware,Dover,"50 block of S Governors Ave",0,0,N/A
+1117742,"May 15, 2018",Delaware,Wilmington,"300 block of Shipley Rd",0,0,N/A
+1114915,"May 13, 2018",Delaware,Dover,"50 block of Mitscher Rd",1,0,N/A
+1114200,"May 13, 2018",Delaware,Wilmington,"1300 block of Chestnut St",0,1,N/A
+1115762,"May 12, 2018",Delaware,Wilmington,"500 block of W 6th St",0,0,N/A
+1113567,"May 11, 2018",Delaware,Bridgeville,"21000 block of Mill Park Dr",1,0,N/A
+1114193,"May 11, 2018",Delaware,Dover,"1061 S Little Creek Rd",0,0,N/A
+1113722,"May 11, 2018",Delaware,Wilmington,"900 block of Anchorage St",0,1,N/A
+1115610,"May 10, 2018",Delaware,Wilmington,"W 8th St and Morrow St",0,0,N/A
+1112853,"May 10, 2018",Delaware,Wilmington,"601 Concord Ave",0,1,N/A
+1115760,"May 10, 2018",Delaware,Wilmington,"600 block of Monroe St",0,0,N/A
+1115768,"May 9, 2018",Delaware,Wilmington,"E 10th St and N Pine St",0,0,N/A
+1112864,"May 8, 2018",Delaware,Milford,"300 Aurora Pl",0,0,N/A
+1109652,"May 7, 2018",Delaware,Wilmington,"700 block of E 5th St",1,0,N/A
+1111321,"May 5, 2018",Delaware,Milford,"S Washington St and SE 3rd St",0,0,N/A
+1115766,"May 5, 2018",Delaware,Wilmington,"700 block of E 11th St",0,0,N/A
+1115764,"May 4, 2018",Delaware,Wilmington,"500 block of Lombard St",0,0,N/A
+1106445,"May 3, 2018",Delaware,Wilmington,"1000 block of N Lombard St",0,1,N/A
+1108299,"May 3, 2018",Delaware,Milford,"300 Aurora Pl",0,0,N/A
+1103532,"April 29, 2018",Delaware,"Rehoboth Beach (Dewey Beach)","2009 Highway One",0,0,N/A
+1103539,"April 28, 2018",Delaware,Dover,"Lakewood Dr and Columbia Ave",0,0,N/A
+1110461,"April 28, 2018",Delaware,Harrington,"US 13",0,0,N/A
+1099946,"April 24, 2018",Delaware,Magnolia,"100 block of Woodville Dr",0,0,N/A
+1099127,"April 24, 2018",Delaware,Dover,"200 block of W Reed St",0,1,N/A
+1098370,"April 24, 2018",Delaware,Wilmington,"1000 block of N Heald St",0,1,N/A
+1097485,"April 22, 2018",Delaware,Dover,"100 block of Mitscher Rd",0,0,N/A
+1098353,"April 22, 2018",Delaware,Selbyville,"Shade Tree Ln",0,0,N/A
+1098368,"April 20, 2018",Delaware,Middletown,"Ash Blvd and Foxtail Ln",0,0,N/A
+1096451,"April 20, 2018",Delaware,Wilmington,"1200 block of E 22nd St",0,1,N/A
+1096605,"April 19, 2018",Delaware,Dover,"Old Forge Dr and Meadow Garden Ln",0,0,N/A
+1096122,"April 19, 2018",Delaware,Newark,"200 block of Peach Rd",0,0,N/A
+1096841,"April 19, 2018",Delaware,Seaford,"11000 block of Henry Dr",0,0,N/A
+1094882,"April 18, 2018",Delaware,Seaford,"24000 block of Clench Jean Ln",0,0,N/A
+1094898,"April 17, 2018",Delaware,Dover,"400 Block of E Water St",0,0,N/A
+1094895,"April 17, 2018",Delaware,"New Castle","50 block of Birkshire Rd",0,0,N/A
+1094891,"April 17, 2018",Delaware,Harrington,"50 block of Clark St",0,1,N/A
+1094104,"April 17, 2018",Delaware,Dover,"50 block of Ann Ave",0,0,N/A
+1094883,"April 17, 2018",Delaware,Smyrna,"200 block of Bryn Ln",0,0,N/A
+1093330,"April 16, 2018",Delaware,Dover,"100 block of Mannering Dr",0,1,N/A
+1093336,"April 15, 2018",Delaware,Wilmington,"3318 Kirkwood Hwy",0,0,N/A
+1093340,"April 14, 2018",Delaware,Magnolia,"McKinley Cir",0,0,N/A
+1093338,"April 14, 2018",Delaware,Wilmington,"Philadelphia Pike and Murphy Rd",0,0,N/A
+1092169,"April 14, 2018",Delaware,Newark,"50 block of E Cherokee Dr",0,0,N/A
+1093679,"April 13, 2018",Delaware,Milford,"300 Aurora Pl",0,2,N/A
+1091785,"April 13, 2018",Delaware,Smyrna,"SR 1 and Smyrna Leipsic Rd",0,0,N/A
+1091787,"April 13, 2018",Delaware,Dover,"William St and Pear St",0,0,N/A
+1088300,"April 9, 2018",Delaware,Wilmington,"1100 block of W 3rd St",0,1,N/A
+1088306,"April 9, 2018",Delaware,Dover,"640 S DuPont Hwy",0,0,N/A
+1086979,"April 8, 2018",Delaware,Wilmington,"400 block of N Pine St",0,2,N/A
+1088302,"April 7, 2018",Delaware,Milford,"Park Ave and N Washington St",0,0,N/A
+1086736,"April 7, 2018",Delaware,Dover,"1 block of Headstart Ln",0,1,N/A
+1085770,"April 5, 2018",Delaware,Wilmington,"100 block of North Clayton St",0,1,N/A
+1084974,"April 3, 2018",Delaware,Felton,"S Dupont Hwy",0,0,N/A
+1083475,"April 1, 2018",Delaware,Seaford,"11000 block of Hope Ln",0,0,N/A
+1082791,"April 1, 2018",Delaware,Dover,"295 S Dupont Hwy",0,0,N/A
+1082788,"April 1, 2018",Delaware,Wilmington,"2900 block of N Tatnall St",0,0,N/A
+1082786,"April 1, 2018",Delaware,Dover,"26 S Governors Ave",0,1,N/A
+1084928,"April 1, 2018",Delaware,Wilmington,"Brookside Dr",0,1,N/A
+1083472,"March 31, 2018",Delaware,Townsend,"US 13 and DE 71",0,0,N/A
+1080166,"March 28, 2018",Delaware,Wilmington,"50 block of W 27th St",0,1,N/A
+1079229,"March 27, 2018",Delaware,Dover,"Lepore Rd and N DuPont Hwy",0,0,N/A
+1080907,"March 27, 2018",Delaware,Wilmington,"900 block of Vandever Ave",0,1,N/A
+1077776,"March 25, 2018",Delaware,Wilmington,"2400 block of Lamotte St",0,0,N/A
+1077771,"March 24, 2018",Delaware,Dover,"N Dupont Hwy and Messina Hill Rd",0,0,N/A
+1074435,"March 20, 2018",Delaware,Seaford,"Chandler Heights",0,0,N/A
+1074421,"March 20, 2018",Delaware,Newark,"S Main St",0,0,N/A
+1072776,"March 19, 2018",Delaware,Newark,"750 E Delaware Ave",0,0,N/A
+1074427,"March 19, 2018",Delaware,Milford,"1029 S Walnut St",0,1,N/A
+1072775,"March 18, 2018",Delaware,Newark,"Blue Ridge Cir",0,0,N/A
+1072050,"March 17, 2018",Delaware,Newark,"1119 S College Ave",0,0,N/A
+1072766,"March 17, 2018",Delaware,Dover,"S Governors Ave and W Division St",0,1,N/A
+1070497,"March 15, 2018",Delaware,Milford,"50 block of Causey Ave",0,0,N/A
+1070502,"March 15, 2018",Delaware,Dover,"Buckson Dr and Bacon Ave",0,0,N/A
+1069139,"March 14, 2018",Delaware,Wilmington,"100 block of N Broom St",1,0,N/A
+1069143,"March 13, 2018",Delaware,Wilmington,"900 block of Vandever Ave",0,1,N/A
+1069147,"March 12, 2018",Delaware,Newark,"900 Churchmans Rd",0,0,N/A
+1068574,"March 12, 2018",Delaware,Harrington,"Dorman St and Commerce St",0,0,N/A
+1067726,"March 11, 2018",Delaware,Dover,"Martin Luther King Jr Blvd",0,0,N/A
+1067707,"March 11, 2018",Delaware,Dover,"White Oak Rd and Stevenson Rd",0,0,N/A
+1067714,"March 11, 2018",Delaware,Dover,"S New St",0,0,N/A
+1067718,"March 10, 2018",Delaware,Dover,"1365 N Dupont Hwy",0,0,N/A
+1065898,"March 9, 2018",Delaware,Wilmington,"300 block of N Van Buren St",0,0,N/A
+1065895,"March 9, 2018",Delaware,Newark,"Malvern Rd and Augusta Dr",1,0,N/A
+1063523,"March 3, 2018",Delaware,Dover,"200 block of S Queen St",0,0,N/A
+1062017,"March 3, 2018",Delaware,Wilmington,"800 block of N Pine St",0,1,N/A
+1061550,"March 2, 2018",Delaware,Bear,"Bear Christiana Rd",0,0,N/A
+1060764,"March 2, 2018",Delaware,Milford,"200 block of NW 3rd St",0,0,N/A
+1061939,"March 2, 2018",Delaware,Lincoln,"22000 block of Pine Haven Rd",0,0,N/A
+1059182,"February 27, 2018",Delaware,Lewes,"17000 block of N Brandt St",0,0,N/A
+1059906,"February 27, 2018",Delaware,Dover,"White Oak Rd and Stevenson Dr",0,0,N/A
+1058352,"February 25, 2018",Delaware,Wilmington,"2300 block of N Market St",1,0,N/A
+1057610,"February 25, 2018",Delaware,Dover,"50 block of S State St",0,0,N/A
+1056835,"February 24, 2018",Delaware,Wilmington,"900 block of Bennett St",0,1,N/A
+1056838,"February 24, 2018",Delaware,Wilmington,N/A,0,1,N/A
+1054913,"February 22, 2018",Delaware,Wilmington,"400 block of N Clayton St",0,0,N/A
+1054901,"February 21, 2018",Delaware,Wilmington,"Lancaster Ave and S Clayton St",0,1,N/A
+1054298,"February 21, 2018",Delaware,Dover,"50 block of Periwinkle Ct",0,0,N/A
+1054324,"February 20, 2018",Delaware,Dover,"Saulsbury Rd and Forrest Ave",0,0,N/A
+1052584,"February 18, 2018",Delaware,Middletown,"500 block of New St",1,0,N/A
+1050903,"February 16, 2018",Delaware,Wilmington,"4th St and Clayton St",0,1,N/A
+1051628,"February 16, 2018",Delaware,Ellendale,"Dupont Blvd and Beach Hwy",0,0,N/A
+1050358,"February 15, 2018",Delaware,Wilmington,"23rd St and N Pine St",0,1,N/A
+1049146,"February 14, 2018",Delaware,Middletown,"100 block of E Lockwood St",0,0,N/A
+1048531,"February 13, 2018",Delaware,Felton,"100 block of Sandalwood Dr",0,0,N/A
+1048537,"February 13, 2018",Delaware,Dover,"50 block of Kentwood Dr",0,0,N/A
+1048282,"February 12, 2018",Delaware,Wilmington,"2100 block of N Pine St",0,1,N/A
+1048556,"February 12, 2018",Delaware,Harrington,"S DuPont Hwy",0,0,N/A
+1048551,"February 12, 2018",Delaware,"Rehoboth Beach","19000 block of Norwood St",0,1,N/A
+1048298,"February 11, 2018",Delaware,Dover,"200 block of Cecil St",0,0,N/A
+1049142,"February 11, 2018",Delaware,Seaford,N/A,0,0,N/A
+1060767,"February 10, 2018",Delaware,Harrington,N/A,0,0,N/A
+1046089,"February 9, 2018",Delaware,Wilmington,"200 block of W 23rd St",0,1,N/A
+1052599,"February 8, 2018",Delaware,Newark,"1 block of Aldershot Dr",0,0,N/A
+1058492,"February 7, 2018",Delaware,Milford,"619 N Dupont Blvd",0,0,N/A
+1044128,"February 6, 2018",Delaware,"New Castle","Christiana Rd and Fresconi Ct",0,0,N/A
+1044849,"February 6, 2018",Delaware,Seaford,"8774 Concord Rd",0,0,N/A
+1044856,"February 6, 2018",Delaware,Newark,"Thayer Ct",0,0,N/A
+1044137,"February 5, 2018",Delaware,Wilmington,"2200 block of Lamotte St",2,0,N/A
+1041557,"February 1, 2018",Delaware,Dover,"400 block of S New St",0,0,N/A
+1333935,"February 1, 2018",Delaware,Wilmington,"801 W 5th St",0,0,N/A
+1041174,"January 31, 2018",Delaware,Dover,"100 block of S Governors Blvd",0,0,N/A
+1041175,"January 31, 2018",Delaware,"New Castle (Dunleith)","400 block of Morehouse Dr",0,1,N/A
+1147081,"January 28, 2018",Delaware,Hartly,"1200 block of Crystal Rd",0,0,N/A
+1037153,"January 26, 2018",Delaware,Wilmington,"2300 block of N Pine St",1,0,N/A
+1036551,"January 26, 2018",Delaware,"New Castle","550 S Dupont Hwy",0,0,N/A
+1039589,"January 25, 2018",Delaware,Middletown,"100 block of Liborio Ln",0,0,N/A
+1036677,"January 25, 2018",Delaware,Wilmington,"50 block of W Salisbury Dr",0,1,N/A
+1036170,"January 25, 2018",Delaware,Bridgeville,"E Newton Rd and Adams Rd",1,0,N/A
+1037144,"January 25, 2018",Delaware,Hartly,"700 block of Fords Corner Rd",0,0,N/A
+1038623,"January 24, 2018",Delaware,"Camden Wyoming","50 block of Apple Blossom Dr",0,0,N/A
+1034680,"January 24, 2018",Delaware,Dover,"2200 block of S State St",0,0,N/A
+1034730,"January 24, 2018",Delaware,Milford,"5 Linstone Ln",0,0,N/A
+1039604,"January 24, 2018",Delaware,Middletown,"900 block of Janvier Ct",0,0,N/A
+1041570,"January 23, 2018",Delaware,Milford,"300 Aurora Pl",0,0,N/A
+1031401,"January 20, 2018",Delaware,Dover,"200 block of David Hall Rd",0,0,N/A
+1030631,"January 18, 2018",Delaware,Smyrna,"300 block of Daniel Rd",0,0,N/A
+1030609,"January 18, 2018",Delaware,Wilmington,"200 block of N Madison St",0,1,N/A
+1030626,"January 17, 2018",Delaware,Newark,"100 block of Madison Dr",0,0,N/A
+1029828,"January 17, 2018",Delaware,"Wilmington (Edgemoor)","50 block of Polk Rd",0,1,N/A
+1029102,"January 17, 2018",Delaware,Wilmington,"2300 block of N Market St",0,1,N/A
+1030402,"January 17, 2018",Delaware,Dover,"43 S Kirkwood St",0,0,N/A
+1029203,"January 17, 2018",Delaware,Middletown,"100 block of E Lockwood St",0,2,N/A
+1041577,"January 15, 2018",Delaware,Dagsboro,N/A,0,0,N/A
+1029777,"January 15, 2018",Delaware,Frederica,"100 block of Jackson St",0,0,N/A
+1028761,"January 14, 2018",Delaware,Newark,"50 block of White Clay Crescent Dr",0,0,N/A
+1024456,"January 10, 2018",Delaware,Lincoln,"22000 block of Pine Haven Rd",0,1,N/A
+1024547,"January 10, 2018",Delaware,Wilmington,"2700 block of N Claymont St",0,1,N/A
+1028810,"January 10, 2018",Delaware,Frederica,"80 Block of Barefoot Ln",0,0,N/A
+1036180,"January 9, 2018",Delaware,Newark,"50 block of North St",0,0,N/A
+1024461,"January 9, 2018",Delaware,Milton,"Fisher Rd and Hudson Rd",0,1,N/A
+1019240,"January 2, 2018",Delaware,Wilmington,"2700 block of W 5th St",0,1,N/A
+1020098,"January 1, 2018",Delaware,Dover,"Charles Polk Rd",0,0,N/A
+1069150,"December 31, 2017",Delaware,Wilmington,"1300 block of Banning St",0,0,N/A
+1017165,"December 29, 2017",Delaware,Dover,"820 Carvel Dr",0,0,N/A
+1019245,"December 29, 2017",Delaware,Wilmington,"2800 block of Washington St",0,0,N/A
+1016387,"December 28, 2017",Delaware,Wilmington,"201 S Heald St",0,1,N/A
+1015754,"December 27, 2017",Delaware,Dover,"Martin Luther King Blvd",0,0,N/A
+1015740,"December 27, 2017",Delaware,Wilmington,"200 block of S Madison St",0,1,N/A
+1015724,"December 27, 2017",Delaware,Newark,"1232 Capitol Trl",0,1,N/A
+1015736,"December 27, 2017",Delaware,"New Castle","113 Parma Ave",1,0,N/A
+1015374,"December 26, 2017",Delaware,Wilmington,"Todds Ln and N Claymont St",0,0,N/A
+1013181,"December 21, 2017",Delaware,Magnolia,"50 W Birdie Ln",0,0,N/A
+1032824,"December 21, 2017",Delaware,Newark,"301 College Sq",0,0,N/A
+1009185,"December 17, 2017",Delaware,Wilmington,"E 17th St",0,1,N/A
+1009182,"December 16, 2017",Delaware,Wilmington,"800 block of Vandever Ave",1,0,N/A
+1008595,"December 15, 2017",Delaware,Wilmington,"Farrand Dr and Kirkwood Hwy",1,0,N/A
+1008591,"December 15, 2017",Delaware,Frederica,"100 block of Jackson St",0,0,N/A
+1007468,"December 14, 2017",Delaware,Wilmington,"300 block of N Van Buren St",0,1,N/A
+1007100,"December 13, 2017",Delaware,"New Castle","Freedom Trl",0,1,N/A
+1007572,"December 12, 2017",Delaware,Bear,"1645 Pulaski Hwy",0,0,N/A
+1004820,"December 10, 2017",Delaware,Wilmington,"200 block of N Rodney St",0,1,N/A
+1004355,"December 9, 2017",Delaware,Dover,"Fieldstone Ct and Kenton Rd",1,1,N/A
+1001742,"December 5, 2017",Delaware,Wilmington,"800 block of N Jackson St",1,0,N/A
+1001846,"December 5, 2017",Delaware,Dover,"Unit block of S New St",0,1,N/A
+1004360,"December 5, 2017",Delaware,Wilmington,"500 Block of Main St",0,0,N/A
+1001850,"December 4, 2017",Delaware,Milford,"200 block of S Washington St",0,1,N/A
+1001056,"December 4, 2017",Delaware,Wilmington,"5029 Governor Printz Blvd",2,0,N/A
+999846,"December 2, 2017",Delaware,Wilmington,"W 27th St and Tatnall St",0,1,N/A
+999849,"December 1, 2017",Delaware,Lewes,"Breakwater St",0,1,N/A
+998551,"November 29, 2017",Delaware,Wilmington,"1300 N Claymont St",0,2,N/A
+997368,"November 28, 2017",Delaware,Newark,"Freedom Rd and Penman Seventy 6 St",0,1,N/A
+1001049,"November 27, 2017",Delaware,"New Castle","700 block of W 11th St",0,1,N/A
+995106,"November 24, 2017",Delaware,Wilmington,"E 23rd St",0,1,N/A
+995110,"November 24, 2017",Delaware,"Milford (Slaughter Beach)","400 block of Bay Ave",0,0,N/A
+993442,"November 22, 2017",Delaware,Wilmington,"W 7th St and N Tatnall St",0,2,N/A
+992889,"November 21, 2017",Delaware,Newark,"1 block of Lawrence Ave",0,0,N/A
+992395,"November 19, 2017",Delaware,Georgetown,"20762 Dupont Blvd",0,0,N/A
+992386,"November 19, 2017",Delaware,Milford,"200 block of NW 3rd St",0,1,N/A
+992371,"November 19, 2017",Delaware,Wilmington,"1200 block of W 3rd St",1,1,N/A
+992389,"November 19, 2017",Delaware,Milford,"300 block of NW 4th St",0,0,N/A
+991406,"November 18, 2017",Delaware,Middletown,"400 block of W Harvest Ln",0,1,N/A
+992392,"November 18, 2017",Delaware,Milford,"400 block of Bay Ave",0,0,N/A
+990641,"November 17, 2017",Delaware,Newark,"1 block of Teal Cir",0,1,N/A
+990236,"November 15, 2017",Delaware,Middletown,"E Lake Street",0,1,N/A
+987000,"November 13, 2017",Delaware,Wilmington,"700 block of Townsend Pl",0,1,N/A
+991238,"November 13, 2017",Delaware,Wilmington,"100 block of E. 24th st",0,2,N/A
+987003,"November 11, 2017",Delaware,Dover,"Martin Luther King Blvd and River Rd",0,1,N/A
+986996,"November 11, 2017",Delaware,Wilmington,"3100 Naamans Rd",0,0,N/A
+984362,"November 9, 2017",Delaware,Wilmington,"500 block of South Franklin St",1,0,N/A
+984361,"November 8, 2017",Delaware,Milton,"15000 block of Walker Dr",0,0,N/A
+985724,"November 8, 2017",Delaware,Dover,"800 block of Paul St",0,0,N/A
+982557,"November 6, 2017",Delaware,Wilmington,"2400 block of N Market St",0,2,N/A
+982553,"November 5, 2017",Delaware,Dover,"1200 N Dupont Hwy",0,0,N/A
+979922,"November 3, 2017",Delaware,Newark,N/A,0,0,N/A
+977557,"October 31, 2017",Delaware,Wilmington,"700 block of N Van Buren St",0,1,N/A
+977553,"October 30, 2017",Delaware,Bridgeville,"Mill Park Dr",0,1,N/A
+975905,"October 29, 2017",Delaware,Wilmington,"23rd and Washington",0,1,N/A
+974291,"October 27, 2017",Delaware,Dover,"865 N DuPont Hwy",0,0,N/A
+974288,"October 26, 2017",Delaware,Wilmington,"320 E 5th St",0,0,N/A
+979305,"October 26, 2017",Delaware,Claymont,"281 Harbor Dr",0,0,N/A
+972872,"October 25, 2017",Delaware,Seaford,"11000 block of Orange Blossom Ln",0,0,N/A
+971807,"October 23, 2017",Delaware,"Rehoboth Beach","37000 block of Johnston St",0,1,N/A
+971813,"October 23, 2017",Delaware,Frankford,"Roxana Rd and Burbage Rd",0,1,N/A
+965192,"October 21, 2017",Delaware,Wilmington,"1600 block of W 4th St",0,1,N/A
+963721,"October 19, 2017",Delaware,Kenton,"Cooper St",2,0,N/A
+963071,"October 17, 2017",Delaware,"New Castle","200 block of Highland Blvd",0,1,N/A
+961933,"October 17, 2017",Delaware,Wilmington,"W 6th St and N Jefferson St",0,1,N/A
+961927,"October 16, 2017",Delaware,Wilmington,"500 block of W 6th St",1,0,N/A
+959960,"October 15, 2017",Delaware,Dover,"865 N Dupont Hwy",0,2,N/A
+959958,"October 15, 2017",Delaware,Wilmington,"600 block of Pine Street",0,1,N/A
+961924,"October 14, 2017",Delaware,Bear,"1241 Quintillo Dr",0,1,N/A
+964000,"October 13, 2017",Delaware,Wilmington,"27th and Claymont",0,2,N/A
+1072056,"October 12, 2017",Delaware,Bridgeville,N/A,0,0,N/A
+957338,"October 11, 2017",Delaware,Newark,"50 block of Raven Turn",0,1,N/A
+957343,"October 11, 2017",Delaware,Dover,"100 block of Presidents Dr",0,1,N/A
+957822,"October 10, 2017",Delaware,Laurel,"Market St and Railroad Ave",0,0,N/A
+956456,"October 9, 2017",Delaware,"New Castle","50 block of Briarcliff Dr",0,1,N/A
+956459,"October 8, 2017",Delaware,Wilmington,"600 block of Concord Ave",0,1,N/A
+955633,"October 7, 2017",Delaware,"New Castle","I-495 and Hessler Blvd",0,0,N/A
+955787,"October 6, 2017",Delaware,Wilmington,"400 block of W 32nd St",0,0,N/A
+953780,"October 5, 2017",Delaware,Wilmington,"400 block of Townsend Street",0,1,N/A
+953946,"October 5, 2017",Delaware,Milton,"13000 block of Sunland Drive",1,1,N/A
+953782,"October 4, 2017",Delaware,Wilmington,"Van Buren and Pleasant street",0,1,N/A
+950314,"October 2, 2017",Delaware,Wilmington,"W 7th and N Monroe",0,2,N/A
+950312,"October 1, 2017",Delaware,Wilmington,"600 block of S Van Buren",0,1,N/A
+945460,"September 30, 2017",Delaware,Wilmington,"1200 block of Lobdell St",0,1,N/A
+946036,"September 30, 2017",Delaware,Wilmington,"30th and Market",0,2,N/A
+945106,"September 29, 2017",Delaware,"Wilmington (Elsmere)","103 S Maryland Ave",0,1,N/A
+945466,"September 29, 2017",Delaware,Wilmington,"3806 Governor Printz Boulevard",0,1,N/A
+943784,"September 28, 2017",Delaware,Wilmington,"4300 block of Miller Rd",1,0,N/A
+944863,"September 27, 2017",Delaware,Wilmington,"1000 block of Pine Street",0,1,N/A
+943488,"September 26, 2017",Delaware,Dover,"Fulton St and New St",0,0,N/A
+942704,"September 26, 2017",Delaware,Wilmington,"37th St and Monroe St",0,1,N/A
+943482,"September 26, 2017",Delaware,Dover,"400 block of Kent St",0,0,N/A
+942426,"September 25, 2017",Delaware,Wilmington,"2600 block of N Harrison St",0,1,N/A
+1042496,"September 24, 2017",Delaware,Wilmington,"2400 block of N Monroe St",0,1,N/A
+941601,"September 24, 2017",Delaware,Bridgeville,"11000 block of Iris Field Ln",1,0,N/A
+941605,"September 24, 2017",Delaware,Wilmington,N/A,0,1,N/A
+941612,"September 23, 2017",Delaware,Wilmington,"1100 block of Beech St",0,2,N/A
+939565,"September 21, 2017",Delaware,Dover,"1700 E Lebanon Rd",0,0,N/A
+938680,"September 20, 2017",Delaware,"Rehoboth Beach","21000 block of Catalina Cir",0,0,N/A
+940526,"September 19, 2017",Delaware,Newark,"Four Seasons Pkwy",0,0,N/A
+935956,"September 18, 2017",Delaware,Wilmington,"1000 block of N Spruce St",0,1,N/A
+936649,"September 18, 2017",Delaware,Wilmington,"E 10th St and N Pine St",0,2,N/A
+934779,"September 17, 2017",Delaware,Wilmington,"900 block of E 17th",0,1,N/A
+1077229,"September 15, 2017",Delaware,Seaford,"23000 block of Dove Rd",1,0,N/A
+933154,"September 14, 2017",Delaware,Dover,"100 block of N New St",0,1,N/A
+934781,"September 14, 2017",Delaware,Wilmington,"2600 block of N Market St",0,1,N/A
+931704,"September 12, 2017",Delaware,Milton,"Cool Springs Road",0,0,N/A
+932370,"September 12, 2017",Delaware,Wilmington,"W 27th St",0,1,N/A
+931692,"September 11, 2017",Delaware,Wilmington,"2600 block of Zebley Pl",0,1,N/A
+934796,"September 11, 2017",Delaware,Smyrna,"500 block of Barley Ct",0,0,N/A
+928851,"September 7, 2017",Delaware,Wilmington,"100 block of Cedar St",1,0,N/A
+935445,"September 4, 2017",Delaware,Wilmington,"Maryland Ave",0,0,N/A
+927605,"September 4, 2017",Delaware,Wilmington,"1900 block of 5th St",0,1,N/A
+926979,"September 4, 2017",Delaware,Wilmington,"700 block of Townsend Pl",0,1,N/A
+1059929,"September 3, 2017",Delaware,Dover,"360 Webbs Ln",0,0,N/A
+926977,"September 3, 2017",Delaware,Wilmington,"50 block of W 26th St",1,0,N/A
+925868,"September 2, 2017",Delaware,Wilmington,"800 block of N. Adams St.",1,0,N/A
+924890,"September 1, 2017",Delaware,Dover,"51 Webbs Ln",0,3,N/A
+924471,"August 30, 2017",Delaware,Georgetown,"1309 Lee Ave",0,0,N/A
+926326,"August 28, 2017",Delaware,"Dover (Leipsic)","168 E Denny St",0,0,N/A
+922938,"August 28, 2017",Delaware,Wilmington,"100 block of E. 23rd St.",0,1,N/A
+919944,"August 24, 2017",Delaware,Wilmington,"300 block of Concord Avenue",0,1,N/A
+920536,"August 24, 2017",Delaware,Wilmington,"S Scott St and Tulip St",0,0,N/A
+919931,"August 24, 2017",Delaware,Bridgeville,"Appletree Road",1,1,N/A
+919189,"August 23, 2017",Delaware,Wilmington,"114 E 24th St",0,1,N/A
+919183,"August 22, 2017",Delaware,Wilmington,"934 Clifford Brown Walk",0,2,N/A
+918526,"August 20, 2017",Delaware,Newark,"Barnwell Ln",0,0,N/A
+917122,"August 20, 2017",Delaware,Newark,"200 block of Barnwell Ln",0,0,N/A
+915980,"August 18, 2017",Delaware,Wilmington,"1800 block of N. Tatnall St.",0,1,N/A
+914098,"August 15, 2017",Delaware,Dover,"Maple Parkway and North Du Pont Highway",0,0,N/A
+913307,"August 11, 2017",Delaware,Bear,"100 block of Carlotta Dr",0,0,N/A
+909630,"August 9, 2017",Delaware,Wilmington,"600 block of N Pine St",1,0,N/A
+909613,"August 8, 2017",Delaware,Wilmington,"W 4th and N Monroe",0,1,N/A
+909636,"August 8, 2017",Delaware,Dover,"1426 N Dupont Hwy",0,0,N/A
+909620,"August 8, 2017",Delaware,Wilmington,"Lancaster and Van Buren",0,1,N/A
+913294,"August 6, 2017",Delaware,"New Castle","Bunker Hill Rd",0,0,N/A
+907132,"August 3, 2017",Delaware,Seaford,"1 Chandler St",0,1,N/A
+906142,"August 3, 2017",Delaware,Wilmington,"1100 block of Maryland Ave",0,2,N/A
+902554,"July 30, 2017",Delaware,Wilmington,"2300 block of N Locust St",0,1,N/A
+902562,"July 30, 2017",Delaware,Wilmington,"400 block of Townsend St",0,1,N/A
+902549,"July 30, 2017",Delaware,Wilmington,"23rd St and Pine St",0,1,N/A
+903974,"July 30, 2017",Delaware,Lewes,"15099 Cape Henlopen Dr",0,0,N/A
+900941,"July 29, 2017",Delaware,Newark,"630 Suburban Dr",0,1,N/A
+900963,"July 28, 2017",Delaware,Wilmington,"400 block of N Washington St",0,4,N/A
+902747,"July 28, 2017",Delaware,Wilmington,N/A,0,1,N/A
+900919,"July 28, 2017",Delaware,Wilmington,"700 block of S Van Buren St",1,0,N/A
+899950,"July 27, 2017",Delaware,Wilmington,"2400 block of N Madison St",0,2,N/A
+901754,"July 27, 2017",Delaware,Wilmington,"1100 block of Westover Rd",0,0,N/A
+900644,"July 27, 2017",Delaware,Wilmington,"2400 block of MacDonough Rd",0,0,N/A
+899957,"July 26, 2017",Delaware,Dover,"100 block of Davis Cir",0,0,N/A
+896184,"July 22, 2017",Delaware,Wilmington,"100 block of E 24th St",0,1,N/A
+895961,"July 22, 2017",Delaware,Wilmington,"1200 block of E 27th St",0,2,N/A
+894959,"July 20, 2017",Delaware,Dover,"400 block of River Road",0,1,N/A
+894954,"July 19, 2017",Delaware,Dover,"400 block of River Rd",0,1,N/A
+892056,"July 16, 2017",Delaware,Wilmington,"7th St and N Monroe St",0,1,N/A
+891837,"July 15, 2017",Delaware,Dover,"300 block of Billy Mitchell Ln",0,0,N/A
+890761,"July 14, 2017",Delaware,Wilmington,"1200 block of W 3rd St",1,0,N/A
+889580,"July 12, 2017",Delaware,"New Castle","Baylis Street",0,0,N/A
+889575,"July 12, 2017",Delaware,Wilmington,"300 block of E. 26th Street",0,1,N/A
+886411,"July 8, 2017",Delaware,Wilmington,"W 4th St",0,1,N/A
+885286,"July 6, 2017",Delaware,Claymont,"609 Naamans Rd",0,0,N/A
+885280,"July 6, 2017",Delaware,Wilmington,"1300 block of Cedar St",0,1,N/A
+884837,"July 6, 2017",Delaware,"New Castle","260 Christiana Rd",0,2,N/A
+883972,"July 5, 2017",Delaware,Dover,"51 Webbs Ln",0,1,N/A
+883977,"July 5, 2017",Delaware,Milton,"Reynolds Road",0,1,N/A
+883974,"July 5, 2017",Delaware,"New Castle","3125 New Castle Avenue",0,1,N/A
+882474,"July 4, 2017",Delaware,Wilmington,"400 block of E 9th St",0,1,N/A
+882131,"July 3, 2017",Delaware,Newark,"2000 block of Capitol Trl",0,0,N/A
+880458,"July 1, 2017",Delaware,Wilmington,"1700 Block of W Third St",0,2,N/A
+880539,"July 1, 2017",Delaware,Milford,"5 Linstone Ln",1,1,N/A
+879731,"June 30, 2017",Delaware,"New Castle (county)",N/A,0,1,N/A
+878751,"June 29, 2017",Delaware,Wilmington,"Rysing Drive and S Cannon Drive",0,1,N/A
+879726,"June 29, 2017",Delaware,Wilmington,"23rd St and Market St",0,1,N/A
+877802,"June 28, 2017",Delaware,Seaford,"Rt 13 Alternate and Virginia Ave",0,1,N/A
+1065204,"June 28, 2017",Delaware,"Rehoboth Beach","Oak Ave",0,0,N/A
+878409,"June 28, 2017",Delaware,Wilmington,"9th St and Jefferson St",0,1,N/A
+877638,"June 27, 2017",Delaware,Dover,"255 Webbs Ln",1,1,N/A
+876808,"June 26, 2017",Delaware,Wilmington,"131 Scarborough Park Dr",0,1,N/A
+876023,"June 25, 2017",Delaware,Wilmington,"1600 block of West 3rd Street",0,1,N/A
+876021,"June 25, 2017",Delaware,Wilmington,"699 Robinson Ln",0,1,N/A
+875547,"June 24, 2017",Delaware,"New Castle","Chesterfield Dr",0,1,N/A
+1538238,"June 23, 2017",Delaware,Wilmington,"2700 block of Thompson Pl",0,1,N/A
+874475,"June 22, 2017",Delaware,Magnolia,"400 Block of Cherry Dr E",0,0,N/A
+873088,"June 21, 2017",Delaware,Wilmington,"2900 block of Tatnall Street",0,1,N/A
+873093,"June 20, 2017",Delaware,Bear,"Pulaski Highway",0,0,N/A
+872086,"June 19, 2017",Delaware,Newark,"1232 Capitol Trail",0,0,N/A
+870688,"June 18, 2017",Delaware,Wilmington,"400 block of W 7th",0,2,N/A
+870214,"June 18, 2017",Delaware,Milford,"5 Linstone Ln",0,1,N/A
+868037,"June 14, 2017",Delaware,Wilmington,"1800 block of Conrad St.",0,1,N/A
+867445,"June 13, 2017",Delaware,Wilmington,"2600 block of N Jefferson St",0,0,N/A
+867258,"June 13, 2017",Delaware,Wilmington,"300 block of W 29th St",0,1,N/A
+867252,"June 13, 2017",Delaware,Wilmington,"1100 block of Read St",0,2,N/A
+866291,"June 13, 2017",Delaware,Georgetown,"North Bedford Street",0,0,N/A
+867407,"June 12, 2017",Delaware,"Wilmington (Newport)","700 Block of Harwood Rd",0,0,N/A
+866446,"June 12, 2017",Delaware,Dover,"Stevenson Dr",0,0,N/A
+866506,"June 11, 2017",Delaware,Dover,"Collins Drive",0,0,N/A
+864692,"June 9, 2017",Delaware,"New Castle","Briarcliff Dr",0,1,N/A
+862634,"June 7, 2017",Delaware,Wilmington,"1706 Oak St",0,0,N/A
+860942,"June 6, 2017",Delaware,Wilmington,"DE Rt 896",0,0,N/A
+860937,"June 6, 2017",Delaware,Wilmington,"700 block of E 6th St",0,1,N/A
+861457,"June 6, 2017",Delaware,Newark,"231 Executive Ave",0,0,N/A
+860950,"June 5, 2017",Delaware,Wilmington,"1600 block of N Pine St",0,1,N/A
+859628,"June 3, 2017",Delaware,Wilmington,"900 block of Kirkwood St",0,1,N/A
+859060,"June 3, 2017",Delaware,Wilmington,"200 Block of N Rodney St",0,1,N/A
+858656,"June 3, 2017",Delaware,Wilmington,"24th St and Lamotte St",0,1,N/A
+858393,"June 1, 2017",Delaware,Dover,"1760 N DuPont Hwy",1,0,N/A
+856007,"May 30, 2017",Delaware,Wilmington,"2000 Block of Washington St",0,1,N/A
+859058,"May 30, 2017",Delaware,"New Castle","Dallas Dr",0,0,N/A
+854707,"May 28, 2017",Delaware,Wilmington,"600 block of N Harrison",0,2,N/A
+853811,"May 27, 2017",Delaware,"New Castle","200 block of Keller Beyer Road",0,1,N/A
+853599,"May 26, 2017",Delaware,"New Castle","44 Birkshire Rd",0,1,N/A
+853105,"May 26, 2017",Delaware,Wilmington,"200 block of N. DuPont St",0,3,N/A
+858660,"May 25, 2017",Delaware,Dover,"1 block of S New St",0,0,N/A
+850913,"May 24, 2017",Delaware,Wilmington,"1200 block of Elm St",1,0,N/A
+851615,"May 24, 2017",Delaware,Wilmington,"200 block of West 7th Street",0,0,N/A
+850918,"May 24, 2017",Delaware,Dover,"16 Sussex Ave",0,2,N/A
+850472,"May 23, 2017",Delaware,Dover,"Walker Rd and Saulsbury Rd",0,1,N/A
+850466,"May 23, 2017",Delaware,Newark,"2700 block of Normandy Court",0,1,N/A
+851494,"May 23, 2017",Delaware,Dover,"50 block of S Kirkwood St",0,0,N/A
+850262,"May 22, 2017",Delaware,Wilmington,"700 block of Windsor Street",0,0,N/A
+849178,"May 22, 2017",Delaware,Wilmington,"400 block of W 7th St",0,1,N/A
+849186,"May 21, 2017",Delaware,Wilmington,"3200 block of Champions Dr",1,0,N/A
+848192,"May 19, 2017",Delaware,Dover,"1400 block of South Farm View Drive",0,1,N/A
+849193,"May 19, 2017",Delaware,Wilmington,"Jill Court",0,0,N/A
+847540,"May 18, 2017",Delaware,Wilmington,"2400 Block of Claymont St",1,0,N/A
+847535,"May 17, 2017",Delaware,Dover,"200 Block of N New St",0,1,N/A
+846782,"May 17, 2017",Delaware,Wilmington,"4th Street and Rodney Street",0,1,N/A
+844999,"May 16, 2017",Delaware,Wilmington,"W 26th St and Tatnall St",0,2,N/A
+844563,"May 15, 2017",Delaware,Wilmington,"Shearman Street and N. Lombard Street",0,1,N/A
+844237,"May 15, 2017",Delaware,Dover,"1st block of South New Street",0,1,N/A
+845638,"May 15, 2017",Delaware,Dover,"1400 block of Woodmill Dr",0,0,N/A
+844232,"May 14, 2017",Delaware,Wilmington,"A Street and Chapel Street",0,1,N/A
+842281,"May 11, 2017",Delaware,Smyrna,"Lincoln St",0,1,N/A
+844096,"May 10, 2017",Delaware,Wilmington,"Eighth and Windsor streets",0,1,N/A
+840996,"May 10, 2017",Delaware,Wilmington,"100 block of Elliot's Way",0,1,N/A
+840998,"May 10, 2017",Delaware,Wilmington,"500 block of W 25th St",1,0,N/A
+1538234,"May 8, 2017",Delaware,Wilmington,"50 block of E 23rd St",0,1,N/A
+837630,"May 6, 2017",Delaware,Wilmington,"Beech St and S Van Buren St",0,1,N/A
+837628,"May 5, 2017",Delaware,Wilmington,"24th St and Lamotte St",0,1,N/A
+837112,"May 5, 2017",Delaware,Millsboro,"28547 DuPont Blvd",0,0,N/A
+837626,"May 5, 2017",Delaware,Wilmington,"W 2nd St and N Van Buren St",1,0,N/A
+834987,"May 3, 2017",Delaware,Dover,"Webbs Lane",1,0,N/A
+835859,"May 2, 2017",Delaware,Dover,"10 block of S New St",0,0,N/A
+833168,"May 1, 2017",Delaware,Newark,"24 Brookhill Dr",0,0,N/A
+834980,"May 1, 2017",Delaware,Seaford,"10599 Concord Road",0,1,N/A
+833929,"May 1, 2017",Delaware,Wilmington,"Maple and Porter streets",0,1,N/A
+833093,"April 30, 2017",Delaware,Wilmington,"800 block of W. 9th St.",0,1,N/A
+833089,"April 30, 2017",Delaware,Wilmington,"500 block of Taylor St.",0,0,N/A
+832186,"April 29, 2017",Delaware,Wilmington,"3rd and N Rodney",0,0,N/A
+833736,"April 28, 2017",Delaware,Wilmington,"500 block of West St",0,0,N/A
+831741,"April 27, 2017",Delaware,"New Castle","500 S DuPont Hwy",0,1,N/A
+830128,"April 26, 2017",Delaware,Seaford,"24057 Sussex Hwy",0,0,N/A
+829273,"April 26, 2017",Delaware,Dover,"10 block of S New St",0,0,N/A
+829656,"April 26, 2017",Delaware,Wilmington,"900 block of Kirkwood St",1,0,N/A
+829053,"April 26, 2017",Delaware,Bear,"1693 Pulaski Hwy",2,0,N/A
+829277,"April 25, 2017",Delaware,Wilmington,"1700 block of N. Pine St.",0,1,N/A
+828222,"April 25, 2017",Delaware,Wilmington,"100 block of North Van Buren Street",0,1,N/A
+829085,"April 25, 2017",Delaware,Wilmington,"900 block of Maryland Avenue",1,0,N/A
+829286,"April 24, 2017",Delaware,"New Castle","Liborio Ln",0,0,N/A
+827302,"April 22, 2017",Delaware,Wilmington,"23rd and West",0,1,N/A
+827300,"April 22, 2017",Delaware,Wilmington,"27th and Market",0,1,N/A
+829282,"April 22, 2017",Delaware,Smyrna,"53 E Glenwood Ave",0,1,N/A
+826595,"April 21, 2017",Delaware,Wilmington,"Seventh and Monroe streets",0,1,N/A
+827298,"April 21, 2017",Delaware,Dover,DE-1,0,0,N/A
+825580,"April 20, 2017",Delaware,Wilmington,"2900 block of N Washington St",0,1,N/A
+825578,"April 20, 2017",Delaware,Newark,"1100 Stanton Christiana Rd",0,0,N/A
+825988,"April 20, 2017",Delaware,Wilmington,"2nd St and Connell St",0,1,N/A
+824475,"April 19, 2017",Delaware,Wilmington,"602 Philadelphia Pike",1,0,N/A
+822851,"April 17, 2017",Delaware,Dover,"Collins Dr",0,1,N/A
+822853,"April 17, 2017",Delaware,Dover,"820 Carvel Dr",0,3,N/A
+822211,"April 17, 2017",Delaware,"Wilmington (Elsmere)","Faulkland Road and Del. 100",0,1,N/A
+822215,"April 16, 2017",Delaware,Wilmington,"50 block of S Pennewell Dr",0,1,N/A
+822033,"April 16, 2017",Delaware,Wilmington,"1400 block of W. 3rd Street",0,1,N/A
+821190,"April 14, 2017",Delaware,Wilmington,"W. 27th St.",0,1,N/A
+817650,"April 12, 2017",Delaware,Dover,"900 Block of W North St",0,1,N/A
+817655,"April 11, 2017",Delaware,Wilmington,"Seventh St and West St",1,0,N/A
+819697,"April 11, 2017",Delaware,Milford,"4500 block of Summer Brook Way",0,0,N/A
+817298,"April 10, 2017",Delaware,Dover,"DuPont Highway and Division Street",0,0,N/A
+816809,"April 10, 2017",Delaware,Wilmington,"600 block of West Sixth Street",0,1,N/A
+815463,"April 9, 2017",Delaware,"New Castle","Lambson Ln and E Hillview Ave",0,1,N/A
+815209,"April 8, 2017",Delaware,Woodside,"S DuPont Hwy",0,0,N/A
+816824,"April 8, 2017",Delaware,Wilmington,"4301 Kirkwood Highway",0,0,N/A
+814870,"April 7, 2017",Delaware,Wilmington,"MLK Jr  Blvd and Justison St",0,1,N/A
+815204,"April 7, 2017",Delaware,Millsboro,"27000 block of Sandy Dr",0,0,N/A
+814274,"April 6, 2017",Delaware,Magnolia,"West Walnut Street",0,0,N/A
+813178,"April 5, 2017",Delaware,Wilmington,"1300 block of E. 29th St.",0,2,N/A
+812879,"April 4, 2017",Delaware,Dover,"400 block of S Governors Ave",0,0,N/A
+811185,"April 3, 2017",Delaware,Bear,"1176 Pulaski Hwy",0,1,N/A
+811183,"April 3, 2017",Delaware,Wilmington,"West 26th and West streets",0,1,N/A
+812877,"April 3, 2017",Delaware,Dover,"S Governors Ave and S Bradford St",0,0,N/A
+809922,"April 2, 2017",Delaware,Wilmington,"400 block of Eastlawn Avenue",0,1,N/A
+809920,"April 2, 2017",Delaware,Wilmington,"500 block of W. 7th Street",0,1,N/A
+1060762,"April 1, 2017",Delaware,Wilmington,"N Market St and 26th St",0,0,N/A
+1538260,"March 29, 2017",Delaware,Dover,"76 Stevenson Dr",0,2,N/A
+806102,"March 29, 2017",Delaware,Wilmington,"2500 block of N Heald St",0,1,N/A
+805794,"March 28, 2017",Delaware,Wilmington,"2300 block of N Claymont St",1,0,N/A
+806203,"March 27, 2017",Delaware,Wilmington,"100 block of Town Estates Drive",0,0,N/A
+802856,"March 25, 2017",Delaware,Wilmington,"200 block of W 7th St",0,1,N/A
+802859,"March 25, 2017",Delaware,Wilmington,"700 block of North Tatnall Street",1,0,N/A
+803281,"March 24, 2017",Delaware,Dover,"S Kirkwood St and Forest Ave",0,0,N/A
+802432,"March 24, 2017",Delaware,Wilmington,"800 block of Vandever Ave",0,2,N/A
+805103,"March 24, 2017",Delaware,Dover,"South DuPont Highway",0,0,N/A
+801700,"March 23, 2017",Delaware,Wilmington,"600 block of Pine St",0,1,N/A
+800989,"March 22, 2017",Delaware,Wilmington,"506 E 5th St",0,1,N/A
+797809,"March 18, 2017",Delaware,"Ocean View","36000 block of Pine Grove Ln",0,1,N/A
+794788,"March 13, 2017",Delaware,Dover,"255 Webbs Ln.",0,0,N/A
+793255,"March 12, 2017",Delaware,Wilmington,"1000 block of W. 7th St.",0,1,N/A
+791511,"March 8, 2017",Delaware,Wilmington,"1000 block of N Lombard St",0,1,N/A
+791515,"March 8, 2017",Delaware,Wilmington,"900 block of Marshall St",1,0,N/A
+790132,"March 7, 2017",Delaware,Dover,"800 block of Bacon Ave",0,0,N/A
+789337,"March 6, 2017",Delaware,Newark,"1913 Sheldon Dr",0,0,N/A
+786956,"March 2, 2017",Delaware,Harbeson,"22000 block of Hurdle Ditch Rd",0,0,N/A
+787185,"March 1, 2017",Delaware,Dover,"South Queen Street and Bank Lane",0,0,N/A
+785476,"February 28, 2017",Delaware,Wilmington,"900 block of Vandever Avenue",0,1,N/A
+786092,"February 28, 2017",Delaware,Dover,"820 Carvel Dr",1,0,N/A
+782049,"February 23, 2017",Delaware,Wilmington,"600 block of E 23rd St",1,1,N/A
+783405,"February 22, 2017",Delaware,Newark,"1000 block of S College Rd",0,0,N/A
+779848,"February 21, 2017",Delaware,Wilmington,"2200 block of N Market St",2,0,N/A
+779874,"February 20, 2017",Delaware,Wilmington,"800 block of Vandever Avenue",0,1,N/A
+777947,"February 18, 2017",Delaware,Newark,"S College Ave and Christina Pkwy",0,0,N/A
+779855,"February 18, 2017",Delaware,"New Castle","1500 block of Surry Ct",1,0,N/A
+777624,"February 17, 2017",Delaware,"New Castle","700 block of Grantham Ln",0,1,N/A
+1538245,"February 16, 2017",Delaware,Wilmington,"400 block of Delamore Pl",0,1,N/A
+1538242,"February 16, 2017",Delaware,Wilmington,"942 Bennett St",0,1,N/A
+777953,"February 16, 2017",Delaware,Wilmington,"900 block of Lombard",0,0,N/A
+776160,"February 14, 2017",Delaware,Wilmington,"2000 block of Shallcross Avenue",0,0,N/A
+774954,"February 13, 2017",Delaware,Wilmington,"2101 Prior Rd",0,0,N/A
+774964,"February 12, 2017",Delaware,Wilmington,"400 block of W. 29th St",0,1,N/A
+774030,"February 11, 2017",Delaware,Wilmington,"1100 block of B Street",0,1,N/A
+774066,"February 10, 2017",Delaware,"New Castle","Fairhaven Court",0,0,N/A
+772271,"February 10, 2017",Delaware,Dover,"Stevenson Dr",0,0,N/A
+772276,"February 9, 2017",Delaware,Wilmington,"1000 block of W 3rd St",0,1,N/A
+771092,"February 8, 2017",Delaware,"New Castle","100 block of Parma Ave",0,1,N/A
+771085,"February 8, 2017",Delaware,Wilmington,"1700 block of Conrad Street",0,1,N/A
+771083,"February 8, 2017",Delaware,Wilmington,"2400 block of N. Monroe St.",0,1,N/A
+784933,"February 7, 2017",Delaware,Dover,"S New St",0,1,N/A
+774948,"February 7, 2017",Delaware,"New Castle","Revelle and Deen streets",0,0,N/A
+770313,"February 3, 2017",Delaware,Wilmington,"Lancaster Avenue and South Van Buren Street",0,0,N/A
+767812,"February 3, 2017",Delaware,Greenwood,"Deep Grass Ln",0,0,N/A
+767185,"February 3, 2017",Delaware,Wilmington,"S Van Buren St and Beech St",0,1,N/A
+767183,"January 31, 2017",Delaware,Milford,"N Rehoboth Rd",0,0,N/A
+764910,"January 31, 2017",Delaware,Selbyville,"31000 block of Lighthouse Rd",0,0,N/A
+764469,"January 30, 2017",Delaware,Wilmington,"1200 block of Oak St",0,1,N/A
+765159,"January 30, 2017",Delaware,Wilmington,"3rd and Washington streets",0,1,N/A
+763483,"January 29, 2017",Delaware,Wilmington,"2900 block of N. Claymont St.",0,1,N/A
+763107,"January 29, 2017",Delaware,Wilmington,"300 block of East 5th Street",0,1,N/A
+762863,"January 29, 2017",Delaware,Laurel,"56 Sunset Dr",1,0,N/A
+762758,"January 29, 2017",Delaware,Wilmington,"13th St and French St",0,1,N/A
+762736,"January 27, 2017",Delaware,Wilmington,"9th St and N Pine St",0,1,N/A
+762752,"January 27, 2017",Delaware,Laurel,"Laurel Rd and Shiloh Church Rd",0,0,N/A
+761825,"January 27, 2017",Delaware,"New Castle","Booker Circle",0,1,N/A
+760722,"January 26, 2017",Delaware,Dover,"700 block of S State St",0,0,N/A
+1131906,"January 26, 2017",Delaware,Newark,"700 block of Vinings Way",1,0,N/A
+760718,"January 25, 2017",Delaware,Dover,"300 block of Fulton Street",0,0,N/A
+761612,"January 24, 2017",Delaware,Newark,"Prospect Ave",0,1,N/A
+759893,"January 24, 2017",Delaware,Wilmington,"200 block of N Market St",0,2,N/A
+760129,"January 23, 2017",Delaware,Claymont,"Naamans Road",0,0,N/A
+758480,"January 23, 2017",Delaware,Wilmington,"1700 block of W 13th St",1,0,N/A
+757386,"January 22, 2017",Delaware,Newark,"700 Prides Crossing",0,0,N/A
+758270,"January 22, 2017",Delaware,Wilmington,"2300 block of N. Pine St",1,0,N/A
+759226,"January 22, 2017",Delaware,"New Castle","100 block of Wimbledon Court",0,0,N/A
+757946,"January 21, 2017",Delaware,Harrington,"4000 block of Cattail Branch Rd",0,0,N/A
+756261,"January 20, 2017",Delaware,Wilmington,"200 block of S Harrison St",1,1,N/A
+756252,"January 19, 2017",Delaware,Dover,"Loockerman and Queen Streets",0,0,N/A
+755421,"January 18, 2017",Delaware,Wilmington,"S Market St",0,0,N/A
+755781,"January 17, 2017",Delaware,Wilmington,"South Heald Street and A Street",0,1,N/A
+753081,"January 17, 2017",Delaware,Wilmington,"7th and Market streets",1,0,N/A
+755775,"January 17, 2017",Delaware,Wilmington,"200 block of N Rodney St",0,1,N/A
+753084,"January 16, 2017",Delaware,Greenwood,"Unity Ln",0,1,N/A
+1538240,"January 16, 2017",Delaware,Wilmington,"E 22nd St and N Spruce St",0,1,N/A
+751257,"January 15, 2017",Delaware,Wilmington,"2200 block of N Church St",0,1,N/A
+751222,"January 15, 2017",Delaware,Wilmington,"1400 block of Northeast Blvd",0,1,N/A
+750823,"January 14, 2017",Delaware,Wilmington,"2200 block of Lamotte St",1,0,N/A
+760324,"January 13, 2017",Delaware,"Rehoboth Beach","1900 block of Duffy St",0,1,N/A
+747867,"January 11, 2017",Delaware,Wilmington,"100 block of E 14th St",1,0,N/A
+748642,"January 11, 2017",Delaware,Wilmington,"300 block of S. Jackson St.",0,3,N/A
+747875,"January 10, 2017",Delaware,Dover,"120 Haman Dr",1,0,N/A
+747170,"January 9, 2017",Delaware,Wilmington,"101 N Clayton St",1,0,N/A
+747177,"January 8, 2017",Delaware,Wilmington,"200 block of Porter St",1,0,N/A
+743757,"January 3, 2017",Delaware,Dover,"S. Queen St.",0,0,N/A
+742572,"January 3, 2017",Delaware,Wilmington,"7th Street and North Jackson Street",0,1,N/A
+741648,"January 1, 2017",Delaware,Harrington,"301 Dorman St",0,1,N/A
+737847,"December 30, 2016",Delaware,Magnolia,"Flint Dr",0,1,N/A
+1060765,"December 29, 2016",Delaware,Dover,"W North Street and Saulsbury Rd",0,0,N/A
+737837,"December 29, 2016",Delaware,"Seaford (Blades)","West 2nd St",0,0,N/A
+736908,"December 28, 2016",Delaware,Wilmington,"100 block of S Jackson St",0,1,N/A
+736910,"December 27, 2016",Delaware,Wilmington,"300 block of 9th Street",0,1,N/A
+735846,"December 27, 2016",Delaware,Laurel,"1000 block of Hollybrook Apartments",0,0,N/A
+733453,"December 23, 2016",Delaware,Dover,"Collins Drive",0,2,N/A
+730679,"December 20, 2016",Delaware,Wilmington,"1000 block of Linda Rd",1,0,N/A
+729961,"December 18, 2016",Delaware,Milford,"Southwest Front Street",0,0,N/A
+724865,"December 13, 2016",Delaware,Wilmington,"200 block of W. 30th Street",0,0,N/A
+726392,"December 13, 2016",Delaware,Dover,"400 block of New Castle Avenue",0,0,N/A
+725882,"December 12, 2016",Delaware,Dover,"1400 block of South Farmview",0,1,N/A
+723549,"December 10, 2016",Delaware,Dover,"100 block of South New Street",0,2,N/A
+722345,"December 8, 2016",Delaware,Wilmington,"W. Fifth and N. Scott streets",0,1,N/A
+720529,"December 6, 2016",Delaware,Dover,"400 block of Aspen Drive",1,0,N/A
+719768,"December 5, 2016",Delaware,Wilmington,"22nd Street and Pine Street",0,1,N/A
+719761,"December 4, 2016",Delaware,Bear,"100 block of Garwood Drive",0,1,N/A
+717114,"December 1, 2016",Delaware,Wilmington,"2900 block of Baynard Blvd",0,1,N/A
+715258,"November 30, 2016",Delaware,"New Castle","Howell Drive and Daniel Lane",0,1,N/A
+717109,"November 30, 2016",Delaware,"New Castle","Deen and Pell Street",0,0,N/A
+714336,"November 28, 2016",Delaware,Millsboro,"25935 Plaza Drive",0,0,N/A
+714170,"November 28, 2016",Delaware,Dover,"South New Street",0,0,N/A
+713618,"November 28, 2016",Delaware,Wilmington,"22nd and Jefferson streets",1,0,N/A
+712811,"November 28, 2016",Delaware,Wilmington,"West 27th and North Van Buren streets",0,1,N/A
+717116,"November 27, 2016",Delaware,"Dover (Leipsic)","Walnut Street",0,0,N/A
+711670,"November 25, 2016",Delaware,Wilmington,"Seventh and Washington",0,0,N/A
+709617,"November 24, 2016",Delaware,Wilmington,"North Van Buren Street",0,1,N/A
+709141,"November 23, 2016",Delaware,Newark,"100 block of South Patrice Drive",0,2,N/A
+709139,"November 23, 2016",Delaware,Dover,"30 South New Street",0,0,N/A
+707305,"November 21, 2016",Delaware,Dover,"300 block of Martin St",0,0,N/A
+705687,"November 19, 2016",Delaware,Wilmington,"800 block of Morrow St.",1,0,N/A
+705053,"November 18, 2016",Delaware,Wilmington,"Cedar Ave and Maryland Avenue",0,2,N/A
+703122,"November 16, 2016",Delaware,Millsboro,"W Monroe St and Houston St",1,0,N/A
+702539,"November 16, 2016",Delaware,Wilmington,"Linden and S. Van Buren",0,1,N/A
+700986,"November 14, 2016",Delaware,Wilmington,"8th and N. Madison streets",0,1,N/A
+699363,"November 11, 2016",Delaware,Dover,"1st block of S. New Street",0,0,N/A
+698615,"November 9, 2016",Delaware,Bridgeville,"2000 block of Windy Lane",0,0,N/A
+696569,"November 8, 2016",Delaware,Claymont,"200 block of Dewey Court",1,0,N/A
+697136,"November 8, 2016",Delaware,Dover,"South New and Reed streets",0,0,N/A
+697132,"November 7, 2016",Delaware,Wilmington,"2152 Melson Rd",0,0,N/A
+694687,"November 6, 2016",Delaware,Bear,"US 40 and Brookmont Dr",0,0,N/A
+694259,"November 6, 2016",Delaware,Newark,"100 block of Flamingo Dr",0,1,N/A
+697145,"November 5, 2016",Delaware,Seaford,"100 block of Woodland Mills",0,0,N/A
+697751,"November 3, 2016",Delaware,Dover,"Kenton Road and College Road",0,0,N/A
+697748,"November 3, 2016",Delaware,Dover,"Cooper Road",0,0,N/A
+692082,"November 3, 2016",Delaware,Wilmington,"409 W 25th St",0,1,N/A
+692556,"November 3, 2016",Delaware,Wilmington,"600 block of N. Madison St",0,0,N/A
+693267,"November 2, 2016",Delaware,Wilmington,"1000 block of N. Church Street",0,0,N/A
+692319,"November 2, 2016",Delaware,Wilmington,"1200 block of Lancaster Ave",0,1,N/A
+692092,"November 2, 2016",Delaware,Wilmington,"1300 block of Chestnut St",0,1,N/A
+692090,"November 2, 2016",Delaware,Wilmington,"1300 block of Chestnut St",0,1,N/A
+691326,"November 1, 2016",Delaware,Wilmington,"200 block of E. 24th St.",1,0,N/A
+690282,"October 31, 2016",Delaware,"New Castle","Revelle Street and Baylis Street",0,1,N/A
+686274,"October 26, 2016",Delaware,Wilmington,"500 block of W. 25th St",0,2,N/A
+684541,"October 25, 2016",Delaware,Dover,"400 block of New Castle Ave",0,1,N/A
+685121,"October 25, 2016",Delaware,Middletown,"500 block of New Street",0,1,N/A
+683784,"October 24, 2016",Delaware,Dover,"500 block of River Road",1,0,N/A
+683027,"October 24, 2016",Delaware,Newark,"100 Christiana Mall Road",0,0,N/A
+683023,"October 23, 2016",Delaware,"Wilmington (Newport)","500 block of Jackson Ave",0,1,N/A
+680304,"October 20, 2016",Delaware,Wilmington,"Fourth and North Madison streets",0,1,N/A
+681681,"October 20, 2016",Delaware,"New Castle","50 block of Highland Blvd",0,1,N/A
+681690,"October 20, 2016",Delaware,Wilmington,"1600 block of West 3rd Street",0,0,N/A
+681688,"October 20, 2016",Delaware,Milton,"West Springside Drive",0,1,N/A
+679897,"October 19, 2016",Delaware,Wilmington,"2600 block of N. West St",0,1,N/A
+680310,"October 18, 2016",Delaware,Wilmington,"499 Bethune Dr",0,1,N/A
+679038,"October 17, 2016",Delaware,Wilmington,"1000 block of Clayton Road",0,0,N/A
+679044,"October 16, 2016",Delaware,Dover,"1400 block of Forrest Ave",0,1,N/A
+679042,"October 16, 2016",Delaware,Wilmington,"1500 block of W. Fourth St",0,0,N/A
+677268,"October 15, 2016",Delaware,"Rehoboth Beach","Wolfe Neck Road",0,1,N/A
+677749,"October 14, 2016",Delaware,Wilmington,"W. Third St. and N. Clayton St.",0,1,N/A
+674414,"October 11, 2016",Delaware,Wilmington,"3100 block of N. Harrison St.",0,1,N/A
+673762,"October 10, 2016",Delaware,Wilmington,"W 9th St and N West St",0,1,N/A
+673765,"October 10, 2016",Delaware,Dover,"100 block of W. Loockerman St",0,0,N/A
+672889,"October 9, 2016",Delaware,Wilmington,"W 22nd St",0,1,N/A
+672887,"October 8, 2016",Delaware,Felton,"Walnut Shade Rd and S DuPont Hwy",0,0,N/A
+673757,"October 8, 2016",Delaware,"Wilmington (Stanton)","500 block of Sixth Ave",0,0,N/A
+670047,"October 4, 2016",Delaware,Harbeson,"25000 block of Hollis Road",0,0,N/A
+669393,"October 3, 2016",Delaware,Newark,"20 block of Gogh Cir",0,1,N/A
+668667,"October 3, 2016",Delaware,Wilmington,"700 block of E. 10th St",0,1,N/A
+669015,"October 3, 2016",Delaware,Newark,"Gogh Circle and Ruebens Circle",0,1,N/A
+668615,"October 2, 2016",Delaware,Wilmington,"1200 block of Elm Street",0,0,N/A
+668609,"October 2, 2016",Delaware,"New Castle","100 block of Jillian's Way",0,1,N/A
+668624,"September 30, 2016",Delaware,Newark,"300 block of Auckland Drive",0,1,N/A
+665049,"September 27, 2016",Delaware,Dover,"Leipsic Road",0,0,N/A
+662956,"September 24, 2016",Delaware,Bear,"U.S. 40",0,0,N/A
+659412,"September 20, 2016",Delaware,Wilmington,"1500 block of West 3rd Street",0,1,N/A
+660092,"September 20, 2016",Delaware,Wilmington,"200 block of East 14th Street",0,1,N/A
+657805,"September 18, 2016",Delaware,Wilmington,"200 block of W 20th St",1,1,N/A
+657958,"September 16, 2016",Delaware,Wilmington,"2700 block of West St.",0,2,N/A
+657517,"September 16, 2016",Delaware,Wilmington,"900 block of N Pine St",0,0,N/A
+657502,"September 15, 2016",Delaware,Dover,"1700 N Dupont Hwy",0,0,N/A
+655198,"September 14, 2016",Delaware,Wilmington,"2600 block of North Market Street",0,1,N/A
+656351,"September 14, 2016",Delaware,Millsboro,"20000 block of Miller Drive",0,1,N/A
+654286,"September 11, 2016",Delaware,"New Castle","100 block of N.Dupont Highway",0,0,N/A
+652981,"September 11, 2016",Delaware,"New Castle","500 block of S. DuPont Highway",0,1,N/A
+652983,"September 10, 2016",Delaware,"New Castle","DE-273 and Airport Rd",0,1,N/A
+650907,"September 8, 2016",Delaware,"New Castle","50 block of Morris Rd",0,1,N/A
+649012,"September 5, 2016",Delaware,"New Castle","300 block of Wildel Ave",0,1,N/A
+647723,"September 3, 2016",Delaware,Wilmington,"200 block of N. Franklin St.",0,1,N/A
+647716,"September 3, 2016",Delaware,Wilmington,"50 block of W 27th St",0,1,N/A
+647711,"September 3, 2016",Delaware,"New Castle",N/A,0,1,N/A
+646713,"September 1, 2016",Delaware,Wilmington,"300 block of W. 24th Street",0,1,N/A
+645022,"September 1, 2016",Delaware,Wilmington,"West 27th Street",0,3,N/A
+646127,"August 31, 2016",Delaware,Dover,"River Road and Water Street",0,0,N/A
+647726,"August 30, 2016",Delaware,Wilmington,"10th and Spruce streets",0,0,N/A
+642964,"August 29, 2016",Delaware,Wilmington,"500 block of W Sixth St",0,1,N/A
+640343,"August 26, 2016",Delaware,Wilmington,"Lea Blvd and N Market St",0,1,N/A
+639517,"August 25, 2016",Delaware,Wilmington,"700  S. Vanburen Street",0,1,N/A
+637934,"August 23, 2016",Delaware,Wilmington,"27th and N. Tatnall streets",0,1,N/A
+636999,"August 22, 2016",Delaware,Wilmington,"500 block of W. 31st St",0,1,N/A
+635091,"August 21, 2016",Delaware,Wilmington,"1200 block of Elm St.",0,1,N/A
+636757,"August 21, 2016",Delaware,Dover,"300 block of Charring Cross Rd",0,0,N/A
+633849,"August 18, 2016",Delaware,Dover,"100 block of South Queen Street",1,0,N/A
+632869,"August 17, 2016",Delaware,Wilmington,"31st and North West streets",0,1,N/A
+632871,"August 16, 2016",Delaware,Dover,"River Road and New Castle Avenue",0,0,N/A
+630459,"August 15, 2016",Delaware,Wilmington,"3800 block of N. Market St.",0,0,N/A
+630456,"August 15, 2016",Delaware,Wilmington,"600 block of W. Sixth St.",0,1,N/A
+631476,"August 15, 2016",Delaware,"New Castle","700 block of Center St",0,0,N/A
+629733,"August 14, 2016",Delaware,Wilmington,"500 block of W. 38th Street",0,1,N/A
+630463,"August 13, 2016",Delaware,Dover,"200 block of Bradley Road",0,0,N/A
+629393,"August 13, 2016",Delaware,Wilmington,"1600 block of West Third Street",0,1,N/A
+629164,"August 13, 2016",Delaware,"New Castle","44 Birkshire Rd",0,1,N/A
+629090,"August 13, 2016",Delaware,Lincoln,"10000 block of Crescent Shores Drive",0,1,N/A
+626478,"August 10, 2016",Delaware,"Wilmington (Elsmere)","131 Scarborough Park",0,1,N/A
+623234,"August 6, 2016",Delaware,Dover,"100 block of Holmes Street",0,1,N/A
+623513,"August 6, 2016",Delaware,Wilmington,"Burnside Blvd and Newport Gap Pk",0,1,N/A
+624714,"August 4, 2016",Delaware,Wilmington,"300 block of  E. 23rd St.",0,0,N/A
+621571,"August 3, 2016",Delaware,Dover,"100 block of Madison Court",0,0,N/A
+620582,"August 2, 2016",Delaware,Wilmington,"9th and Spruce streets",0,1,N/A
+618053,"July 31, 2016",Delaware,Wilmington,"2600 block of N. Market Street",0,1,N/A
+618821,"July 31, 2016",Delaware,Wilmington,"400 block of Concord Ave",0,1,N/A
+616180,"July 29, 2016",Delaware,Dover,"Stevenson Drive",0,0,N/A
+615416,"July 27, 2016",Delaware,Wilmington,"100 block of E. 27th St",0,1,N/A
+612770,"July 24, 2016",Delaware,Dover,"51 Webbs Lane",0,0,N/A
+610490,"July 23, 2016",Delaware,Wilmington,"1300 West 5th Street",0,1,N/A
+611552,"July 23, 2016",Delaware,Wilmington,"3500 block of N. Church St.",0,1,N/A
+610513,"July 22, 2016",Delaware,Wilmington,"4021 Kennett Pike",0,0,N/A
+606949,"July 18, 2016",Delaware,"New Castle","260 Christiana Road",2,0,N/A
+606626,"July 18, 2016",Delaware,Wilmington,"Third Street",1,0,N/A
+616174,"July 18, 2016",Delaware,Milford,"Big Stone Beach Road",0,0,N/A
+606945,"July 18, 2016",Delaware,Wilmington,"700 block of E 11th St",1,0,N/A
+605400,"July 15, 2016",Delaware,Harrington,"Milford Harrington Highway",0,0,N/A
+603328,"July 13, 2016",Delaware,Newark,"1300 block of Greentree Rd",0,2,N/A
+601519,"July 12, 2016",Delaware,Wilmington,"200 block of W. 23rd St.",0,2,N/A
+601526,"July 9, 2016",Delaware,Newark,"First block of Baywatch Road",0,0,N/A
+599765,"July 9, 2016",Delaware,Wilmington,"West Fourth and North Jefferson Streets",0,1,N/A
+598995,"July 9, 2016",Delaware,"New Castle","600 block of Country Path Dr",1,0,N/A
+598988,"July 8, 2016",Delaware,Wilmington,"600 block of W. Sixth St",0,2,N/A
+602620,"July 8, 2016",Delaware,Wilmington,N/A,0,2,N/A
+597490,"July 6, 2016",Delaware,Bear,"700 block of Red Clay Drive",0,1,N/A
+595792,"July 5, 2016",Delaware,Dover,"200 block of Stardust Drive",0,1,N/A
+596804,"July 5, 2016",Delaware,Newark,"Raven Turn",0,1,N/A
+595796,"July 4, 2016",Delaware,Wilmington,"Sherman Street and Clifford Brown Walk",0,1,N/A
+594974,"July 3, 2016",Delaware,Wilmington,"East 10th and Spruce streets",0,1,N/A
+594152,"July 2, 2016",Delaware,Wilmington,"300 block of North Lincoln Street",0,1,N/A
+594475,"July 2, 2016",Delaware,Wilmington,"221 Chestnut Avenue",2,0,N/A
+595786,"July 1, 2016",Delaware,Wilmington,"300 block of E. 5th St.",0,0,N/A
+594150,"July 1, 2016",Delaware,Smyrna,"Providence Drive",0,0,N/A
+590815,"June 28, 2016",Delaware,Wilmington,"800 block of N. Adams St.",0,1,N/A
+589808,"June 27, 2016",Delaware,Newark,"400 block of N Barrett Ln",0,0,N/A
+590820,"June 27, 2016",Delaware,Wilmington,"1300 block of N. Walnut St",0,1,N/A
+590887,"June 27, 2016",Delaware,Frederica,"S DE-1",1,0,N/A
+589790,"June 26, 2016",Delaware,Wilmington,"27th and Moore streets",0,1,N/A
+589797,"June 26, 2016",Delaware,Wilmington,"900 block of N Spruce St",1,0,N/A
+588086,"June 24, 2016",Delaware,Newark,"2102 Ashkirk Drive",1,0,N/A
+586092,"June 22, 2016",Delaware,Wilmington,"Northeast Boulevard and East 30th Street",0,1,N/A
+583267,"June 18, 2016",Delaware,Wilmington,"900 block of North Pine Street",1,0,N/A
+580848,"June 14, 2016",Delaware,Wilmington,"South Van Buren and Elm streets",0,4,N/A

--- a/data/participants/2013-02-11 - 2016-07-09.csv
+++ b/data/participants/2013-02-11 - 2016-07-09.csv
@@ -1,0 +1,1333 @@
+"Incident Date",State,"City Or County",Address,"Participant Gender","Participant Name","Participant Age Group",Operations
+"July 9, 2016",Delaware,Wilmington,"West Fourth and North Jefferson Streets",male,N/A,"Adult 18+",N/A
+"July 9, 2016",Delaware,"New Castle","600 block of Country Path Dr",male,"Malcolm Evans","Adult 18+",N/A
+"July 9, 2016",Delaware,"New Castle","600 block of Country Path Dr",female,"Cheryl Jennings","Adult 18+",N/A
+"July 8, 2016",Delaware,Wilmington,"600 block of W. Sixth St",male,N/A,"Teen 12-17",N/A
+"July 8, 2016",Delaware,Wilmington,"600 block of W. Sixth St",female,N/A,"Adult 18+",N/A
+"July 8, 2016",Delaware,Wilmington,N/A,male,N/A,"Teen 12-17",N/A
+"July 8, 2016",Delaware,Wilmington,N/A,female,N/A,"Adult 18+",N/A
+"July 8, 2016",Delaware,Wilmington,N/A,N/A,N/A,Unknown,N/A
+"July 8, 2016",Delaware,Wilmington,N/A,male,N/A,"Teen 12-17",N/A
+"July 6, 2016",Delaware,Bear,"700 block of Red Clay Drive",male,N/A,"Adult 18+",N/A
+"July 5, 2016",Delaware,Dover,"200 block of Stardust Drive",male,N/A,"Adult 18+",N/A
+"July 5, 2016",Delaware,Newark,"Raven Turn",male,N/A,"Adult 18+",N/A
+"July 4, 2016",Delaware,Wilmington,"Sherman Street and Clifford Brown Walk",male,N/A,"Teen 12-17",N/A
+"July 3, 2016",Delaware,Wilmington,"East 10th and Spruce streets",male,N/A,"Adult 18+",N/A
+"July 2, 2016",Delaware,Wilmington,"300 block of North Lincoln Street",male,N/A,"Adult 18+",N/A
+"July 2, 2016",Delaware,Wilmington,"221 Chestnut Avenue",female,"Nicole Shaw","Adult 18+",N/A
+"July 2, 2016",Delaware,Wilmington,"221 Chestnut Avenue",male,"Walter Shaw","Adult 18+",N/A
+"July 1, 2016",Delaware,Smyrna,"Providence Drive",male,"Steffen Forrest","Adult 18+",N/A
+"June 28, 2016",Delaware,Wilmington,"800 block of N. Adams St.",male,N/A,"Adult 18+",N/A
+"June 27, 2016",Delaware,Newark,"400 block of N Barrett Ln",male,N/A,"Adult 18+",N/A
+"June 27, 2016",Delaware,Newark,"400 block of N Barrett Ln",male,N/A,"Adult 18+",N/A
+"June 27, 2016",Delaware,Wilmington,"1300 block of N. Walnut St",male,N/A,"Adult 18+",N/A
+"June 27, 2016",Delaware,Frederica,"S DE-1",male,"Raymond A. Hutson","Adult 18+",N/A
+"June 26, 2016",Delaware,Wilmington,"27th and Moore streets",male,N/A,"Teen 12-17",N/A
+"June 26, 2016",Delaware,Wilmington,"900 block of N Spruce St",male,"Brian Wilson","Adult 18+",N/A
+"June 26, 2016",Delaware,Wilmington,"900 block of N Spruce St",male,"Allen Cannon","Adult 18+",N/A
+"June 26, 2016",Delaware,Wilmington,"900 block of N Spruce St",male,"Eric Ray","Adult 18+",N/A
+"June 24, 2016",Delaware,Newark,"2102 Ashkirk Drive",male,"Tyreek Larkins","Adult 18+",N/A
+"June 24, 2016",Delaware,Newark,"2102 Ashkirk Drive",male,N/A,Unknown,N/A
+"June 22, 2016",Delaware,Wilmington,"Northeast Boulevard and East 30th Street",male,N/A,"Adult 18+",N/A
+"June 18, 2016",Delaware,Wilmington,"900 block of North Pine Street",male,"Donald Tucker","Adult 18+",N/A
+"June 14, 2016",Delaware,Wilmington,"South Van Buren and Elm streets",female,N/A,"Teen 12-17",N/A
+"June 14, 2016",Delaware,Wilmington,"South Van Buren and Elm streets",male,N/A,"Teen 12-17",N/A
+"June 14, 2016",Delaware,Wilmington,"South Van Buren and Elm streets",male,N/A,"Teen 12-17",N/A
+"June 14, 2016",Delaware,Wilmington,"South Van Buren and Elm streets",male,N/A,"Teen 12-17",N/A
+"June 14, 2016",Delaware,Wilmington,"South Van Buren and Elm streets",N/A,N/A,Unknown,N/A
+"June 14, 2016",Delaware,Felton,"50 block of Weatherstone Ln",female,N/A,"Teen 12-17",N/A
+"June 14, 2016",Delaware,Felton,"50 block of Weatherstone Ln",male,N/A,"Adult 18+",N/A
+"June 13, 2016",Delaware,Wilmington,"200 block of South Harrison",male,N/A,"Adult 18+",N/A
+"June 12, 2016",Delaware,Newark,"700 block of Vining's Way",male,N/A,"Adult 18+",N/A
+"June 12, 2016",Delaware,Newark,"700 block of Vining's Way",male,N/A,"Adult 18+",N/A
+"June 11, 2016",Delaware,Wilmington,"1200 block of East 22nd Street",male,N/A,"Adult 18+",N/A
+"June 10, 2016",Delaware,Wilmington,"1200 block of Oak Street",male,N/A,"Teen 12-17",N/A
+"June 10, 2016",Delaware,Seaford,"Coverdale Road",male,"Dominique Hall","Adult 18+",N/A
+"June 7, 2016",Delaware,Wilmington,"50 block of Jensen Dr",male,"Charles White","Adult 18+",N/A
+"June 7, 2016",Delaware,Wilmington,"50 block of Jensen Dr",N/A,N/A,Unknown,N/A
+"June 6, 2016",Delaware,Wilmington,"800 block of Kirkwood Street",male,N/A,"Adult 18+",N/A
+"June 5, 2016",Delaware,Wilmington,"Concord Avenue and North Washington Street",male,N/A,"Adult 18+",N/A
+"June 3, 2016",Delaware,Wilmington,"900 block of Martin Luther King Boulevard",male,N/A,"Teen 12-17",N/A
+"June 2, 2016",Delaware,Wilmington,"Maryland Avenue and Robinson Lane",male,N/A,"Adult 18+",N/A
+"June 2, 2016",Delaware,Wilmington,"700 block of S. Van Buren St",male,N/A,"Teen 12-17",N/A
+"June 1, 2016",Delaware,Dover,"1000 block of S. Bradford St",female,N/A,"Adult 18+",N/A
+"June 1, 2016",Delaware,Dover,"1000 block of S. Bradford St",male,"Jason Scott","Adult 18+",N/A
+"May 31, 2016",Delaware,Dover,"1300 block of S. Farmview Drive",male,"Joseph Wilson","Adult 18+",N/A
+"May 31, 2016",Delaware,Dover,"1300 block of S. Farmview Drive",female,"Monica Lewis","Adult 18+",N/A
+"May 28, 2016",Delaware,Wilmington,"2600 block of Bowers St",male,N/A,"Adult 18+",N/A
+"May 26, 2016",Delaware,Dover,"100 block of Cherry Street",male,"Kevin Wayman Jr","Adult 18+",N/A
+"May 25, 2016",Delaware,Claymont,"2705 Philadelphia Pike",male,N/A,Unknown,N/A
+"May 25, 2016",Delaware,Dover,"First block of Webbs Lane",male,N/A,"Adult 18+",N/A
+"May 25, 2016",Delaware,Claymont,"2705 Philadelphia Pike",male,N/A,"Adult 18+",N/A
+"May 25, 2016",Delaware,Claymont,"2705 Philadelphia Pike",male,N/A,"Adult 18+",N/A
+"May 24, 2016",Delaware,Wilmington,"200 block of S. Harrison Street",male,N/A,"Adult 18+",N/A
+"May 24, 2016",Delaware,Wilmington,"200 block of S. Harrison Street",male,N/A,"Adult 18+",N/A
+"May 24, 2016",Delaware,"New Castle","50 block of W Balbach Ave",male,N/A,"Adult 18+",N/A
+"May 21, 2016",Delaware,Seaford,"22000 block of Coverdale Road",male,"Jeremy A. Cannon","Adult 18+",N/A
+"May 19, 2016",Delaware,Wilmington,"900 block of Clifford Brown Walk",male,"Brandon Wingo","Teen 12-17",N/A
+"May 19, 2016",Delaware,Wilmington,"900 block of Clifford Brown Walk",male,"Zaahir Smith","Adult 18+",N/A
+"May 19, 2016",Delaware,Wilmington,"900 block of Clifford Brown Walk",male,"Diamonte Taylor","Adult 18+",N/A
+"May 19, 2016",Delaware,Wilmington,"900 block of Clifford Brown Walk",male,"Kevon Harris-Dickerson","Adult 18+",N/A
+"May 19, 2016",Delaware,Wilmington,"900 block of Clifford Brown Walk",female,"Latasha Pierce","Adult 18+",N/A
+"May 18, 2016",Delaware,Wilmington,"1600 block of Thatcher St",male,N/A,"Adult 18+",N/A
+"May 18, 2016",Delaware,Wilmington,"1600 block of Thatcher St",male,"Zaahir Smith","Adult 18+",N/A
+"May 18, 2016",Delaware,Wilmington,"1600 block of Thatcher St",male,"Diamonte Taylor","Adult 18+",N/A
+"May 17, 2016",Delaware,Dover,"South Kirkwood and Division streets",male,"Dexter Brown","Adult 18+",N/A
+"May 17, 2016",Delaware,Wilmington,"Beech and South Van Buren Streets",male,N/A,"Adult 18+",N/A
+"May 16, 2016",Delaware,Wilmington,"1000 block of N. Lombard St.",male,N/A,"Teen 12-17",N/A
+"May 16, 2016",Delaware,Middletown,"Marl Pit Road",male,"Kyair Benson","Adult 18+",N/A
+"May 15, 2016",Delaware,Wilmington,"600 block of W. Sixth St.",female,N/A,"Adult 18+",N/A
+"May 15, 2016",Delaware,Dover,"Fulton Street",female,N/A,"Adult 18+",N/A
+"May 15, 2016",Delaware,Dover,"Fulton Street",male,N/A,"Adult 18+",N/A
+"May 14, 2016",Delaware,Dover,"East Water Street and New Castle Avenue",male,N/A,"Teen 12-17",N/A
+"May 14, 2016",Delaware,Dover,"East Water Street and New Castle Avenue",male,N/A,"Teen 12-17",N/A
+"May 11, 2016",Delaware,Milford,"300 Aurora Place",male,N/A,"Adult 18+",N/A
+"May 9, 2016",Delaware,Wilmington,"N Market St and 23rd St",male,N/A,"Teen 12-17",N/A
+"May 8, 2016",Delaware,Wilmington,"100 block of South Franklin Street",female,N/A,"Adult 18+",N/A
+"May 8, 2016",Delaware,Wilmington,"100 block of South Franklin Street",male,"Nykere Jackson","Adult 18+",N/A
+"May 7, 2016",Delaware,Dover,"900 block of Janeka Lane",male,N/A,"Adult 18+",N/A
+"May 7, 2016",Delaware,Dover,"900 block of Janeka Lane",male,"Caleb Mason","Adult 18+",N/A
+"May 7, 2016",Delaware,Wilmington,"North Market and 27th streets",male,N/A,"Adult 18+",N/A
+"May 7, 2016",Delaware,Wilmington,"North Market and 27th streets",female,N/A,"Adult 18+",N/A
+"May 7, 2016",Delaware,Wilmington,"W 3rd St and N Rodney St",male,"Terrance Kinard","Adult 18+",N/A
+"May 3, 2016",Delaware,Wilmington,"600 block of N. Madison St",male,N/A,"Teen 12-17",N/A
+"May 2, 2016",Delaware,"Wilmington (Edgemoor)","Rysing Dr and N Cannon Dr",N/A,N/A,"Adult 18+",N/A
+"May 2, 2016",Delaware,"Wilmington (Edgemoor)","Rysing Dr and N Cannon Dr",N/A,N/A,"Adult 18+",N/A
+"April 30, 2016",Delaware,Dover,"North DuPont Highway and Lake View Drive",male,"Allen Durham","Adult 18+",N/A
+"April 29, 2016",Delaware,Dover,"200 block of Acorn Lane",male,"Taylor Heesh","Adult 18+",N/A
+"April 26, 2016",Delaware,"New Castle","100 block of Freedom Trail",female,"Lauren Steed","Adult 18+",N/A
+"April 26, 2016",Delaware,"New Castle","100 block of Freedom Trail",male,"Brian Goodwin","Adult 18+",N/A
+"April 26, 2016",Delaware,Dover,"Queen and Reed streets",male,N/A,"Teen 12-17",N/A
+"April 26, 2016",Delaware,Dover,"Queen and Reed streets",N/A,N/A,Unknown,N/A
+"April 25, 2016",Delaware,Wilmington,"400 block of Anderson Dr",male,"Tymere Bailey","Adult 18+",N/A
+"April 22, 2016",Delaware,Townsend,"500 block of Dogtown Rd",male,"Joshua James","Adult 18+",N/A
+"April 22, 2016",Delaware,Townsend,"500 block of Dogtown Rd",male,"Jamar L Waters","Adult 18+",N/A
+"April 22, 2016",Delaware,Townsend,"500 block of Dogtown Rd",male,"Sylvester E Gould Jr","Adult 18+",N/A
+"April 21, 2016",Delaware,Wilmington,"400 block of W 3rd St",N/A,N/A,"Teen 12-17",N/A
+"April 16, 2016",Delaware,Wilmington,"10th and Bennett streets",male,"Shamir Rice","Adult 18+",N/A
+"April 15, 2016",Delaware,Bear,"800 block of Seymour Road",female,N/A,"Adult 18+",N/A
+"April 14, 2016",Delaware,Magnolia,"100 block of Terry Dr",male,"William J. Preston","Adult 18+",N/A
+"April 14, 2016",Delaware,Magnolia,"100 block of Terry Dr",male,"Keith J. Maye","Adult 18+",N/A
+"April 14, 2016",Delaware,Magnolia,"100 block of Terry Dr",male,"David Preston","Adult 18+",N/A
+"April 8, 2016",Delaware,"New Castle","Simmonds Drive",male,"Lamonte Butler","Adult 18+",N/A
+"April 4, 2016",Delaware,Wilmington,"400 block of Maryland Ave.",male,N/A,"Adult 18+",N/A
+"April 1, 2016",Delaware,Wilmington,"800 block of N. Pine St.",male,"Shurkri Brown","Adult 18+",N/A
+"April 1, 2016",Delaware,Wilmington,"800 block of N. Pine St.",male,"Stanley Taylor","Adult 18+",N/A
+"April 1, 2016",Delaware,Wilmington,"3806 Governor Printz Blvd",male,"Nathaniel Mangrum","Adult 18+",N/A
+"April 1, 2016",Delaware,Wilmington,"3806 Governor Printz Blvd",male,"Keivese Tolbert","Adult 18+",N/A
+"April 1, 2016",Delaware,Wilmington,"3806 Governor Printz Blvd",male,"Tyerin Griffin","Adult 18+",N/A
+"March 30, 2016",Delaware,"New Castle","Centerville Road",male,N/A,"Teen 12-17",N/A
+"March 30, 2016",Delaware,"New Castle","3000 block of New Castle Avenue",male,N/A,"Adult 18+",N/A
+"March 30, 2016",Delaware,Wilmington,"1100 block of Elm St",male,"Jason C Hicks","Adult 18+",N/A
+"March 30, 2016",Delaware,Wilmington,"1100 block of Elm St",male,"Joseph Hunt","Adult 18+",N/A
+"March 30, 2016",Delaware,Wilmington,"1100 block of Elm St",male,"Durrion Morrison","Adult 18+",N/A
+"March 30, 2016",Delaware,Dover,"2300 block of Port Mahon Rd",male,"Dontray Hendricks","Adult 18+",N/A
+"March 30, 2016",Delaware,Dover,"2300 block of Port Mahon Rd",male,"Daiquan T. Bordley","Adult 18+",N/A
+"March 30, 2016",Delaware,Dover,"2300 block of Port Mahon Rd",male,"Zhyhee Y. Harmon","Adult 18+",N/A
+"March 30, 2016",Delaware,Dover,"2300 block of Port Mahon Rd",female,"Chelsea Braunskill","Adult 18+",N/A
+"March 28, 2016",Delaware,Dover,"Reese and Lincoln streets",male,"Giovanni Echevarria","Adult 18+",N/A
+"March 28, 2016",Delaware,Wilmington,"12th Street and Northeast Boulevard",male,N/A,"Adult 18+",N/A
+"March 27, 2016",Delaware,Wilmington,"28th and Market streets",N/A,N/A,"Adult 18+",N/A
+"March 27, 2016",Delaware,Wilmington,"2700 block of N. Pine Street",N/A,N/A,Unknown,N/A
+"March 27, 2016",Delaware,Harrington,"300 block of Flat Iron Rd",male,N/A,"Adult 18+",N/A
+"March 23, 2016",Delaware,Dover,"Cecil and New Streets",male,N/A,"Adult 18+",N/A
+"March 22, 2016",Delaware,Wilmington,"600 block of North Jefferson Street",female,N/A,"Adult 18+",N/A
+"March 22, 2016",Delaware,Wilmington,"400 block of Porter St.",male,N/A,"Adult 18+",N/A
+"March 22, 2016",Delaware,Dover,"North Kirkwood Street",male,N/A,"Teen 12-17",N/A
+"March 22, 2016",Delaware,Dover,"North Kirkwood Street",male,N/A,"Adult 18+",N/A
+"March 20, 2016",Delaware,Newark,"268 Cornell Dr",female,N/A,"Adult 18+",N/A
+"March 19, 2016",Delaware,Wilmington,"300 block of New Castle Ave",male,N/A,"Teen 12-17",N/A
+"March 17, 2016",Delaware,Wilmington,"200 block of Franklin St",male,N/A,"Teen 12-17",N/A
+"March 17, 2016",Delaware,Wilmington,"200 block of N Connell St",male,"Christian Serrano","Adult 18+",N/A
+"March 17, 2016",Delaware,Wilmington,"200 block of N Connell St",N/A,"Jose Moreta","Adult 18+",N/A
+"March 17, 2016",Delaware,Wilmington,"200 block of N Connell St",male,"Joshua Gonzales","Adult 18+",N/A
+"March 16, 2016",Delaware,Wilmington,"1100 block of Lorewood Grove Road",male,"William Cooke","Adult 18+",N/A
+"March 16, 2016",Delaware,Wilmington,"800 block of Morrow St.",male,N/A,"Adult 18+",N/A
+"March 16, 2016",Delaware,Wilmington,"800 block of Morrow St.",male,N/A,"Adult 18+",N/A
+"March 15, 2016",Delaware,Wilmington,"Ninth and Spruce streets",male,N/A,"Adult 18+",N/A
+"March 15, 2016",Delaware,Wilmington,"1100 block of Lancaster Avenue",male,N/A,"Adult 18+",N/A
+"March 14, 2016",Delaware,Wilmington,"11th and Clifford Brown Walk",male,N/A,"Adult 18+",N/A
+"March 12, 2016",Delaware,Wilmington,"400 block of W. Seventh Street",male,N/A,"Adult 18+",N/A
+"March 11, 2016",Delaware,Wilmington,"600 block of Taylor St",male,"Ryan Schneese","Adult 18+",N/A
+"March 11, 2016",Delaware,Wilmington,"600 block of Taylor St",male,"Sha'Mir Sudler","Adult 18+",N/A
+"March 10, 2016",Delaware,Dover,"100 block of Westover Drive",male,N/A,"Teen 12-17",N/A
+"March 10, 2016",Delaware,Dover,"100 block of Westover Drive",male,N/A,"Teen 12-17",N/A
+"March 10, 2016",Delaware,Wilmington,"900 block of Bennett St",male,N/A,"Adult 18+",N/A
+"March 10, 2016",Delaware,Dover,"S. New and Division streets",male,"Kenneth DeShields","Adult 18+",N/A
+"March 9, 2016",Delaware,"New Castle","100 block of Covington Place",male,N/A,"Adult 18+",N/A
+"March 8, 2016",Delaware,Wilmington,"50 block of Gordon St",male,N/A,"Adult 18+",N/A
+"March 8, 2016",Delaware,Wilmington,"Taylor and Bennett streets",male,N/A,"Adult 18+",N/A
+"March 7, 2016",Delaware,Wilmington,"Seventh and Franklin streets",male,N/A,"Adult 18+",N/A
+"March 4, 2016",Delaware,Wilmington,"1200 block of West 7th Street",male,"Leroy Collins","Adult 18+",N/A
+"March 3, 2016",Delaware,Wilmington,"500 block of W. 6th St.",male,N/A,"Adult 18+",N/A
+"March 3, 2016",Delaware,Dover,"257 N Dupont Hwy",male,"Jason Westley","Adult 18+",N/A
+"March 3, 2016",Delaware,Wilmington,"500 block of West 6th Street",male,N/A,"Adult 18+",N/A
+"March 2, 2016",Delaware,Wilmington,"2100 block of Pine Street",male,"Jack Lassiter","Adult 18+",N/A
+"March 1, 2016",Delaware,Wilmington,"2900 block of Jessup Street",male,N/A,"Adult 18+",N/A
+"February 28, 2016",Delaware,"New Castle","50 block of Oakmont Dr",female,N/A,"Adult 18+",N/A
+"February 27, 2016",Delaware,Wilmington,"2100 block of North Pine Street",male,N/A,"Adult 18+",N/A
+"February 27, 2016",Delaware,Newark,"4140 Ogletown-Stanton Road",female,N/A,"Adult 18+",N/A
+"February 27, 2016",Delaware,Newark,"4140 Ogletown-Stanton Road",male,N/A,"Adult 18+",N/A
+"February 27, 2016",Delaware,Newark,"16 Chatham Ln",male,"Clifton Thompson","Adult 18+",N/A
+"February 27, 2016",Delaware,Newark,"16 Chatham Ln",male,"Reginald Waters","Adult 18+",N/A
+"February 26, 2016",Delaware,Wilmington,"1000 block of North Pine Street",male,"Sameir Handy","Adult 18+",N/A
+"February 26, 2016",Delaware,Wilmington,"1000 block of North Pine Street",male,"Adam Jablonski","Adult 18+",N/A
+"February 26, 2016",Delaware,Wilmington,"Shearman Street",male,N/A,"Adult 18+",N/A
+"February 26, 2016",Delaware,Wilmington,"800 block of North Pine Street",male,N/A,"Teen 12-17",N/A
+"February 25, 2016",Delaware,Dover,"200 block of S. Governors Boulevard",male,"Jason E. Mills","Adult 18+",N/A
+"February 23, 2016",Delaware,Wilmington,"200 block of North Madison Street",male,"Ronald Jackson","Adult 18+",N/A
+"February 21, 2016",Delaware,Dover,"West Reed Street",male,N/A,"Adult 18+",N/A
+"February 21, 2016",Delaware,Dover,"West Reed Street",male,N/A,"Adult 18+",N/A
+"February 21, 2016",Delaware,Dover,"West Reed Street",male,N/A,"Adult 18+",N/A
+"February 20, 2016",Delaware,Dover,"316 Fulton Street",male,N/A,"Adult 18+",N/A
+"February 20, 2016",Delaware,Dover,"316 Fulton Street",male,"Mahyoub Ali","Adult 18+",N/A
+"February 20, 2016",Delaware,Wilmington,"Madison Street",male,N/A,"Adult 18+",N/A
+"February 19, 2016",Delaware,Wilmington,"1900 block of Maryland Avenue",male,N/A,"Adult 18+",N/A
+"February 19, 2016",Delaware,Wilmington,"1900 block of Maryland Avenue",male,N/A,"Adult 18+",N/A
+"February 18, 2016",Delaware,Wilmington,"1300 block of Clifford Brown Walk",male,N/A,"Adult 18+",N/A
+"February 16, 2016",Delaware,Newark,"750 East Delaware Avenue",male,N/A,"Teen 12-17",N/A
+"February 13, 2016",Delaware,Wilmington,"1700 block of West Second Street",male,N/A,"Adult 18+",N/A
+"February 12, 2016",Delaware,Wilmington,"300 block of Clyde Street",male,"Stanley Evans","Adult 18+",N/A
+"February 12, 2016",Delaware,Wilmington,"300 block of Clyde Street",male,N/A,"Adult 18+",N/A
+"February 10, 2016",Delaware,Wilmington,"200 block of W. 30th St.",male,"Antoine Harris","Adult 18+",N/A
+"February 9, 2016",Delaware,Wilmington,"1100 block of Linden Street",male,"Kenneth Truitt","Adult 18+",N/A
+"February 9, 2016",Delaware,Wilmington,"1100 block of Linden Street",male,N/A,"Teen 12-17",N/A
+"February 9, 2016",Delaware,Wilmington,"200 block of West 29th Street",male,"Tymere Brown","Adult 18+",N/A
+"February 8, 2016",Delaware,Wilmington,"1100 block of W. Second St.",female,N/A,"Teen 12-17",N/A
+"February 8, 2016",Delaware,"New Castle","128 N Dupont Hwy",male,"Eric Pearson","Adult 18+",N/A
+"February 7, 2016",Delaware,Bridgeville,"Apple Tree Road",female,N/A,"Adult 18+",N/A
+"February 7, 2016",Delaware,Bridgeville,"Apple Tree Road",male,N/A,"Adult 18+",N/A
+"February 7, 2016",Delaware,Bridgeville,"Apple Tree Road",female,N/A,"Child 0-11",N/A
+"February 5, 2016",Delaware,Wilmington,"Hay Road",male,"Keith Covington","Adult 18+",N/A
+"February 5, 2016",Delaware,Wilmington,"Hay Road",male,"Andre Harding","Adult 18+",N/A
+"February 5, 2016",Delaware,Wilmington,"Hay Road",N/A,N/A,"Adult 18+",N/A
+"February 5, 2016",Delaware,Wilmington,"Hay Road",N/A,N/A,"Teen 12-17",N/A
+"February 3, 2016",Delaware,Dover,"Barrister Place",male,"Zhamir Cooper-Watson","Adult 18+",N/A
+"January 29, 2016",Delaware,Dover,"800 block of Lincoln Street",female,"Nechole Seymour","Adult 18+",N/A
+"January 29, 2016",Delaware,Dover,"800 block of Lincoln Street",male,"Robert Cole","Adult 18+",N/A
+"January 28, 2016",Delaware,Wilmington,"25th Street",male,"Timothy Czeiner","Adult 18+",N/A
+"January 28, 2016",Delaware,Wilmington,"2500 block of West Street",male,"Tarail McDuffie","Adult 18+",N/A
+"January 27, 2016",Delaware,"New Castle","Wilton Blvd",male,N/A,"Adult 18+",N/A
+"January 26, 2016",Delaware,Wilmington,"2200 block of Jessup Street",male,N/A,"Adult 18+",N/A
+"January 26, 2016",Delaware,Wilmington,"2200 block of Jessup Street",male,N/A,"Adult 18+",N/A
+"January 26, 2016",Delaware,Wilmington,"2200 block of Jessup Street",male,N/A,"Adult 18+",N/A
+"January 25, 2016",Delaware,Wilmington,"West 36th Street",male,"Malik Willingham","Adult 18+",N/A
+"January 21, 2016",Delaware,Dover,"Greenhill Avenue and White Oak Road",female,"Gabriella Rivera","Adult 18+",N/A
+"January 21, 2016",Delaware,Dover,"Greenhill Avenue and White Oak Road",male,N/A,"Teen 12-17",N/A
+"January 21, 2016",Delaware,Dover,"Greenhill Avenue and White Oak Road",male,N/A,"Teen 12-17",N/A
+"January 20, 2016",Delaware,Wilmington,"27th Street and Bowers Street",male,N/A,"Teen 12-17",N/A
+"January 13, 2016",Delaware,Wilmington,"1200 block of N. Locust St",male,"Therman Redden","Adult 18+",N/A
+"January 12, 2016",Delaware,Dover,"211 Delaware Avenue",male,"Aaron Carillo","Teen 12-17",N/A
+"January 12, 2016",Delaware,Dover,"211 Delaware Avenue",male,"Nasir Bush","Teen 12-17",N/A
+"January 11, 2016",Delaware,Wilmington,"900 block of Brown Street",male,"Ira Brown","Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"900 block of Brown Street",female,N/A,"Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"900 block of Brown Street",male,N/A,"Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"900 block of Brown Street",male,N/A,"Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"900 block of Brown Street",male,N/A,"Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"1800 block of West Second Street",male,N/A,"Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"1800 block of West Second Street",male,N/A,"Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"1800 block of West Second Street",male,N/A,"Adult 18+",N/A
+"January 8, 2016",Delaware,Dover,"2600 block of South State Street",male,N/A,"Adult 18+",N/A
+"January 8, 2016",Delaware,Dover,"2600 block of South State Street",male,N/A,"Adult 18+",N/A
+"January 7, 2016",Delaware,Bridgeville,"2000 block of Conrail Street",male,"James F. Dickerson","Adult 18+",N/A
+"January 7, 2016",Delaware,Dover,"Churchmans Road",male,"Lateef Dickerson","Adult 18+",N/A
+"January 7, 2016",Delaware,Dover,"Churchmans Road",male,"Taron Hampton","Adult 18+",N/A
+"January 7, 2016",Delaware,Dover,"Churchmans Road",male,"Von Smith","Adult 18+",N/A
+"January 3, 2016",Delaware,Wilmington,"600 block of West Fifth St.",male,N/A,"Adult 18+",N/A
+"January 3, 2016",Delaware,Newark,"50 block of Mercer Dr",male,N/A,"Adult 18+",N/A
+"January 3, 2016",Delaware,Newark,"50 block of Mercer Dr",N/A,N/A,"Adult 18+",N/A
+"January 3, 2016",Delaware,Newark,"50 block of Mercer Dr",N/A,N/A,"Adult 18+",N/A
+"December 30, 2015",Delaware,Middletown,"300 block of Jefferson Street",male,N/A,"Adult 18+",N/A
+"December 30, 2015",Delaware,Middletown,"300 block of Jefferson Street",male,N/A,"Adult 18+",N/A
+"December 30, 2015",Delaware,Middletown,"300 block of Jefferson Street",male,N/A,"Adult 18+",N/A
+"December 30, 2015",Delaware,Newark,"4126 Ogletown Stanton Road",male,N/A,"Adult 18+",N/A
+"December 30, 2015",Delaware,Newark,"4126 Ogletown Stanton Road",male,N/A,"Adult 18+",N/A
+"December 28, 2015",Delaware,Wilmington,"Concord Avenue and Jefferson Street",male,N/A,"Adult 18+",N/A
+"December 27, 2015",Delaware,Wilmington,"North Broom Street and West Third Street",male,N/A,"Adult 18+",N/A
+"December 27, 2015",Delaware,Wilmington,"North Broom Street and West Third Street",male,N/A,"Teen 12-17",N/A
+"December 27, 2015",Delaware,Dover,"801 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"December 27, 2015",Delaware,Dover,"801 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"December 27, 2015",Delaware,Newark,"Kirkwood Highway and Wollaston Avenue",male,"Khaliq D. Scott","Adult 18+",N/A
+"December 27, 2015",Delaware,Wilmington,"East 23rd and Lamotte Streets",male,"Andre Winn","Adult 18+",N/A
+"December 27, 2015",Delaware,Wilmington,"East 23rd and Lamotte Streets",male,N/A,"Adult 18+",N/A
+"December 26, 2015",Delaware,Lincoln,"21000 block of West Mayhew Drive",male,N/A,"Adult 18+",N/A
+"December 23, 2015",Delaware,Wilmington,"Gov. Printz Boulevard",male,"Shayne Litteral","Adult 18+",N/A
+"December 23, 2015",Delaware,Wilmington,"1100 block of Beech Street",male,N/A,"Adult 18+",N/A
+"December 21, 2015",Delaware,Claymont,"749 Montclair Drive",female,N/A,"Adult 18+",N/A
+"December 21, 2015",Delaware,Claymont,"749 Montclair Drive",male,"Scott Sullivan","Adult 18+",N/A
+"December 21, 2015",Delaware,Wilmington,"East 23rd Street",male,"Antoine Perkins","Adult 18+",N/A
+"December 21, 2015",Delaware,Dover,"1502 E Lebanon Rd",male,"Malik Nasir","Adult 18+",N/A
+"December 20, 2015",Delaware,Wilmington,"Locust and East 23rd Streets",male,N/A,"Adult 18+",N/A
+"December 20, 2015",Delaware,Wilmington,"Locust and East 23rd Streets",male,N/A,"Teen 12-17",N/A
+"December 20, 2015",Delaware,"Millsboro (Long Neck)","34000 block of Starboard Court",female,N/A,"Adult 18+",N/A
+"December 20, 2015",Delaware,"Millsboro (Long Neck)","34000 block of Starboard Court",male,"Cecil T. Hicks","Adult 18+",N/A
+"December 20, 2015",Delaware,Wilmington,"1000 block of West Fourth Street",male,N/A,"Adult 18+",N/A
+"December 20, 2015",Delaware,Wilmington,"1000 block of West Fourth Street",male,"Michael Newton","Adult 18+",N/A
+"December 18, 2015",Delaware,Bear,"100 block of Hawk Drive",male,N/A,"Adult 18+",N/A
+"December 17, 2015",Delaware,Laurel,"Sussex Highway",male,N/A,"Adult 18+",N/A
+"December 17, 2015",Delaware,Wilmington,"2300 block of N Monroe St",male,N/A,"Adult 18+",N/A
+"December 17, 2015",Delaware,Newark,"300 block of Salem Church Road",male,"James McCardell","Adult 18+",N/A
+"December 17, 2015",Delaware,Newark,"300 block of Salem Church Road",male,"Brian Richardson","Adult 18+",N/A
+"December 15, 2015",Delaware,Dover,"South Little Creek Road",male,N/A,"Adult 18+",N/A
+"December 15, 2015",Delaware,Dover,"South Little Creek Road",male,"Malik Washington","Adult 18+",N/A
+"December 15, 2015",Delaware,Dover,"South Little Creek Road",male,N/A,"Adult 18+",N/A
+"December 15, 2015",Delaware,"New Castle","100 block of Freedom Trail",male,N/A,"Adult 18+",N/A
+"December 15, 2015",Delaware,"New Castle","100 block of Freedom Trail",male,N/A,"Adult 18+",N/A
+"December 13, 2015",Delaware,Dover,"779 North DuPont Highway",male,N/A,"Adult 18+",N/A
+"December 11, 2015",Delaware,Wilmington,"1300 block of Read St.",male,N/A,"Teen 12-17",N/A
+"December 10, 2015",Delaware,Dover,"Village Drive",male,N/A,"Teen 12-17",N/A
+"December 10, 2015",Delaware,Dover,"Village Drive",male,"Deontray Watson","Teen 12-17",N/A
+"December 9, 2015",Delaware,Wilmington,"West Fourth Street",male,"Marquies Brown","Adult 18+",N/A
+"December 9, 2015",Delaware,Wilmington,"2200 block of North Market Street",male,N/A,"Adult 18+",N/A
+"December 8, 2015",Delaware,Georgetown,"Park Avenue",male,"Christopher Altoe","Adult 18+",N/A
+"December 5, 2015",Delaware,Wilmington,"2500 block of Bowers Street",male,N/A,"Teen 12-17",N/A
+"December 3, 2015",Delaware,Wilmington,"2702 Jacqueline Dr",male,"Jamai White","Adult 18+",N/A
+"December 3, 2015",Delaware,Dover,"Cecil and New",male,"Alex Durham","Adult 18+",N/A
+"December 1, 2015",Delaware,Wilmington,"700 block of E. 22nd St.",male,"Jabari Saunders","Adult 18+",N/A
+"November 29, 2015",Delaware,Frederica,"Johnny Cake Landing Road",N/A,N/A,"Adult 18+",N/A
+"November 29, 2015",Delaware,Frederica,"Johnny Cake Landing Road",N/A,N/A,"Adult 18+",N/A
+"November 28, 2015",Delaware,Wilmington,"2700 block of Northeast Boulevard",N/A,N/A,"Adult 18+",N/A
+"November 27, 2015",Delaware,Bear,"1921 Pulaski Hwy",male,"Aloysisus Taylor","Adult 18+",N/A
+"November 27, 2015",Delaware,Bear,"1921 Pulaski Hwy",male,"Bobby Taylor","Adult 18+",N/A
+"November 26, 2015",Delaware,"New Castle","3000 block of New Castle Ave",N/A,N/A,Unknown,N/A
+"November 26, 2015",Delaware,"New Castle","3000 block of New Castle Ave",N/A,N/A,Unknown,N/A
+"November 25, 2015",Delaware,Wilmington,"2500 block of Carter Street",male,N/A,Unknown,N/A
+"November 24, 2015",Delaware,Bear,"Brookmont Dr and Pulaski Hwy",male,N/A,"Adult 18+",N/A
+"November 23, 2015",Delaware,Dover,"200 block of South New Street",male,"Keith Stevens","Adult 18+",N/A
+"November 23, 2015",Delaware,Dover,"200 block of South New Street",female,"Cierra Brummell","Adult 18+",N/A
+"November 20, 2015",Delaware,Wilmington,"W 20th St and N West St",male,N/A,"Adult 18+",N/A
+"November 18, 2015",Delaware,Newark,"100 Mcintosh Plaza",male,"Thomas Mcilvain","Adult 18+",N/A
+"November 18, 2015",Delaware,Newark,"100 Mcintosh Plaza",male,"Frank Prentice","Adult 18+",N/A
+"November 18, 2015",Delaware,Newark,"100 Mcintosh Plaza",male,"Michael Carello","Adult 18+",N/A
+"November 17, 2015",Delaware,Dover,"Lincoln Street and Gibbs Drive",male,"Lawrence Bracy","Adult 18+",N/A
+"November 16, 2015",Delaware,Dover,"White Oak Road and Frear Drive",male,"Dahppy Brewah","Adult 18+",N/A
+"November 16, 2015",Delaware,Wilmington,"1031 S Market St",male,"William O. Brown","Adult 18+",N/A
+"November 16, 2015",Delaware,Wilmington,"1031 S Market St",male,"Lamott Matthews","Adult 18+",N/A
+"November 13, 2015",Delaware,Claymont,"Harvey Road and Garfield Avenue",male,"William F. McNulty","Adult 18+",N/A
+"November 13, 2015",Delaware,Harrington,"West Center Street",male,N/A,Unknown,N/A
+"November 13, 2015",Delaware,Harrington,"West Center Street",male,N/A,Unknown,N/A
+"November 10, 2015",Delaware,"Wilmington (Edgemoor)","Philadelphia Pk and Beeson Ave",female,N/A,"Adult 18+",N/A
+"November 10, 2015",Delaware,"Wilmington (Edgemoor)","Philadelphia Pk and Beeson Ave",male,"Norris Farlow","Adult 18+",N/A
+"November 10, 2015",Delaware,"Wilmington (Edgemoor)","Philadelphia Pk and Beeson Ave",male,"John Johnson","Adult 18+",N/A
+"November 3, 2015",Delaware,Wilmington,"900 block of Maryland Avenue",male,N/A,"Teen 12-17",N/A
+"November 2, 2015",Delaware,Wilmington,"3rd and North Harrison Street",female,N/A,"Teen 12-17",N/A
+"November 2, 2015",Delaware,Wilmington,"3rd and North Harrison Street",male,N/A,"Adult 18+",N/A
+"November 2, 2015",Delaware,Wilmington,"3rd and North Harrison Street",male,"Troy Gee","Adult 18+",N/A
+"November 2, 2015",Delaware,Wilmington,"3rd and North Harrison Street",male,"Elijah Warren","Adult 18+",N/A
+"November 2, 2015",Delaware,Dover,"Beechwood Avenue",male,N/A,"Adult 18+",N/A
+"November 2, 2015",Delaware,Wilmington,"South Heald and Lobdell street",male,N/A,"Adult 18+",N/A
+"November 2, 2015",Delaware,Wilmington,"Taylor and Kirkwood",male,N/A,"Adult 18+",N/A
+"November 1, 2015",Delaware,Wilmington,"10th and Bennett Streets",female,N/A,"Adult 18+",N/A
+"November 1, 2015",Delaware,Wilmington,"10th and Bennett Streets",male,N/A,"Adult 18+",N/A
+"October 31, 2015",Delaware,Dover,"1131 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"October 31, 2015",Delaware,Milford,"100 block of West St.",male,"Joseynazio ""Jose"" Colombo","Adult 18+",N/A
+"October 31, 2015",Delaware,Milford,"100 block of West St.",male,"Eric A. Harris","Adult 18+",N/A
+"October 29, 2015",Delaware,Wilmington,"1801 Milltown Road",male,N/A,"Adult 18+",N/A
+"October 29, 2015",Delaware,Wilmington,"1801 Milltown Road",N/A,N/A,"Teen 12-17",N/A
+"October 29, 2015",Delaware,Wilmington,"1801 Milltown Road",N/A,N/A,"Teen 12-17",N/A
+"October 28, 2015",Delaware,Felton,"Barney Jenkins Rd and S DuPont Hwy",male,N/A,"Adult 18+",N/A
+"October 27, 2015",Delaware,Wilmington,"1300 block of Lancaster Avenue",male,N/A,"Adult 18+",N/A
+"October 27, 2015",Delaware,Wilmington,"1300 block of Lancaster Avenue",male,N/A,"Adult 18+",N/A
+"October 27, 2015",Delaware,Wilmington,"1800 block of Prospect Rd",male,N/A,"Adult 18+",N/A
+"October 25, 2015",Delaware,Laurel,"County Seat Highway",female,N/A,"Adult 18+",N/A
+"October 22, 2015",Delaware,Wilmington,"800 block of Vanever Avenue",N/A,N/A,Unknown,N/A
+"October 22, 2015",Delaware,Wilmington,"800 block of Vanever Avenue",N/A,N/A,Unknown,N/A
+"October 22, 2015",Delaware,Wilmington,"800 block of Vanever Avenue",N/A,N/A,Unknown,N/A
+"October 21, 2015",Delaware,Dover,"South Du Pont Highway and Martin Luther King Jr. Boulevard",male,"Michael Neal","Adult 18+",N/A
+"October 21, 2015",Delaware,Wilmington,"800 block of Spruce St.",male,N/A,"Adult 18+",N/A
+"October 20, 2015",Delaware,Wilmington,"100 block of Lower Oak St.",male,"Quadrice Barksdale","Adult 18+",N/A
+"October 19, 2015",Delaware,"New Castle","1300 block of W. Fourth St.",male,"Taleem Bryant","Adult 18+",N/A
+"October 17, 2015",Delaware,Dover,"1400 John Clark Road",male,"Clifton M. Leager","Adult 18+",N/A
+"October 17, 2015",Delaware,Dover,"1400 John Clark Road",N/A,N/A,Unknown,N/A
+"October 17, 2015",Delaware,Dover,"1400 John Clark Road",male,N/A,Unknown,N/A
+"October 17, 2015",Delaware,Dover,"1400 John Clark Road",female,"Haley Henwood","Adult 18+",N/A
+"October 17, 2015",Delaware,Dover,"1400 John Clark Road",male,"Saleem Shabazz","Adult 18+",N/A
+"October 15, 2015",Delaware,Wilmington,"900 W. Eighth St",male,"Donte Broomer","Adult 18+",N/A
+"October 15, 2015",Delaware,Wilmington,"900 W. Eighth St",male,"Shavar Jackson","Adult 18+",N/A
+"October 15, 2015",Delaware,Wilmington,"900 W. Eighth St",male,"Stephon Williams","Adult 18+",N/A
+"October 15, 2015",Delaware,Wilmington,"West 27th and Tatnall Streets",male,N/A,"Adult 18+",N/A
+"October 14, 2015",Delaware,Wilmington,"Claymont Street",male,N/A,"Adult 18+",N/A
+"October 14, 2015",Delaware,Wilmington,"300 block of N Monroe St",male,"William Beltran","Adult 18+",N/A
+"October 14, 2015",Delaware,Wilmington,"West Third and North Lincoln Streets",male,N/A,"Adult 18+",N/A
+"October 14, 2015",Delaware,Wilmington,"West Third and North Lincoln Streets",male,"Nasir Manuel","Adult 18+",N/A
+"October 14, 2015",Delaware,Wilmington,"West Third and North Lincoln Streets",male,N/A,"Adult 18+",N/A
+"October 13, 2015",Delaware,Wilmington,"900 block of Buyer Street",male,"Gregory Dorsey","Adult 18+",N/A
+"October 11, 2015",Delaware,"New Castle","50 block of Oakmont Dr",male,N/A,"Adult 18+",N/A
+"October 11, 2015",Delaware,"New Castle","Oakmont Drive",male,N/A,"Adult 18+",N/A
+"October 11, 2015",Delaware,Middletown,"Greenlawn Boulevard",male,N/A,"Teen 12-17",N/A
+"October 11, 2015",Delaware,Middletown,"Greenlawn Boulevard",male,N/A,"Teen 12-17",N/A
+"October 11, 2015",Delaware,Middletown,"Greenlawn Boulevard",male,N/A,"Teen 12-17",N/A
+"October 6, 2015",Delaware,Dover,"West Division and North Queen Streets",male,"Lewis Harrell","Adult 18+",N/A
+"October 5, 2015",Delaware,Wilmington,"Bennett and East Eighth streets",female,"Armoni Fields","Child 0-11",N/A
+"October 5, 2015",Delaware,Wilmington,"Bennett and East Eighth streets",male,"Korie D. Henry","Adult 18+",N/A
+"October 5, 2015",Delaware,Wilmington,"100 block of W. 27th St.",male,N/A,"Adult 18+",N/A
+"October 5, 2015",Delaware,Wilmington,"300 block of E. 14th St.",male,N/A,"Adult 18+",N/A
+"October 4, 2015",Delaware,"New Castle","30 Highland Blvd",male,N/A,"Teen 12-17",N/A
+"October 2, 2015",Delaware,Dover,"400 Barrister Place",male,"Thomas Deputy","Adult 18+",N/A
+"October 2, 2015",Delaware,Newark,"1-29 E Cleveland Ave",male,N/A,"Adult 18+",N/A
+"October 2, 2015",Delaware,Newark,"1-29 E Cleveland Ave",male,N/A,Unknown,N/A
+"October 2, 2015",Delaware,Newark,"1-29 E Cleveland Ave",male,N/A,Unknown,N/A
+"October 2, 2015",Delaware,Newark,"1-29 E Cleveland Ave",male,N/A,Unknown,N/A
+"October 1, 2015",Delaware,Wilmington,"West 28th and North West",male,N/A,"Adult 18+",N/A
+"October 1, 2015",Delaware,Wilmington,"E. 23rd St.",male,N/A,"Adult 18+",N/A
+"September 29, 2015",Delaware,Dover,"Fulton Street",male,N/A,"Adult 18+",N/A
+"September 27, 2015",Delaware,Wilmington,"600 block of N. Jefferson St.",male,"Daywan Scott","Adult 18+",N/A
+"September 27, 2015",Delaware,Wilmington,"1000 block of S. Market St.",male,N/A,"Adult 18+",N/A
+"September 27, 2015",Delaware,Wilmington,"1000 block of S. Market St.",male,"Terrance Everett","Adult 18+",N/A
+"September 24, 2015",Delaware,"New Castle","Jensen Drive",male,N/A,Unknown,N/A
+"September 24, 2015",Delaware,Bear,"Pulaski Highway",N/A,N/A,Unknown,N/A
+"September 23, 2015",Delaware,Wilmington,"Tulip and South Scott streets",male,"Jeremy ""Bam"" McDole","Adult 18+",N/A
+"September 18, 2015",Delaware,Wilmington,"4th and N. Van Buren",male,"Robert Flippen","Adult 18+",N/A
+"September 16, 2015",Delaware,"New Castle","100 Wildfire Lane",male,"Markief Baynard","Adult 18+",N/A
+"September 16, 2015",Delaware,"New Castle","100 Wildfire Lane",male,"Cornelius Woodruff","Adult 18+",N/A
+"September 16, 2015",Delaware,Bear,"100 block of Wimbledon Court",male,N/A,"Adult 18+",N/A
+"September 10, 2015",Delaware,Wilmington,"4th and Lombard Streets",male,N/A,Unknown,N/A
+"September 9, 2015",Delaware,Wilmington,"500 block of E. Ninth Street",male,N/A,"Adult 18+",N/A
+"September 9, 2015",Delaware,Wilmington,"500 block of E. Ninth Street",male,"Michael Newton","Adult 18+",N/A
+"September 9, 2015",Delaware,Wilmington,"500 block of E. Ninth Street",male,N/A,Unknown,N/A
+"September 8, 2015",Delaware,Dover,"Kent Avenue and Water Street",male,"Tywon Peace","Teen 12-17",N/A
+"September 8, 2015",Delaware,Wilmington,"Pennsylvania Avenue and North Van Buren Street",male,"Driver Bryce Davis-Hutt","Adult 18+",N/A
+"September 7, 2015",Delaware,Claymont,"Ridge Road",male,N/A,"Adult 18+",N/A
+"September 7, 2015",Delaware,Wilmington,"600 block of W. Sixth St.",male,"Hassan Brown","Adult 18+",N/A
+"September 6, 2015",Delaware,Felton,"1000 block of Cabin Ridge Road",male,N/A,"Adult 18+",N/A
+"September 5, 2015",Delaware,Wilmington,"600 block of N. Monroe St.",female,N/A,"Adult 18+",N/A
+"September 4, 2015",Delaware,Dover,N/A,male,N/A,"Adult 18+",N/A
+"September 4, 2015",Delaware,Dover,N/A,male,"Alex Joseph","Adult 18+",N/A
+"September 4, 2015",Delaware,Dover,N/A,male,"Johnson Joseph","Adult 18+",N/A
+"September 4, 2015",Delaware,Wilmington,"800 block of W. Third St",N/A,N/A,Unknown,N/A
+"September 3, 2015",Delaware,Dover,"1019 Walker Road",male,N/A,Unknown,N/A
+"September 3, 2015",Delaware,Dover,"1019 Walker Road",male,N/A,Unknown,N/A
+"September 3, 2015",Delaware,Wilmington,"North Madison Street and West 24th Street",male,N/A,Unknown,N/A
+"September 3, 2015",Delaware,Wilmington,"West 25th Street and North Market Street",male,N/A,Unknown,N/A
+"September 1, 2015",Delaware,Wilmington,"Gordon and Lamotte streets",male,N/A,"Adult 18+",N/A
+"September 1, 2015",Delaware,Wilmington,"Gordon and Lamotte streets",N/A,N/A,Unknown,N/A
+"August 30, 2015",Delaware,"Ocean View","37000 block of Muddy Neck Road",female,N/A,"Child 0-11",N/A
+"August 30, 2015",Delaware,"Ocean View","37000 block of Muddy Neck Road",male,"Joseph M. Jenkins Jr.","Adult 18+",N/A
+"August 30, 2015",Delaware,"Ocean View (Oceanview)","37000 block of Muddy Neck Road",male,"Joseph M. Jenkins, Jr","Adult 18+",N/A
+"August 30, 2015",Delaware,"Ocean View (Oceanview)","37000 block of Muddy Neck Road",female,N/A,"Child 0-11",N/A
+"August 29, 2015",Delaware,Laurel,"West Eighth Street",male,"Lee Harper","Adult 18+",N/A
+"August 29, 2015",Delaware,Wilmington,"1200 block of Vandever Ave",male,N/A,"Adult 18+",N/A
+"August 29, 2015",Delaware,Wilmington,"West Sixth Street",male,N/A,"Adult 18+",N/A
+"August 28, 2015",Delaware,Dover,"Webbs Lane",male,N/A,"Adult 18+",N/A
+"August 28, 2015",Delaware,Wilmington,"Delamore Place",male,"Stephan DeShields","Adult 18+",N/A
+"August 28, 2015",Delaware,Wilmington,"Delamore Place",male,"Bilah Goldsborough","Adult 18+",N/A
+"August 28, 2015",Delaware,Dover,"100 block of New Street",male,"Terrance Fletcher","Adult 18+",N/A
+"August 24, 2015",Delaware,Hockessin,"Saint Clair Dr",male,"Shazim Uppal","Adult 18+",N/A
+"August 24, 2015",Delaware,Hockessin,"Saint Clair Dr",male,"Benjamin Rauf","Adult 18+",N/A
+"August 22, 2015",Delaware,Claymont,"Harvey Rd and Jackson Ave",male,N/A,"Adult 18+",N/A
+"August 21, 2015",Delaware,Wilmington,"200 block of North Monroe Street",male,N/A,"Adult 18+",N/A
+"August 21, 2015",Delaware,Wilmington,"200 block of North Monroe Street",male,N/A,"Teen 12-17",N/A
+"August 21, 2015",Delaware,Wilmington,"200 block of Delamore Place",male,N/A,"Adult 18+",N/A
+"August 18, 2015",Delaware,Wilmington,"500 block of Vandever Ave.",male,N/A,"Adult 18+",N/A
+"August 18, 2015",Delaware,Wilmington,"700 block of Townsend Place",male,N/A,"Child 0-11",N/A
+"August 18, 2015",Delaware,Wilmington,"700 block of Townsend Place",male,"Jaleel Goldsborough","Adult 18+",N/A
+"August 17, 2015",Delaware,Wilmington,"10th and Bennett Streets",male,N/A,"Adult 18+",N/A
+"August 16, 2015",Delaware,Wilmington,"West 6th and Madison Streets",male,N/A,"Adult 18+",N/A
+"August 15, 2015",Delaware,Wilmington,"North Locust Street",male,N/A,"Teen 12-17",N/A
+"August 15, 2015",Delaware,Wilmington,"800 block of Vandever Ave",male,"Markevis Clark","Adult 18+",N/A
+"August 15, 2015",Delaware,Wilmington,"800 block of Vandever Ave",male,"Hakiem Anderson","Adult 18+",N/A
+"August 13, 2015",Delaware,Wilmington,"West Second Street and North Madison Street",N/A,N/A,"Adult 18+",N/A
+"August 13, 2015",Delaware,Wilmington,"Pleasant Street and North Van Buren Street",male,N/A,"Adult 18+",N/A
+"August 12, 2015",Delaware,Wilmington,"17th and Thatcher Streets",male,"Amin Ackridge","Adult 18+",N/A
+"August 10, 2015",Delaware,Wilmington,"400 block of W. 7th Street",female,"Latrice Blackshear","Adult 18+",N/A
+"August 10, 2015",Delaware,Wilmington,"400 block of W. 7th Street",female,N/A,"Child 0-11",N/A
+"August 10, 2015",Delaware,Wilmington,"400 block of W. 7th Street",female,N/A,"Adult 18+",N/A
+"August 10, 2015",Delaware,Wilmington,"400 block of W. 7th Street",male,"Thomas Robles","Adult 18+",N/A
+"August 10, 2015",Delaware,Wilmington,"400 block of W. 7th Street",male,"Tyler Carter","Adult 18+",N/A
+"August 10, 2015",Delaware,Dover,"1210 White Oak Road",male,N/A,"Adult 18+",N/A
+"August 10, 2015",Delaware,Dover,"1210 White Oak Road",male,N/A,Unknown,N/A
+"August 10, 2015",Delaware,Dover,"Manchester Square and Stevenson Drive",N/A,N/A,Unknown,N/A
+"August 9, 2015",Delaware,Dover,"652 North DuPont Highway",male,"Royshawn Clark","Adult 18+",N/A
+"August 9, 2015",Delaware,Lincoln,"21000 block of W. Mayhew Dr.",male,N/A,"Child 0-11",N/A
+"August 9, 2015",Delaware,Lincoln,"21000 block of W. Mayhew Dr.",male,"Juan J. Shirey","Adult 18+",N/A
+"August 9, 2015",Delaware,Lincoln,"21000 block of W. Mayhew Dr.",male,N/A,"Adult 18+",N/A
+"August 9, 2015",Delaware,Wilmington,"2400 block of North Tatnall Street",male,N/A,"Adult 18+",N/A
+"August 9, 2015",Delaware,Wilmington,"2400 block of North Tatnall Street",male,"Marcel Dixon","Adult 18+",N/A
+"August 8, 2015",Delaware,Dover,"500 Persimmon Tree Ln",male,N/A,"Adult 18+",N/A
+"August 8, 2015",Delaware,Milford,"500 block of N Walnut St",male,"John Harmon","Adult 18+",N/A
+"August 8, 2015",Delaware,Milford,"500 block of N Walnut St",male,"Abdul T. White","Adult 18+",N/A
+"August 8, 2015",Delaware,Milford,"500 block of N Walnut St",male,N/A,Unknown,N/A
+"August 8, 2015",Delaware,Milford,"500 block of N Walnut St",male,N/A,Unknown,N/A
+"August 7, 2015",Delaware,Wilmington,"2400 block of Carter Street",male,N/A,"Adult 18+",N/A
+"August 6, 2015",Delaware,Dagsboro,"28000 block of East Diamond Dr",male,"William U. Drummond","Adult 18+",N/A
+"July 31, 2015",Delaware,Claymont,"Pennsylvania Avenue and Mansion Avenue",male,N/A,"Adult 18+",N/A
+"July 30, 2015",Delaware,"Rehoboth Beach","300 block of Rehoboth Ave",male,N/A,Unknown,N/A
+"July 30, 2015",Delaware,"Rehoboth Beach","300 block of Rehoboth Ave",male,N/A,Unknown,N/A
+"July 29, 2015",Delaware,"New Castle","300 block of Martin Drive",male,N/A,"Adult 18+",N/A
+"July 29, 2015",Delaware,"New Castle","300 block of Martin Drive",male,N/A,"Adult 18+",N/A
+"July 29, 2015",Delaware,Wilmington,"777 Delaware Park Blvd",male,N/A,"Adult 18+",N/A
+"July 29, 2015",Delaware,Wilmington,"777 Delaware Park Blvd",male,N/A,"Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",male,"Isaias Gonzalez","Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",male,"Timane Dollard","Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",male,"Dameir Walker","Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",male,"Miguel Taylor","Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",male,"Marquivus Hardy","Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",female,"Zieisha Watters","Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",male,N/A,Unknown,N/A
+"July 24, 2015",Delaware,Wilmington,"800 block of of W. Ninth St.",male,"Howard Watkins","Adult 18+",N/A
+"July 24, 2015",Delaware,Wilmington,"2501 Newport Gap Pike",male,N/A,"Adult 18+",N/A
+"July 24, 2015",Delaware,Wilmington,"2501 Newport Gap Pike",male,N/A,Unknown,N/A
+"July 24, 2015",Delaware,Claymont,"4th Avenue",male,N/A,"Adult 18+",N/A
+"July 23, 2015",Delaware,Wilmington,"West Fourth and Washington Streets",male,"James Rogers","Adult 18+",N/A
+"July 23, 2015",Delaware,Wilmington,"West Fourth and Washington Streets",male,"Taushia Mitchell","Adult 18+",N/A
+"July 22, 2015",Delaware,Wilmington,"500 block of N. Madison St",male,N/A,"Adult 18+",N/A
+"July 22, 2015",Delaware,Wilmington,"900 block of Maryland Ave",male,N/A,"Adult 18+",N/A
+"July 22, 2015",Delaware,Wilmington,"900 block of Maryland Ave",male,N/A,"Adult 18+",N/A
+"July 22, 2015",Delaware,Wilmington,"500 block of North Madison St",male,N/A,"Adult 18+",N/A
+"July 22, 2015",Delaware,Dover,"400 block of Sussex Avenue",male,N/A,"Teen 12-17",N/A
+"July 21, 2015",Delaware,Wilmington,"Chestnut and South Franklin streets",male,N/A,"Adult 18+",N/A
+"July 21, 2015",Delaware,Wilmington,"2400 block of Carter St",male,N/A,"Adult 18+",N/A
+"July 21, 2015",Delaware,Bear,"20 block of Monferrato Ct",female,"Jennifer Fertig","Adult 18+",N/A
+"July 21, 2015",Delaware,Bear,"20 block of Monferrato Ct",male,"Michael Jackson","Adult 18+",N/A
+"July 20, 2015",Delaware,Wilmington,"800 block of Vandever Ave",male,"Bernard Bryant","Adult 18+",N/A
+"July 18, 2015",Delaware,Wilmington,"Concord Avenue and North Washington",male,N/A,"Adult 18+",N/A
+"July 18, 2015",Delaware,Wilmington,"Concord Avenue and North Washington",male,N/A,"Adult 18+",N/A
+"July 18, 2015",Delaware,Wilmington,"100 block of N. Clayton St",male,N/A,"Adult 18+",N/A
+"July 16, 2015",Delaware,Dover,"400 block of New Castle Avenue",male,"Anteaza Vann","Adult 18+",N/A
+"July 16, 2015",Delaware,Wilmington,"Lancaster Avenue and Du Pont Street",male,"Brandon Ryans","Adult 18+",N/A
+"July 15, 2015",Delaware,Wilmington,"1800 block of Foulk Rd",male,"Andrew E. Allen","Adult 18+",N/A
+"July 15, 2015",Delaware,Wilmington,"1800 block of Foulk Rd",male,"Jeremy W. Clark","Adult 18+",N/A
+"July 14, 2015",Delaware,Wilmington,"400 block of S. Madison St",male,N/A,"Adult 18+",N/A
+"July 13, 2015",Delaware,"Wilmington (Edgemoor)",N/A,male,N/A,"Adult 18+",N/A
+"July 13, 2015",Delaware,"Wilmington (Edgemoor)",N/A,male,N/A,"Teen 12-17",N/A
+"July 13, 2015",Delaware,Dover,"900 block of W. North St.",male,"Jamal Weeks","Adult 18+",N/A
+"July 11, 2015",Delaware,Wilmington,"2300 block of Baynard Blvd.",male,N/A,"Adult 18+",N/A
+"July 10, 2015",Delaware,Wilmington,"100 block of S. Franklin Street",male,N/A,"Teen 12-17",N/A
+"July 9, 2015",Delaware,Wilmington,"1300 block of West 6th Street",male,"William Fisher","Adult 18+",N/A
+"July 8, 2015",Delaware,Wilmington,"100 block of N. Van Buren St.",male,N/A,"Adult 18+",N/A
+"July 8, 2015",Delaware,Wilmington,"37012 Country Club Road",male,N/A,Unknown,N/A
+"July 8, 2015",Delaware,Newark,"Finch Way",male,"Cordeiro McClain","Adult 18+",N/A
+"July 7, 2015",Delaware,Wilmington,"10th and Spruce streets",male,N/A,"Adult 18+",N/A
+"July 7, 2015",Delaware,"Rehoboth Beach","37000 block of Country Club Road",male,"Chaise Darley","Adult 18+",N/A
+"July 6, 2015",Delaware,Wilmington,"Sixth and Madison Streets",male,N/A,"Adult 18+",N/A
+"July 6, 2015",Delaware,Dover,"N. New St.",male,N/A,"Adult 18+",N/A
+"July 6, 2015",Delaware,Dover,"N. New St.",male,N/A,"Adult 18+",N/A
+"July 6, 2015",Delaware,Seaford,"Tull Drive",male,N/A,"Adult 18+",N/A
+"July 6, 2015",Delaware,Seaford,"Tull Drive",female,N/A,"Adult 18+",N/A
+"July 6, 2015",Delaware,Wilmington,"1400 block of W. Second St.",male,"Jerome Jeter","Adult 18+",N/A
+"July 2, 2015",Delaware,Wilmington,"603 Philadelphia Pike",male,"Steven Kellam","Adult 18+",N/A
+"July 2, 2015",Delaware,Wilmington,"603 Philadelphia Pike",male,"Carlton Gibbs","Adult 18+",N/A
+"July 2, 2015",Delaware,Wilmington,"603 Philadelphia Pike",male,"Damon Bethea","Adult 18+",N/A
+"July 2, 2015",Delaware,Middletown,"100 block of St. Augustine Court",male,"Thomas Reamer","Adult 18+",N/A
+"July 1, 2015",Delaware,Wilmington,"900 block of N. Jefferson St.",male,"William Yancey","Adult 18+",N/A
+"June 30, 2015",Delaware,Wilmington,"600 block of N. Broom St",male,"Quiaire Nesmith","Adult 18+",N/A
+"June 29, 2015",Delaware,Wilmington,"2900 block of N. Washington St",male,"Otis Bridgeforth","Adult 18+",N/A
+"June 29, 2015",Delaware,Wilmington,"400 block of S. Heald St.",male,"Damont Emory","Adult 18+",N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",N/A,N/A,Unknown,N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",N/A,N/A,Unknown,N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",N/A,N/A,Unknown,N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",N/A,N/A,Unknown,N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",N/A,N/A,Unknown,N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",N/A,N/A,Unknown,N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",male,"Elijah Desir","Adult 18+",N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",male,N/A,"Teen 12-17",N/A
+"June 26, 2015",Delaware,Newark,"Penman Seventy 6 Dr and Sandburg Pl",male,N/A,"Teen 12-17",N/A
+"June 23, 2015",Delaware,Wilmington,"600 block of N. Broom St",male,N/A,"Adult 18+",N/A
+"June 22, 2015",Delaware,Bear,"100 block of Wimbledon Court",male,N/A,"Adult 18+",N/A
+"June 22, 2015",Delaware,Bear,"100 block of Wimbledon Court",male,N/A,Unknown,N/A
+"June 22, 2015",Delaware,Bear,"100 block of Wimbledon Court",male,N/A,Unknown,N/A
+"June 15, 2015",Delaware,"New Castle","3 Memorial Dr",male,N/A,"Adult 18+",N/A
+"June 15, 2015",Delaware,"New Castle","3 Memorial Dr",male,N/A,"Adult 18+",N/A
+"June 14, 2015",Delaware,Wilmington,"600 block of North Jefferson Street",male,"Antonio Cropper","Adult 18+",N/A
+"June 14, 2015",Delaware,Milford,"100 block of NW Front St",male,"Robert G. Cook","Adult 18+",N/A
+"June 13, 2015",Delaware,Magnolia,"300 block of Marshview Terrace",male,N/A,"Adult 18+",N/A
+"June 13, 2015",Delaware,Magnolia,"300 block of Marshview Terrace",male,N/A,"Adult 18+",N/A
+"June 13, 2015",Delaware,Magnolia,"300 block of Marshview Terrace",male,N/A,"Adult 18+",N/A
+"June 13, 2015",Delaware,Dover,"500 block of South Dupont Highway",male,"Ricky S. Sanabria","Adult 18+",N/A
+"June 10, 2015",Delaware,Wilmington,"100 block of N. Connell St",male,N/A,"Adult 18+",N/A
+"June 10, 2015",Delaware,Wilmington,"100 block of N. Connell St",male,N/A,"Adult 18+",N/A
+"June 9, 2015",Delaware,Wilmington,"100 block of Delamore Place",male,N/A,"Adult 18+",N/A
+"June 9, 2015",Delaware,Wilmington,"100 block of Delamore Place",male,N/A,"Adult 18+",N/A
+"June 9, 2015",Delaware,Wilmington,"100 block of Delamore Place",male,N/A,"Adult 18+",N/A
+"June 7, 2015",Delaware,Dover,"100 block of S. New St.",male,"Rondree Campbell","Adult 18+",N/A
+"June 6, 2015",Delaware,Dover,"South Little Creek Road",male,N/A,"Adult 18+",N/A
+"June 6, 2015",Delaware,Dover,"South Little Creek Road",female,N/A,"Adult 18+",N/A
+"June 6, 2015",Delaware,Dover,"1131 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"June 2, 2015",Delaware,Wilmington,"West Fourth and Delamore Streets",female,N/A,"Adult 18+",N/A
+"June 2, 2015",Delaware,Wilmington,"West Fourth and Delamore Streets",male,N/A,"Adult 18+",N/A
+"June 2, 2015",Delaware,Dover,"200 block of Frear Drive",female,"Melissa Thompkins","Adult 18+",N/A
+"June 2, 2015",Delaware,Dover,"200 block of Frear Drive",male,"Frederick Tolson","Adult 18+",N/A
+"June 2, 2015",Delaware,"New Castle","Powhaten Road",male,N/A,"Adult 18+",N/A
+"June 2, 2015",Delaware,"New Castle","Powhaten Road",male,N/A,"Adult 18+",N/A
+"June 1, 2015",Delaware,Wilmington,"500 block of E. 10th St.",male,"Ernest Robinson","Adult 18+",N/A
+"June 1, 2015",Delaware,Wilmington,"100 block of North Broom Street",male,N/A,"Adult 18+",N/A
+"June 1, 2015",Delaware,Wilmington,"Bedford Drive",male,N/A,"Adult 18+",N/A
+"June 1, 2015",Delaware,Dover,"200 block of N. Kirkwood St.",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,"Isaiah Gonzalez","Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,"Nathaniel Gonzalez","Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,Dover,"100 block of Madison Court",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,"Port Penn","W. Market St.",male,"Matthew W. Kennedy","Adult 18+",N/A
+"May 30, 2015",Delaware,Wilmington,"200 block of North Broom Street",male,N/A,"Teen 12-17",N/A
+"May 30, 2015",Delaware,Wilmington,"700 block of N. Washington Street",male,N/A,"Adult 18+",N/A
+"May 29, 2015",Delaware,"New Castle","Christiana Road",male,"Isaiah Jones","Teen 12-17",N/A
+"May 29, 2015",Delaware,"New Castle","Christiana Road",male,"Quadere Wilson","Adult 18+",N/A
+"May 29, 2015",Delaware,Wilmington,"South Broom Street",male,N/A,"Adult 18+",N/A
+"May 29, 2015",Delaware,Claymont,"600 block of Naamans Road",male,"Tommy Foster","Adult 18+",N/A
+"May 28, 2015",Delaware,Newark,"750 E. Delaware Ave.",male,N/A,"Teen 12-17",N/A
+"May 27, 2015",Delaware,"Wilmington (Elsmere)","100 block of Brookside Avenue",male,N/A,"Adult 18+",N/A
+"May 26, 2015",Delaware,Townsend,"3900 block of South Du Pont Highway",female,N/A,"Adult 18+",N/A
+"May 26, 2015",Delaware,Townsend,"3900 block of South Du Pont Highway",male,N/A,"Adult 18+",N/A
+"May 26, 2015",Delaware,Townsend,"3900 block of South Du Pont Highway",male,N/A,"Adult 18+",N/A
+"May 26, 2015",Delaware,Townsend,"3900 block of South Du Pont Highway",male,N/A,"Adult 18+",N/A
+"May 26, 2015",Delaware,Townsend,"3900 block of DuPont Pkwy",male,N/A,"Adult 18+",N/A
+"May 26, 2015",Delaware,Townsend,"3900 block of DuPont Pkwy",male,"Marshall C. Brown","Adult 18+",N/A
+"May 26, 2015",Delaware,Townsend,"3900 block of DuPont Pkwy",male,N/A,Unknown,N/A
+"May 26, 2015",Delaware,Townsend,"3900 block of DuPont Pkwy",male,N/A,Unknown,N/A
+"May 26, 2015",Delaware,Townsend,"3900 block of DuPont Pkwy",female,N/A,"Adult 18+",N/A
+"May 25, 2015",Delaware,Wilmington,"1900 block of West Street",female,N/A,"Adult 18+",N/A
+"May 23, 2015",Delaware,Wilmington,"N Spruce St and Taylor St",male,N/A,"Adult 18+",N/A
+"May 23, 2015",Delaware,Wilmington,N/A,male,N/A,"Adult 18+",N/A
+"May 20, 2015",Delaware,Wilmington,"600 block of N. Madison St.",female,N/A,"Adult 18+",N/A
+"May 19, 2015",Delaware,Wilmington,"12th Street and Northeast Boulevard",male,N/A,"Adult 18+",N/A
+"May 19, 2015",Delaware,Wilmington,"12th Street and Northeast Boulevard",male,N/A,"Adult 18+",N/A
+"May 18, 2015",Delaware,Dover,"1000 block of S. Little Creek Road",male,N/A,"Adult 18+",N/A
+"May 15, 2015",Delaware,Dover,"East Water Street and Sussex Avenue",male,N/A,"Adult 18+",N/A
+"May 15, 2015",Delaware,Dover,"East Water Street and Sussex Avenue",male,N/A,"Adult 18+",N/A
+"May 15, 2015",Delaware,Dover,"Sussex Ave",male,N/A,"Adult 18+",N/A
+"May 15, 2015",Delaware,Dover,"Sussex Ave",male,"Rakim Strickland","Adult 18+",N/A
+"May 13, 2015",Delaware,Dover,"Harmony Lane",male,"Gary Adams","Adult 18+",N/A
+"May 13, 2015",Delaware,Bear,"100 block of Antlers Lane",male,"Edwin Heath Sr.","Adult 18+",N/A
+"May 13, 2015",Delaware,Wilmington,"800 block of W. Third St.",male,N/A,"Adult 18+",N/A
+"May 9, 2015",Delaware,Wilmington,"1000 block of S. Market St.",male,N/A,"Adult 18+",N/A
+"May 8, 2015",Delaware,Newark,"Stanton-Christiana Road",female,N/A,"Adult 18+",N/A
+"May 8, 2015",Delaware,Newark,"Stanton-Christiana Road",male,N/A,"Adult 18+",N/A
+"May 8, 2015",Delaware,Newark,"Stanton-Christiana Road",male,"Donald Lavender","Adult 18+",N/A
+"May 2, 2015",Delaware,Smyrna,"Malvern Lane",N/A,N/A,Unknown,N/A
+"May 2, 2015",Delaware,Smyrna,"Malvern Lane",male,"Kenneth Mathena","Adult 18+",N/A
+"April 30, 2015",Delaware,Dover,N/A,male,"DaShawn Friend","Adult 18+",N/A
+"April 30, 2015",Delaware,Dover,N/A,male,"Fchante Robertson","Adult 18+",N/A
+"April 30, 2015",Delaware,Dover,N/A,male,"James White","Adult 18+",N/A
+"April 28, 2015",Delaware,Dover,"100 block of South Queen Street",male,N/A,"Adult 18+",N/A
+"April 28, 2015",Delaware,Wilmington,"600 block of W. Sixth St.",female,"Artise Brown","Adult 18+",N/A
+"April 28, 2015",Delaware,Wilmington,"600 block of W. Sixth St.",female,N/A,"Adult 18+",N/A
+"April 27, 2015",Delaware,Wilmington,"Concord Avenue and West Street",male,"Tymir Mason","Adult 18+",N/A
+"April 27, 2015",Delaware,Wilmington,"Concord Avenue and West Street",male,"Bryon Wilmer","Adult 18+",N/A
+"April 26, 2015",Delaware,Wilmington,"400 block of Maryland Avenue",male,N/A,"Adult 18+",N/A
+"April 26, 2015",Delaware,Wilmington,"400 block of Maryland Avenue",N/A,N/A,"Adult 18+",N/A
+"April 26, 2015",Delaware,Wilmington,"400 block of Maryland Avenue",N/A,N/A,"Adult 18+",N/A
+"April 26, 2015",Delaware,Magnolia,"400 block of Lambert Drive",male,"Stephen Wheeler","Adult 18+",N/A
+"April 26, 2015",Delaware,Dover,"N. New St.",male,"David L. Clark","Adult 18+",N/A
+"April 26, 2015",Delaware,"New Castle","100 block of Carvel Ave",female,"Sharee Gordon","Adult 18+",N/A
+"April 22, 2015",Delaware,Dover,"89 Kings Highway",male,"Jeffrey D. Callahan","Adult 18+",N/A
+"April 22, 2015",Delaware,Dover,"89 Kings Highway",male,"Gary L. Grose","Adult 18+",N/A
+"April 22, 2015",Delaware,Dover,"89 Kings Highway",male,"Michael E. Dewey","Adult 18+",N/A
+"April 22, 2015",Delaware,Dover,"89 Kings Highway",male,"Christopher A. Griffin","Adult 18+",N/A
+"April 22, 2015",Delaware,Smyrna,"SR 1",male,"Victor Mota Garcia","Adult 18+",N/A
+"April 18, 2015",Delaware,Dover,"430 State College Road",N/A,N/A,"Adult 18+",N/A
+"April 18, 2015",Delaware,Dover,"430 State College Road",N/A,N/A,"Adult 18+",N/A
+"April 18, 2015",Delaware,Dover,"430 State College Road",N/A,N/A,"Adult 18+",N/A
+"April 16, 2015",Delaware,Wilmington,"7th and West Streets",male,N/A,"Teen 12-17",N/A
+"April 15, 2015",Delaware,Wilmington,"800 block of Kirkwood Street",male,N/A,"Adult 18+",N/A
+"April 14, 2015",Delaware,Wilmington,"W 27th St",male,"Deshannon Reid","Adult 18+",N/A
+"April 14, 2015",Delaware,Wilmington,"W 27th St",male,"Damian Thomas","Adult 18+",N/A
+"April 14, 2015",Delaware,Milford,"400 block of East Street",male,"Matthew Gannon, Jr.","Adult 18+",N/A
+"April 13, 2015",Delaware,Wilmington,"800 block of Vandever Avenue",male,"Thomas Bransford IV","Adult 18+",N/A
+"April 6, 2015",Delaware,Wilmington,"700 block of Townsend Place",male,N/A,"Adult 18+",N/A
+"April 6, 2015",Delaware,Newark,"Kimberton Drive",male,N/A,"Adult 18+",N/A
+"April 4, 2015",Delaware,Wilmington,"200 block of N Monroe St",male,"Raekwon Mangrum","Adult 18+",N/A
+"April 4, 2015",Delaware,Wilmington,"200 block of N Monroe St",female,N/A,"Adult 18+",N/A
+"April 4, 2015",Delaware,Wilmington,"200 block of N Monroe St",male,"Michael Broomer","Adult 18+",N/A
+"April 4, 2015",Delaware,Wilmington,"200 block of N Monroe St",male,"Atiba Mayfield","Adult 18+",N/A
+"April 4, 2015",Delaware,Wilmington,"Second and Madison Streets",male,N/A,"Adult 18+",N/A
+"April 4, 2015",Delaware,Wilmington,"Second and Madison Streets",female,N/A,"Adult 18+",N/A
+"April 4, 2015",Delaware,Wilmington,"Second and Madison Streets",male,N/A,"Adult 18+",N/A
+"April 4, 2015",Delaware,Wilmington,"Second and Madison Streets",male,N/A,"Adult 18+",N/A
+"April 3, 2015",Delaware,Bridgeville,"Oak and Sanfilippo Roads",male,N/A,"Adult 18+",N/A
+"April 3, 2015",Delaware,Wilmington,"West Seventh Street",N/A,N/A,"Adult 18+",N/A
+"April 3, 2015",Delaware,Wilmington,"1031 S. Market St.",female,N/A,"Adult 18+",N/A
+"April 3, 2015",Delaware,Wilmington,"1031 S. Market St.",male,N/A,"Adult 18+",N/A
+"April 1, 2015",Delaware,Dover,"300 block of W. Division St.",male,"Ezekiel Benson","Adult 18+",N/A
+"April 1, 2015",Delaware,Wilmington,"200 block of N. Scott St.",male,N/A,"Adult 18+",N/A
+"March 31, 2015",Delaware,Wilmington,"Lancaster Avenue and Delamore Place",male,N/A,"Adult 18+",N/A
+"March 31, 2015",Delaware,Wilmington,"Lancaster Avenue and Delamore Place",N/A,N/A,"Adult 18+",N/A
+"March 27, 2015",Delaware,Dover,"North Governors Avenue",male,"Thomas Clark","Adult 18+",N/A
+"March 27, 2015",Delaware,Dover,"Queen and Cecil Streets",male,"Emilio Freeman","Adult 18+",N/A
+"March 27, 2015",Delaware,Wilmington,"South Franklin and Linden Streets",male,N/A,"Adult 18+",N/A
+"March 27, 2015",Delaware,Wilmington,"South Franklin and Linden Streets",N/A,N/A,"Adult 18+",N/A
+"March 27, 2015",Delaware,Magnolia,"Grays Ln",male,N/A,"Adult 18+",N/A
+"March 27, 2015",Delaware,Wilmington,"Bethel Road",male,"Garrett Hill","Adult 18+",N/A
+"March 25, 2015",Delaware,Claymont,"3300 Brandywine Parkway",male,N/A,"Adult 18+",N/A
+"March 25, 2015",Delaware,Claymont,"3300 Brandywine Parkway",male,N/A,"Adult 18+",N/A
+"March 25, 2015",Delaware,Claymont,"3300 Brandywine Parkway",male,N/A,"Adult 18+",N/A
+"March 25, 2015",Delaware,Wilmington,"400 block of N. Rodney St.",male,"Alexander Fitzgerald","Adult 18+",N/A
+"March 24, 2015",Delaware,Wilmington,"600 block of W. 4th St.",male,N/A,"Teen 12-17",N/A
+"March 24, 2015",Delaware,Wilmington,"5500 block of Heritage Court Dr",female,"Jennifer Chadwick","Adult 18+",N/A
+"March 24, 2015",Delaware,Wilmington,"5500 block of Heritage Court Dr",N/A,"Antonio Graves","Adult 18+",N/A
+"March 24, 2015",Delaware,Wilmington,"5500 block of Heritage Court Dr",N/A,"Jerimiah Feaster","Adult 18+",N/A
+"March 22, 2015",Delaware,"New Castle","Moores Lane",male,N/A,"Adult 18+",N/A
+"March 22, 2015",Delaware,"New Castle","Moores Lane",male,N/A,"Adult 18+",N/A
+"March 21, 2015",Delaware,Wilmington,"6th and N. Jefferson Streets",male,N/A,"Adult 18+",N/A
+"March 20, 2015",Delaware,Delmar,"10000 block of Bacons Road",male,N/A,"Adult 18+",N/A
+"March 20, 2015",Delaware,Delmar,"10000 block of Bacons Road",male,N/A,"Adult 18+",N/A
+"March 20, 2015",Delaware,Delmar,"10000 block of Bacons Road",male,N/A,"Adult 18+",N/A
+"March 20, 2015",Delaware,Delmar,"10000 block of Bacons Road",male,N/A,"Adult 18+",N/A
+"March 16, 2015",Delaware,Dover,"Daniel Rodney Drive and David Hall Road",male,"James A. Wheeler","Adult 18+",N/A
+"March 12, 2015",Delaware,Wilmington,"Second and North Scott streets",female,N/A,"Adult 18+",N/A
+"March 9, 2015",Delaware,Dover,"200 block of N. Du Pont Highway",male,N/A,"Adult 18+",N/A
+"March 8, 2015",Delaware,"New Castle","I-495 and US-13",male,"Shelton Johns","Adult 18+",N/A
+"March 8, 2015",Delaware,"New Castle","I-495 and US-13",female,N/A,"Adult 18+",N/A
+"March 8, 2015",Delaware,Newark,"300 block of Delaware Circle",male,"Michael L. Chamberlin","Adult 18+",N/A
+"March 8, 2015",Delaware,Claymont,"600 block of Naamans Road",male,N/A,"Adult 18+",N/A
+"March 7, 2015",Delaware,Dover,"1426 N Dupont Hwy",female,N/A,"Adult 18+",N/A
+"March 2, 2015",Delaware,Sussex,"35000 block of Spruce Road",male,"Djuan Sheppard","Adult 18+",N/A
+"March 1, 2015",Delaware,Wilmington,"22nd and Spruce",male,N/A,"Adult 18+",N/A
+"February 28, 2015",Delaware,Dover,"First block of Webbs Lane",male,N/A,"Adult 18+",N/A
+"February 28, 2015",Delaware,Dover,"First block of Webbs Lane",male,N/A,"Adult 18+",N/A
+"February 28, 2015",Delaware,Dover,"First block of Webbs Lane",male,N/A,"Adult 18+",N/A
+"February 27, 2015",Delaware,Dover,"River Road and E. Water Street",male,"Wayne Kersey","Adult 18+",N/A
+"February 26, 2015",Delaware,Wilmington,"1200 block of Elm St.",male,N/A,"Teen 12-17",N/A
+"February 24, 2015",Delaware,"New Castle","Wilmington Road and East Sixth St.",male,"Anthony L. Morrow","Adult 18+",N/A
+"February 23, 2015",Delaware,Wilmington,"1300 block of French St.",male,"Malik Frazier","Adult 18+",N/A
+"February 23, 2015",Delaware,Wilmington,"South Heald and Lobdell streets",male,N/A,"Teen 12-17",N/A
+"February 21, 2015",Delaware,Wilmington,"1200 block of N. Union St.",male,"Devon Trotter","Adult 18+",N/A
+"February 16, 2015",Delaware,Wilmington,"E 24th St and Carter St",male,"Deshon Tyreice ""Poppy"" Sellers","Teen 12-17",N/A
+"February 16, 2015",Delaware,Wilmington,"E 24th St and Carter St",male,"Alexander Fitzgerald","Adult 18+",N/A
+"February 16, 2015",Delaware,"New Castle","19 Lambson Ln",male,"Jamar Kilgoe","Adult 18+",N/A
+"February 14, 2015",Delaware,Townsend,"600 block of Marilyn Ct",male,"Dayshon M. Wallace","Adult 18+",N/A
+"February 13, 2015",Delaware,Wilmington,"400 block of North Madison Street",male,N/A,"Teen 12-17",N/A
+"February 12, 2015",Delaware,Newark,"400 block of Kemper Dr",male,N/A,"Adult 18+",N/A
+"February 12, 2015",Delaware,Newark,"400 block of Kemper Dr",male,N/A,"Teen 12-17",N/A
+"February 11, 2015",Delaware,Wilmington,"Seventh and North Washington streets",male,N/A,"Adult 18+",N/A
+"February 11, 2015",Delaware,"New Castle","Amstel Drive",male,"Kelvin Powers","Adult 18+",N/A
+"February 10, 2015",Delaware,Dover,"Stevenson Drive",male,"Jahmelle Taylor","Adult 18+",N/A
+"February 10, 2015",Delaware,Wilmington,"200 block of Delamore Place",male,"Tyreek Ducette","Adult 18+",N/A
+"February 8, 2015",Delaware,Newark,"Albert St",male,"Lamarr Anderson","Adult 18+",N/A
+"February 8, 2015",Delaware,Dover,"Rte 13",male,N/A,"Adult 18+",N/A
+"February 8, 2015",Delaware,Dover,"Rte 13",female,N/A,"Adult 18+",N/A
+"February 8, 2015",Delaware,Dover,"Rte 13",male,"Naquan Ingram","Adult 18+",N/A
+"February 8, 2015",Delaware,Dover,"Rte 13",male,"Agmere Matthews","Adult 18+",N/A
+"February 6, 2015",Delaware,"New Castle","Sandalwood Court",male,"Everett Fray","Adult 18+",N/A
+"February 5, 2015",Delaware,Wilmington,"200 block of South Harrison Street",female,N/A,"Adult 18+",N/A
+"February 5, 2015",Delaware,Wilmington,"200 block of South Harrison Street",male,"Phillip Battle","Adult 18+",N/A
+"February 4, 2015",Delaware,Wilmington,"Lobdell Street and New Castle Avenue",male,N/A,"Adult 18+",N/A
+"February 2, 2015",Delaware,Wilmington,"800 block of Kirkwood St",male,N/A,"Adult 18+",N/A
+"February 2, 2015",Delaware,Wilmington,"Cedar and Anchorage streets",male,N/A,"Adult 18+",N/A
+"February 1, 2015",Delaware,"New Castle","5000 block of East Brigantine Court",male,N/A,"Adult 18+",N/A
+"February 1, 2015",Delaware,Wilmington,"E. 26th St. and Northeast Boulevard",male,"Hykeeam Harris","Adult 18+",N/A
+"January 31, 2015",Delaware,Elsmere,"200 block of Birch Ave",male,"Jonathan Rosario","Adult 18+",N/A
+"January 31, 2015",Delaware,Wilmington,"Fourth and Jackson streets",male,"Tory Jenkins","Adult 18+",N/A
+"January 30, 2015",Delaware,Wilmington,"11th and Tatnell",male,N/A,"Adult 18+",N/A
+"January 27, 2015",Delaware,Wilmington,"900 block of East 17th Street",male,N/A,"Adult 18+",N/A
+"January 26, 2015",Delaware,Wilmington,"200 block of N. Broom St.",male,N/A,"Teen 12-17",N/A
+"January 24, 2015",Delaware,Wilmington,"300 block of W 21st Street",male,"William Rollins Jr.","Adult 18+",N/A
+"January 23, 2015",Delaware,Wilmington,"200 block of N. Broom St.",male,"Jordan Ellerbe","Teen 12-17",N/A
+"January 23, 2015",Delaware,Wilmington,"200 block of N. Broom St.",N/A,N/A,"Teen 12-17",N/A
+"January 23, 2015",Delaware,Wilmington,"200 block of N. Broom St.",N/A,N/A,"Teen 12-17",N/A
+"January 20, 2015",Delaware,"New Castle","500 block of S. DuPont Highway",male,N/A,"Adult 18+",N/A
+"January 20, 2015",Delaware,"New Castle","500 block of South DuPont Highway",male,N/A,"Adult 18+",N/A
+"January 20, 2015",Delaware,"New Castle","500 block of South DuPont Highway",male,"Deshaun Northern","Adult 18+",N/A
+"January 19, 2015",Delaware,Dover,"North Kirkwood Street",male,"Tomas Gordon","Adult 18+",N/A
+"January 19, 2015",Delaware,Dover,"North Kirkwood Street",male,"Brandon McDonald","Adult 18+",N/A
+"January 19, 2015",Delaware,Seaford,"26000 block of Bethel Concord Road",female,N/A,"Adult 18+",N/A
+"January 19, 2015",Delaware,Seaford,"26000 block of Bethel Concord Road",male,"Jesse Dudley","Adult 18+",N/A
+"January 18, 2015",Delaware,Wilmington,"700 block of E. 26th St.",male,N/A,"Adult 18+",N/A
+"January 17, 2015",Delaware,Greenville,"Barley Mill Road",N/A,N/A,Unknown,N/A
+"January 15, 2015",Delaware,Sussex,"23000 block of Cinnamon Lane",male,"Calvin L. Ushery","Adult 18+",N/A
+"January 15, 2015",Delaware,Sussex,"23000 block of Cinnamon Lane",male,"Allen Simmons","Adult 18+",N/A
+"January 15, 2015",Delaware,Wilmington,"Vandever Ave. and Lamotte St",male,N/A,"Adult 18+",N/A
+"January 14, 2015",Delaware,Wilmington,"700 block of N. Monroe St",male,"Sabri Caulk","Adult 18+",N/A
+"January 14, 2015",Delaware,"New Castle","Christiana Road",N/A,N/A,"Adult 18+",N/A
+"January 14, 2015",Delaware,Wilmington,"600 block of Concord Avenue",male,"Robert Bailey","Adult 18+",N/A
+"January 13, 2015",Delaware,Townsend,"Gum Bush Rd",N/A,N/A,"Adult 18+",N/A
+"January 12, 2015",Delaware,Wilmington,"200 block of W. 23rd St.",male,"Keith Mason","Adult 18+",N/A
+"January 12, 2015",Delaware,Newark,"Vinings Way",male,"Brian Eller","Adult 18+",N/A
+"January 12, 2015",Delaware,Newark,"Vinings Way",male,"Lahmeer Carter","Adult 18+",N/A
+"January 9, 2015",Delaware,"New Castle","200 block of Parma Ave",male,"Kyrell Lewis","Adult 18+",N/A
+"January 9, 2015",Delaware,"New Castle","200 block of Parma Ave",male,"Maurice Cruz-Webster","Adult 18+",N/A
+"January 8, 2015",Delaware,Dover,"Rt. 13",male,N/A,"Adult 18+",N/A
+"January 8, 2015",Delaware,Dover,"Rt. 13",male,"James A. Wheeler","Adult 18+",N/A
+"January 8, 2015",Delaware,Kent,"4200 block of N. Du Pont Highway",male,N/A,"Adult 18+",N/A
+"January 5, 2015",Delaware,Wilmington,"800 block of West St.",male,N/A,"Adult 18+",N/A
+"December 30, 2014",Delaware,Milford,"1000 block of N. Walnut St.",male,"Jeremiah G. Stevenson","Adult 18+",N/A
+"December 22, 2014",Delaware,Wilmington,"200 block of N. Clayton St.",male,"Javon Lemons","Adult 18+",N/A
+"December 21, 2014",Delaware,Dover,"50 Greenway Square",male,"James Long","Adult 18+",N/A
+"December 20, 2014",Delaware,Wilmington,"13 Lowry Dr",male,"Nicholas Riley","Adult 18+",N/A
+"December 19, 2014",Delaware,Wilmington,"700 block of Vandever Avenue",male,"Derrick Caudle","Adult 18+",N/A
+"December 18, 2014",Delaware,Wilmington,"500 block of Concord Ave",male,"Raheem Roberts","Adult 18+",N/A
+"December 15, 2014",Delaware,Wilmington,"900 block of N. Madison Street",male,N/A,"Teen 12-17",N/A
+"December 14, 2014",Delaware,Wilmington,"Heritage Drive",male,N/A,"Adult 18+",N/A
+"December 14, 2014",Delaware,Wilmington,"Heritage Drive",male,N/A,"Adult 18+",N/A
+"December 14, 2014",Delaware,Wilmington,"Heritage Drive",male,N/A,"Adult 18+",N/A
+"December 12, 2014",Delaware,"Cedar Heights","Walnut and Maple Avenues",male,"Thomas Ferguson","Adult 18+",N/A
+"December 9, 2014",Delaware,Wilmington,"Vanlyn Ct",male,"Kali Worley","Adult 18+",N/A
+"December 7, 2014",Delaware,Wilmington,"400 block of S. Heald St.",male,N/A,"Adult 18+",N/A
+"December 6, 2014",Delaware,Laurel,N/A,male,"Jeffery A. Jones","Adult 18+",N/A
+"December 5, 2014",Delaware,Wilmington,"1051 S. Market St",male,"Demetrius Mayo","Adult 18+",N/A
+"December 5, 2014",Delaware,Wilmington,"1051 S. Market St",male,"Diwani Knight","Adult 18+",N/A
+"December 5, 2014",Delaware,Wilmington,"1051 S. Market St",male,"Chardae Brown","Adult 18+",N/A
+"December 5, 2014",Delaware,Wilmington,"1051 S. Market St",male,"Anthony Washington","Adult 18+",N/A
+"December 5, 2014",Delaware,Wilmington,"1051 S. Market St",male,"Michael Wiggins","Adult 18+",N/A
+"December 4, 2014",Delaware,Wilmington,"1100 block of West Second St.,",male,N/A,"Adult 18+",N/A
+"December 4, 2014",Delaware,Wilmington,"West 2nd and Van Buren Streets",male,N/A,"Adult 18+",N/A
+"December 3, 2014",Delaware,Wilmington,"2200 bock of N. Pine St. ",male,N/A,"Adult 18+",N/A
+"November 26, 2014",Delaware,Newark,"N Bellwoode Dr",male,N/A,"Adult 18+",N/A
+"November 26, 2014",Delaware,"New Castle","100 block of W 9th St",male,"Malik Watson","Adult 18+",N/A
+"November 26, 2014",Delaware,"New Castle","100 block of W 9th St",male,"Jacquez I. Robinson","Adult 18+",N/A
+"November 26, 2014",Delaware,Newark,"Bell Wood Drive",male,N/A,"Adult 18+",N/A
+"November 26, 2014",Delaware,Wilmington,"23rd Street",male,N/A,"Adult 18+",N/A
+"November 26, 2014",Delaware,Wilmington,"22nd and Spruce streets",male,N/A,"Adult 18+",N/A
+"November 25, 2014",Delaware,Wilmington,"200 block of W. 28th St.",male,N/A,"Adult 18+",N/A
+"November 25, 2014",Delaware,Wilmington,"Maryland Avenue and Stroud Street",male,N/A,"Adult 18+",N/A
+"November 25, 2014",Delaware,Wilmington,"Maryland Avenue and Stroud Street",female,N/A,"Adult 18+",N/A
+"November 24, 2014",Delaware,Milton,"501 Palmer St",male,"Rogelio Martinez Hernandez","Adult 18+",N/A
+"November 24, 2014",Delaware,Milton,"501 Palmer St",male,"Marlon Martinez-Hernandez","Teen 12-17",N/A
+"November 23, 2014",Delaware,Wilmington,"West 28th Street",male,N/A,"Teen 12-17",N/A
+"November 23, 2014",Delaware,Wilmington,"300 block of South Harrison Street",male,N/A,"Adult 18+",N/A
+"November 23, 2014",Delaware,Wilmington,"300 block of South Harrison Street",male,N/A,"Adult 18+",N/A
+"November 22, 2014",Delaware,Wilmington,"27th Street and West Street",male,N/A,"Adult 18+",N/A
+"November 21, 2014",Delaware,Wilmington,"700 block of East 10th Street",male,N/A,"Adult 18+",N/A
+"November 20, 2014",Delaware,Wilmington,"22nd and N. Spruce Streets",male,N/A,"Adult 18+",N/A
+"November 19, 2014",Delaware,Wilmington,"2700 block of Enterprise St.",male,N/A,"Adult 18+",N/A
+"November 15, 2014",Delaware,Georgetown,"Cedar Creek Road",male,N/A,"Adult 18+",N/A
+"November 15, 2014",Delaware,Lincoln,"8819 Cedar Creek Road",male,N/A,"Adult 18+",N/A
+"November 15, 2014",Delaware,"New Castle","N. DuPont Highway",N/A,N/A,Unknown,N/A
+"November 15, 2014",Delaware,"New Castle","N. DuPont Highway",male,N/A,"Adult 18+",N/A
+"November 14, 2014",Delaware,Claymont,"Harvey Road and Garfield Avenue",male,"William F. McNulty","Adult 18+",N/A
+"November 14, 2014",Delaware,Wilmington,"700 N Monroe St",male,N/A,"Teen 12-17",N/A
+"November 14, 2014",Delaware,Wilmington,"700 N Monroe St",male,N/A,"Teen 12-17",N/A
+"November 14, 2014",Delaware,Wilmington,"700 N Monroe St",male,N/A,"Teen 12-17",N/A
+"November 14, 2014",Delaware,Wilmington,"700 N Monroe St",male,N/A,"Adult 18+",N/A
+"November 14, 2014",Delaware,Wilmington,"700 N Monroe St",male,N/A,"Adult 18+",N/A
+"November 13, 2014",Delaware,Newark,"Marrows Road",male,"Marcus Johnson","Adult 18+",N/A
+"November 13, 2014",Delaware,Newark,"Marrows Road",male,"Karel Blalock","Teen 12-17",N/A
+"November 13, 2014",Delaware,Newark,"Marrows Road",male,"Isaac Chattin","Teen 12-17",N/A
+"November 13, 2014",Delaware,Newark,"Marrows Road",male,"Dariel Pankins","Adult 18+",N/A
+"November 12, 2014",Delaware,Bridgeville,"4700 block of Rabbit Run Road",male,"Alton J. Rose, Jr.","Adult 18+",N/A
+"November 11, 2014",Delaware,Wilmington,"1100 block of W. Second St.",male,N/A,"Adult 18+",N/A
+"November 11, 2014",Delaware,Wilmington,"4865 Governor Printz Blvd.",male,N/A,"Adult 18+",N/A
+"November 11, 2014",Delaware,Wilmington,"Taylor and Bennett streets",male,N/A,"Adult 18+",N/A
+"November 11, 2014",Delaware,Wilmington,"1500 block of Lancaster Ave.",female,N/A,"Adult 18+",N/A
+"November 11, 2014",Delaware,Wilmington,"1500 block of Lancaster Ave.",male,N/A,"Adult 18+",N/A
+"November 9, 2014",Delaware,Wilmington,"1200 block of Pleasant St",male,N/A,"Adult 18+",N/A
+"November 9, 2014",Delaware,Wilmington,"1200 block of Pleasant St",male,"Jacquez I. Robinson","Adult 18+",N/A
+"November 8, 2014",Delaware,Wilmington,"24th and N. Tatnall Street",male,N/A,"Teen 12-17",N/A
+"November 8, 2014",Delaware,Wilmington,"24th and N. Tatnall Street",male,N/A,"Teen 12-17",N/A
+"November 7, 2014",Delaware,Wilmington,"South Road",male,N/A,"Adult 18+",N/A
+"November 7, 2014",Delaware,Wilmington,"South Road",female,N/A,"Adult 18+",N/A
+"November 7, 2014",Delaware,Wilmington,"2400 block of N. Market St.",male,N/A,"Adult 18+",N/A
+"November 6, 2014",Delaware,Wilmington,"Fourth and North Rodney Streets",male,N/A,"Teen 12-17",N/A
+"November 5, 2014",Delaware,Wilmington,"200 block of Atlantic Avenue",male,"John Rizzo","Adult 18+",N/A
+"November 5, 2014",Delaware,Wilmington,"400 block of S. Heald St.",male,"Ronald Brown","Adult 18+",N/A
+"November 5, 2014",Delaware,Wilmington,"Taylor and Kirkwood Streets",male,N/A,"Adult 18+",N/A
+"November 4, 2014",Delaware,Wilmington,"Fifth and North Spruce Streets",male,N/A,"Adult 18+",N/A
+"November 4, 2014",Delaware,Wilmington,"Fifth and North Spruce Streets",male,N/A,"Adult 18+",N/A
+"November 4, 2014",Delaware,Wilmington,"600 block of N. Jefferson St.",male,"Officer Justin Wilkers","Adult 18+",N/A
+"November 4, 2014",Delaware,Wilmington,"600 block of N. Jefferson St.",male,N/A,"Adult 18+",N/A
+"November 3, 2014",Delaware,Dover,"1570 N Dupont Hwy",N/A,N/A,"Adult 18+",N/A
+"November 2, 2014",Delaware,Dover,"133 S. Bradford St.",male,N/A,"Adult 18+",N/A
+"November 2, 2014",Delaware,Dover,"133 S. Bradford St.",male,"Michael Brodie","Adult 18+",N/A
+"November 1, 2014",Delaware,Dover,"Loockerman Street",N/A,N/A,"Adult 18+",N/A
+"November 1, 2014",Delaware,Dover,"Loockerman Street",male,N/A,"Adult 18+",N/A
+"October 30, 2014",Delaware,Wilmington,"Fifth and Webb Streets",male,N/A,"Adult 18+",N/A
+"October 29, 2014",Delaware,Wilmington,"700 block of E. 26th St.",male,N/A,"Adult 18+",N/A
+"October 25, 2014",Delaware,Wilmington,"500 block of Concord Avenue",male,"Khalif Lewis","Adult 18+",N/A
+"October 25, 2014",Delaware,Seaford,"Norman Eskridge Highway",male,"James X. Marks","Adult 18+",N/A
+"October 24, 2014",Delaware,Wilmington,"700 block of Wollaston St.",male,N/A,"Teen 12-17",N/A
+"October 23, 2014",Delaware,Wilmington,"Garasches Lane",male,N/A,"Adult 18+",N/A
+"October 23, 2014",Delaware,Wilmington,"900 block of East 17th Street",male,"Larry Horsey","Adult 18+",N/A
+"October 21, 2014",Delaware,Wilmington,"W. 29th St.",male,"Lamar Massas","Adult 18+",N/A
+"October 21, 2014",Delaware,Wilmington,"300 block of W. 29th St.",male,"Miguel Taylor","Adult 18+",N/A
+"October 20, 2014",Delaware,Dover,"835 Bay Road",male,N/A,"Adult 18+",N/A
+"October 20, 2014",Delaware,Dover,"835 Bay Road",male,"Darnell Waples","Adult 18+",N/A
+"October 19, 2014",Delaware,Wilmington,"Fifth and Springer Streets",male,N/A,"Adult 18+",N/A
+"October 19, 2014",Delaware,Wilmington,"East 24th Street",male,N/A,"Teen 12-17",N/A
+"October 10, 2014",Delaware,Wilmington,"800 block of North Monroe Street",male,N/A,"Adult 18+",N/A
+"October 10, 2014",Delaware,Wilmington,"800 block of North Monroe Street",male,N/A,"Adult 18+",N/A
+"October 9, 2014",Delaware,Dagsboro,"30000 block of Hoot Owl Ln",N/A,N/A,"Adult 18+",N/A
+"October 9, 2014",Delaware,Dagsboro,"30000 block of Hoot Owl Ln",N/A,N/A,"Adult 18+",N/A
+"October 9, 2014",Delaware,Dagsboro,"30000 block of Hoot Owl Ln",N/A,N/A,"Adult 18+",N/A
+"October 9, 2014",Delaware,Dagsboro,"30000 block of Hoot Owl Ln",N/A,N/A,"Child 0-11",N/A
+"October 9, 2014",Delaware,Dagsboro,"30000 block of Hoot Owl Ln",male,"Caleb Connor","Adult 18+",N/A
+"October 9, 2014",Delaware,Dagsboro,"30000 block of Hoot Owl Ln",male,"Jason Kashner","Adult 18+",N/A
+"October 8, 2014",Delaware,"Wilmington (Edgemoor)","Rysing Dr and S Rodney Dr",male,N/A,"Adult 18+",N/A
+"October 8, 2014",Delaware,"Wilmington (Edgemoor)","Rysing Dr and S Rodney Dr",male,N/A,"Teen 12-17",N/A
+"October 8, 2014",Delaware,Wilmington,"Old Capitol Trail and St. James Road",male,"Augustine Flores-Perez","Adult 18+",N/A
+"October 5, 2014",Delaware,Wilmington,"1030 S. Market St.",male,N/A,"Adult 18+",N/A
+"October 2, 2014",Delaware,Wilmington,N/A,male,N/A,"Adult 18+",N/A
+"October 2, 2014",Delaware,Wilmington,"Northeast Boulevard and Vandever Avenue",male,"Dennis Davis","Adult 18+",N/A
+"October 2, 2014",Delaware,Wilmington,"West 3rd and North Dupont Street",male,"Tyrone Tackett","Adult 18+",N/A
+"October 1, 2014",Delaware,Wilmington,"1100 block of B Street",male,"Vincent Roy","Adult 18+",N/A
+"October 1, 2014",Delaware,Wilmington,"1300 block of E. 28th St.",male,"Derrick L. Pulliam","Adult 18+",N/A
+"September 30, 2014",Delaware,Wilmington,"Cliffside Court",male,N/A,"Child 0-11",N/A
+"September 30, 2014",Delaware,Wilmington,"Ninth and Lombard Streets",male,"Allen Freeman","Adult 18+",N/A
+"September 28, 2014",Delaware,Wilmington,"800 block of Fourth Street",male,N/A,"Adult 18+",N/A
+"September 27, 2014",Delaware,Wilmington,"800 block of Vandever Avenue",male,N/A,"Teen 12-17",N/A
+"September 23, 2014",Delaware,Wilmington,"2900 block of Washington Street",male,N/A,"Adult 18+",N/A
+"September 20, 2014",Delaware,Wilmington,"Second and West Streets",male,N/A,"Teen 12-17",N/A
+"September 19, 2014",Delaware,Wilmington,"100 N Franklin St",male,N/A,"Adult 18+",N/A
+"September 17, 2014",Delaware,Dover,"3400 block of Judith Rd",female,N/A,"Adult 18+",N/A
+"September 17, 2014",Delaware,Dover,"3400 block of Judith Rd",male,"Glenn A. Sego","Adult 18+",N/A
+"September 15, 2014",Delaware,Elsmere,"2100 block of Seneca Road",male,N/A,"Adult 18+",N/A
+"September 15, 2014",Delaware,Elsmere,"2100 block of Seneca Road",male,N/A,"Adult 18+",N/A
+"September 15, 2014",Delaware,Elsmere,"2100 block of Seneca Road",male,N/A,"Adult 18+",N/A
+"September 14, 2014",Delaware,Wilmington,"26th and North Heald streets",male,N/A,"Teen 12-17",N/A
+"September 11, 2014",Delaware,Laurel,"31000 block of White St",male,N/A,"Adult 18+",N/A
+"September 11, 2014",Delaware,"New Castle","Route 141",male,N/A,"Adult 18+",N/A
+"September 11, 2014",Delaware,"New Castle","Route 141",male,N/A,"Adult 18+",N/A
+"September 10, 2014",Delaware,Glasgow,"2200 block of Glasgow Avenue",male,N/A,"Adult 18+",N/A
+"September 9, 2014",Delaware,Wilmington,"2900 block of West Street",male,"Marquice Houston","Adult 18+",N/A
+"September 9, 2014",Delaware,Dover,"South Governors Boulevard and State Circle",male,N/A,"Adult 18+",N/A
+"September 8, 2014",Delaware,Wilmington,"7th Street and Washington Street",male,N/A,"Adult 18+",N/A
+"September 8, 2014",Delaware,Wilmington,"7th and Washington streets",male,N/A,"Adult 18+",N/A
+"September 6, 2014",Delaware,Wilmington,"700 block of Tatnall Street",male,N/A,"Adult 18+",N/A
+"September 6, 2014",Delaware,Wilmington,"700 block of Tatnall Street",male,N/A,"Teen 12-17",N/A
+"September 5, 2014",Delaware,Wilmington,"Taylor and Kirkwood",male,N/A,"Adult 18+",N/A
+"September 5, 2014",Delaware,Middletown,"Lockwood Street",male,N/A,"Adult 18+",N/A
+"September 5, 2014",Delaware,Middletown,"Lockwood Street",male,N/A,"Adult 18+",N/A
+"September 5, 2014",Delaware,Middletown,"Lockwood Street",male,"Khalil Williams","Adult 18+",N/A
+"September 5, 2014",Delaware,Middletown,"Lockwood Street",male,N/A,"Teen 12-17",N/A
+"September 4, 2014",Delaware,Wilmington,"300 block of W. 24th St.",male,"Manyia Backus","Adult 18+",N/A
+"September 3, 2014",Delaware,Wilmington,"East Seventh Street",N/A,N/A,Unknown,N/A
+"September 3, 2014",Delaware,Wilmington,"East Seventh Street",male,"Kenyetta Jackson",Unknown,N/A
+"September 3, 2014",Delaware,Wilmington,"East Seventh Street",male,"Shawn Mitchell",Unknown,N/A
+"September 3, 2014",Delaware,Wilmington,"900 block of East 26th Street",male,N/A,"Adult 18+",N/A
+"September 3, 2014",Delaware,Wilmington,"36th and Shipley Streets",male,N/A,"Adult 18+",N/A
+"September 2, 2014",Delaware,Wilmington,"1200 block of Lancaster Avenue",male,N/A,"Adult 18+",N/A
+"September 1, 2014",Delaware,Wilmington,"Taylor and Pine Streets",male,N/A,"Adult 18+",N/A
+"August 31, 2014",Delaware,Wilmington,N/A,male,N/A,"Adult 18+",N/A
+"August 31, 2014",Delaware,Wilmington,"27th St and Tatnall St",male,"Howard Watkins","Adult 18+",N/A
+"August 31, 2014",Delaware,Wilmington,"27th St and Tatnall St",male,"Shaquille Briscoe","Adult 18+",N/A
+"August 30, 2014",Delaware,Wilmington,"1600 block of West Fifth Street",male,"Dameir Walker","Adult 18+",N/A
+"August 30, 2014",Delaware,Wilmington,"1030 South Market Street",male,N/A,"Adult 18+",N/A
+"August 30, 2014",Delaware,Wilmington,"1030 South Market Street",male,N/A,"Adult 18+",N/A
+"August 30, 2014",Delaware,Wilmington,"300 block of North Bancroft Parkway",female,"Tamiya Gregory","Adult 18+",N/A
+"August 30, 2014",Delaware,Wilmington,"800 block of North Spruce Street",male,"Ernest Williams","Adult 18+",N/A
+"August 28, 2014",Delaware,Wilmington,"2700 block of North Heald Street",male,N/A,"Teen 12-17",N/A
+"August 27, 2014",Delaware,"Mill Creek","1200 block of Braken Avenue",male,"Nicolas Chapman","Adult 18+",N/A
+"August 27, 2014",Delaware,Dover,"North Kirkwood Street",male,N/A,"Adult 18+",N/A
+"August 27, 2014",Delaware,Dover,"North Kirkwood Street",male,N/A,"Adult 18+",N/A
+"August 26, 2014",Delaware,Wilmington,"50 block of Cunard St",male,N/A,"Teen 12-17",N/A
+"August 26, 2014",Delaware,Wilmington,"1000 block of South Rodney Street",male,N/A,"Adult 18+",N/A
+"August 26, 2014",Delaware,Wilmington,"1000 block of South Rodney Street",male,N/A,"Adult 18+",N/A
+"August 26, 2014",Delaware,Wilmington,"1000 block of South Rodney Street",male,N/A,"Adult 18+",N/A
+"August 26, 2014",Delaware,Wilmington,"1000 block of South Rodney Street",male,N/A,"Adult 18+",N/A
+"August 26, 2014",Delaware,Wilmington,"1400 block of North Washington Street",male,"Thomas Norris","Adult 18+",N/A
+"August 25, 2014",Delaware,Wilmington,"800 block of Pine Street",male,"Shawn McDougale","Adult 18+",N/A
+"August 24, 2014",Delaware,Dover,"South Kirkwood Street",N/A,N/A,"Adult 18+",N/A
+"August 24, 2014",Delaware,Dover,"300 block of Simon Circle",male,"Tyson Henry","Adult 18+",N/A
+"August 24, 2014",Delaware,Dover,"300 block of Simon Circle",female,N/A,"Adult 18+",N/A
+"August 23, 2014",Delaware,Seaford,"Ponds End Rd",male,N/A,"Teen 12-17",N/A
+"August 23, 2014",Delaware,Seaford,"Ponds End Rd",male,N/A,"Adult 18+",N/A
+"August 23, 2014",Delaware,Wilmington,"3000 block of Washington Street",male,"Daniel Gill","Adult 18+",N/A
+"August 21, 2014",Delaware,Lewes,"17000 block of King Philip Way",male,N/A,"Adult 18+",N/A
+"August 21, 2014",Delaware,Lewes,"17000 block of King Philip Way",male,"Montroll T. Burton","Adult 18+",N/A
+"August 21, 2014",Delaware,Lewes,"17000 block of King Philip Way",male,"Paris J. Boyer","Adult 18+",N/A
+"August 21, 2014",Delaware,Wilmington,"4600 block of North Market Street",male,N/A,"Adult 18+",N/A
+"August 21, 2014",Delaware,Wilmington,"4600 block of North Market Street",male,"Obediah York-James","Teen 12-17",N/A
+"August 21, 2014",Delaware,Wilmington,"4600 block of North Market Street",male,N/A,"Adult 18+",N/A
+"August 21, 2014",Delaware,Wilmington,"4600 block of North Market Street",male,N/A,"Adult 18+",N/A
+"August 21, 2014",Delaware,Wilmington,"4600 block of North Market Street",male,N/A,"Adult 18+",N/A
+"August 21, 2014",Delaware,Dover,"100 Governors Avenue",male,"Diandre Willis ","Adult 18+",N/A
+"August 19, 2014",Delaware,Wilmington,"West Third Street",male,"Brandon Wiggins","Adult 18+",N/A
+"August 19, 2014",Delaware,Wilmington,"West Third Street",male,N/A,"Adult 18+",N/A
+"August 19, 2014",Delaware,Wilmington,"800 block of West Fourth Street",male,N/A,"Adult 18+",N/A
+"August 17, 2014",Delaware,Elsmere,"2700 block of Boulevard Road",male,N/A,"Adult 18+",N/A
+"August 17, 2014",Delaware,Wilmington,"700 block of East 28th Street",male,N/A,"Adult 18+",N/A
+"August 17, 2014",Delaware,Elsmere,"2700 block of Boulevard Road",male,"JayJuan Craig","Adult 18+",N/A
+"August 17, 2014",Delaware,Wilmington,"700 block of East 28th Street",N/A,N/A,Unknown,N/A
+"August 17, 2014",Delaware,Elsmere,"2700 block of Boulevard Road",male,"Daveion Johnson","Adult 18+",N/A
+"August 17, 2014",Delaware,Wilmington,"700 block of East 28th Street",N/A,N/A,Unknown,N/A
+"August 17, 2014",Delaware,Wilmington,"400 block of North Washington Street",male,"Kirk Flowers","Adult 18+",N/A
+"August 17, 2014",Delaware,Wilmington,"700 block of East 28th Street",N/A,N/A,Unknown,N/A
+"August 17, 2014",Delaware,Wilmington,"400 block of North Washington Street",male,"Rasheed Smith","Adult 18+",N/A
+"August 17, 2014",Delaware,Wilmington,"700 block of East 28th Street",N/A,N/A,Unknown,N/A
+"August 17, 2014",Delaware,Wilmington,"500 block of West 35th Street",male,"Kirk Flowers","Adult 18+",N/A
+"August 17, 2014",Delaware,Wilmington,"500 block of West 35th Street",male,"Rasheed Smith","Adult 18+",N/A
+"August 17, 2014",Delaware,Wilmington,"500 block of West 35th Street",female,"Cleo Jones","Adult 18+",N/A
+"August 17, 2014",Delaware,Wilmington,"500 block of West 35th Street",female,"Ashley Haskins","Adult 18+",N/A
+"August 17, 2014",Delaware,"New Castle","West Eighth and Delaware Streets",male,"Michael R. Nolting","Adult 18+",N/A
+"August 17, 2014",Delaware,Bear,"Pulaski Highway and Wrangle Hill Road",male,N/A,"Adult 18+",N/A
+"August 17, 2014",Delaware,Bear,"Pulaski Highway and Wrangle Hill Road",male,"Carlos E. Garcia-Antonio","Adult 18+",N/A
+"August 17, 2014",Delaware,Dover,"South New Street",male,N/A,"Adult 18+",N/A
+"August 17, 2014",Delaware,Dover,"South New Street",male,"Aaron Brown","Adult 18+",N/A
+"August 17, 2014",Delaware,"New Castle","100 block of Parma Avenue",male,N/A,"Adult 18+",N/A
+"August 16, 2014",Delaware,Lincoln,"20639 Fleatown Road",male,N/A,"Adult 18+",N/A
+"August 16, 2014",Delaware,Lincoln,"20639 Fleatown Road",male,N/A,"Adult 18+",N/A
+"August 16, 2014",Delaware,Harrington,"South Du Pont Highway",female,"Erika Deputy","Adult 18+",N/A
+"August 16, 2014",Delaware,Lincoln,"20639 Fleatown Road",male,N/A,"Adult 18+",N/A
+"August 15, 2014",Delaware,Wilmington,"2700 block of Northeast Boulevard",male,N/A,"Adult 18+",N/A
+"August 14, 2014",Delaware,Wilmington,"10th and Adams Streets",N/A,N/A,"Adult 18+",N/A
+"August 13, 2014",Delaware,Wilmington,"24th and Claymont Streets",male,N/A,"Adult 18+",N/A
+"August 12, 2014",Delaware,"New Castle","1627 New Jersey Ave",male,N/A,"Teen 12-17",N/A
+"August 12, 2014",Delaware,"New Castle","1627 New Jersey Ave",male,N/A,"Adult 18+",N/A
+"August 12, 2014",Delaware,"New Castle","1627 New Jersey Ave",male,N/A,"Adult 18+",N/A
+"August 12, 2014",Delaware,Wilmington,"400 block of North Monroe Street",male,N/A,"Adult 18+",N/A
+"August 12, 2014",Delaware,Wilmington,"400 block of North Monroe Street",male,N/A,"Adult 18+",N/A
+"August 12, 2014",Delaware,Wilmington,"400 block of North Monroe Street",male,N/A,"Adult 18+",N/A
+"August 12, 2014",Delaware,Wilmington,"400 block of North Monroe Street",male,N/A,"Adult 18+",N/A
+"August 12, 2014",Delaware,Wilmington,"400 block of North Monroe Street",male,N/A,"Adult 18+",N/A
+"August 12, 2014",Delaware,Wilmington,"300 block of North Du Pont Street",male,N/A,"Teen 12-17",N/A
+"August 12, 2014",Delaware,"New Castle","Memorial Drive",male,N/A,"Adult 18+",N/A
+"August 12, 2014",Delaware,"New Castle","Memorial Drive",male,N/A,"Adult 18+",N/A
+"August 11, 2014",Delaware,Dover,N/A,male,N/A,"Adult 18+",N/A
+"August 11, 2014",Delaware,Dover,N/A,male,"Robert Sanders","Adult 18+",N/A
+"August 10, 2014",Delaware,Newark,"Old Baltimore Pike",male,"Tyrone Baines","Adult 18+",N/A
+"August 10, 2014",Delaware,Newark,"Old Baltimore Pike",male,"Durell Owens","Adult 18+",N/A
+"August 10, 2014",Delaware,Greenwood,"11000 block of Adamsville Road",male,N/A,"Adult 18+",N/A
+"August 10, 2014",Delaware,Greenwood,"11000 block of Adamsville Road",male,N/A,"Adult 18+",N/A
+"August 10, 2014",Delaware,Greenwood,"11000 block of Adamsville Road",male,N/A,"Adult 18+",N/A
+"August 8, 2014",Delaware,"New Castle","Stonebridge Boulevard",male,"Stephen Thomas","Adult 18+",N/A
+"August 8, 2014",Delaware,Wilmington,"500 block of Shearman Street",male,N/A,"Adult 18+",N/A
+"August 8, 2014",Delaware,Wilmington,"East 13th and Claymont Streets",male,"Terence Purnell","Adult 18+",N/A
+"August 8, 2014",Delaware,Wilmington,"West 27th and North Tatnall Streets",male,N/A,"Adult 18+",N/A
+"August 8, 2014",Delaware,Wilmington,"West 27th and North Tatnall Streets",female,N/A,"Adult 18+",N/A
+"August 8, 2014",Delaware,"New Castle","U.S. 13",male,"Stephen Thomas","Adult 18+",N/A
+"August 7, 2014",Delaware,Wilmington,"600 block of West Lea Boulevard",male,"Marquis Pressey","Adult 18+",N/A
+"August 6, 2014",Delaware,Bear,"Delaware 71",male,"Master Cpl. Thad Boyce","Adult 18+",N/A
+"August 6, 2014",Delaware,Bear,"Delaware 71",male,"John E. Greenlee","Adult 18+",N/A
+"August 5, 2014",Delaware,Stanton,"1900 block of West Newport Pike",female,N/A,"Adult 18+",N/A
+"August 5, 2014",Delaware,Stanton,"1900 block of West Newport Pike",male,N/A,"Teen 12-17",N/A
+"August 5, 2014",Delaware,Stanton,"1900 block of West Newport Pike",male,"Gregory Alexander","Adult 18+",N/A
+"August 4, 2014",Delaware,Wilmington,N/A,N/A,N/A,"Adult 18+",N/A
+"August 4, 2014",Delaware,Wilmington,N/A,N/A,N/A,"Adult 18+",N/A
+"August 4, 2014",Delaware,Wilmington,N/A,male,N/A,"Adult 18+",N/A
+"August 3, 2014",Delaware,"New Castle","100 block of Stamm Boulevard",N/A,N/A,Unknown,N/A
+"August 3, 2014",Delaware,Laurel,"30661 Sussex Highway",N/A,N/A,Unknown,N/A
+"August 3, 2014",Delaware,Laurel,"30661 Sussex Highway",male,"Henry A. Larios-Quiroz","Adult 18+",N/A
+"August 3, 2014",Delaware,Wilmington,"300 block of Concord Avenue",male,N/A,"Adult 18+",N/A
+"August 1, 2014",Delaware,Wilmington,"300 block of Concord Avenue",male,N/A,"Adult 18+",N/A
+"July 29, 2014",Delaware,Wilmington,"200 block of Washington Street",male,"Taryn Ross","Adult 18+",N/A
+"July 29, 2014",Delaware,Wilmington,"700 block of Curlett Street",male,N/A,"Adult 18+",N/A
+"July 29, 2014",Delaware,Wilmington,"700 block of Curlett Street",N/A,N/A,"Adult 18+",N/A
+"July 29, 2014",Delaware,Wilmington,"700 block of Curlett Street",N/A,N/A,"Adult 18+",N/A
+"July 28, 2014",Delaware,Newark,"50 block of Thorn Ln",male,N/A,"Adult 18+",N/A
+"July 28, 2014",Delaware,Newark,"50 block of Thorn Ln",male,N/A,"Teen 12-17",N/A
+"July 27, 2014",Delaware,Wilmington,"1300 block of Chestnut Street",male,N/A,"Teen 12-17",N/A
+"July 26, 2014",Delaware,Bear,"1800 block of Pulaski Highway",male,N/A,"Adult 18+",N/A
+"July 26, 2014",Delaware,Bear,"1800 block of Pulaski Highway",male,"Brandon Burns","Adult 18+",N/A
+"July 26, 2014",Delaware,Bear,"1800 block of Pulaski Highway",female,"Rebecca Evans","Adult 18+",N/A
+"July 25, 2014",Delaware,Seaford,"300 North Dual Highway",male,"Edward T. Winder","Adult 18+",N/A
+"July 22, 2014",Delaware,Smyrna,"50 block of E South St",male,"William Alexander","Adult 18+",N/A
+"July 22, 2014",Delaware,Smyrna,"50 block of E South St",female,"Sara Smith","Adult 18+",N/A
+"July 21, 2014",Delaware,Dover,"Saulsbury and Walker Roads",male,"Dante Durham","Adult 18+",N/A
+"July 20, 2014",Delaware,Dover,"N DuPont Hwy and Leipsic Rd",male,"Shaquille Thomas","Adult 18+",N/A
+"July 20, 2014",Delaware,Dover,"N DuPont Hwy and Leipsic Rd",female,"Laura Troise","Adult 18+",N/A
+"July 17, 2014",Delaware,Millsboro,N/A,male,N/A,"Adult 18+",N/A
+"July 17, 2014",Delaware,Millsboro,N/A,N/A,N/A,Unknown,N/A
+"July 17, 2014",Delaware,"New Castle","Buttonwood Ave",male,"Erick Moon","Adult 18+",N/A
+"July 17, 2014",Delaware,Wilmington,"22nd and Pine Streets",male,N/A,"Adult 18+",N/A
+"July 14, 2014",Delaware,Dover,"Kentwood Drive",male,"Lateef Dickerson","Adult 18+",N/A
+"July 14, 2014",Delaware,Dover,"Kentwood Drive",female,"Caprice Black","Adult 18+",N/A
+"July 14, 2014",Delaware,Dover,"Kentwood Drive",female,"Diavonna Moulden","Adult 18+",N/A
+"July 13, 2014",Delaware,Wilmington,"100 block of North Van Buren Street",male,N/A,"Adult 18+",N/A
+"July 13, 2014",Delaware,Wilmington,"100 block of North Van Buren Street",male,N/A,"Adult 18+",N/A
+"July 13, 2014",Delaware,Wilmington,"100 block of North Van Buren Street",male,N/A,"Adult 18+",N/A
+"July 13, 2014",Delaware,"New Castle","260 Christiana Road",male,N/A,"Adult 18+",N/A
+"July 13, 2014",Delaware,"New Castle","260 Christiana Road",male,"Marcus Rosser","Adult 18+",N/A
+"July 12, 2014",Delaware,Middletown,"300 block of Marldale Drive",male,N/A,"Adult 18+",N/A
+"July 11, 2014",Delaware,Wilmington,"West 24th and North Market Streets",male,N/A,"Adult 18+",N/A
+"July 9, 2014",Delaware,Wilmington,"100 block of East 22nd Street",male,"Otis Saunders","Adult 18+",N/A
+"July 9, 2014",Delaware,Wilmington,"15 West Lea Boulevard",male,N/A,"Adult 18+",N/A
+"July 9, 2014",Delaware,Wilmington,"15 West Lea Boulevard",male,N/A,"Adult 18+",N/A
+"July 9, 2014",Delaware,Wilmington,"15 West Lea Boulevard",N/A,N/A,"Adult 18+",N/A
+"July 8, 2014",Delaware,Wilmington,N/A,male,N/A,"Adult 18+",N/A
+"July 8, 2014",Delaware,Wilmington,N/A,male,N/A,"Adult 18+",N/A
+"July 7, 2014",Delaware,Wilmington,"West 35th and North Market Streets",male,"Sirair Bailey","Adult 18+",N/A
+"July 7, 2014",Delaware,Wilmington,"West 35th and North Market Streets",male,N/A,"Adult 18+",N/A
+"July 7, 2014",Delaware,Wilmington,"West 7th and North Adams Streets",male,"Crystal Brown","Adult 18+",N/A
+"July 7, 2014",Delaware,Wilmington,"West 35th and North Market Streets",male,"Troy Faison","Adult 18+",N/A
+"July 6, 2014",Delaware,Dover,"217 N Kirkwood St",N/A,N/A,"Adult 18+",N/A
+"July 6, 2014",Delaware,Dover,"217 N Kirkwood St",N/A,N/A,"Adult 18+",N/A
+"July 6, 2014",Delaware,Dover,"217 N Kirkwood St",male,"James Ewell","Teen 12-17",N/A
+"July 6, 2014",Delaware,Wilmington,"West Fifth and North Madison",male,N/A,"Adult 18+",N/A
+"July 5, 2014",Delaware,Wilmington,"200 block of North Van Buren Street",male,"Shavar Watson","Adult 18+",N/A
+"July 5, 2014",Delaware,Felton,"2000 block of Vernon Road",male,"Steven A. Tribbett","Adult 18+",N/A
+"July 4, 2014",Delaware,Dover,"Norway Drive",male,N/A,"Adult 18+",N/A
+"July 4, 2014",Delaware,Dover,"Norway Drive",male,N/A,"Adult 18+",N/A
+"July 4, 2014",Delaware,Wilmington,"300 block of North Monroe Street",male,N/A,"Teen 12-17",N/A
+"July 4, 2014",Delaware,Dover,"Norway Drive",male,N/A,"Adult 18+",N/A
+"July 4, 2014",Delaware,Wilmington,"100 block of West 27th Street",male,N/A,"Adult 18+",N/A
+"July 1, 2014",Delaware,Newark,"300 block of Sandburg Place",male,"Ira Hopkins","Adult 18+",N/A
+"July 1, 2014",Delaware,Newark,"300 block of Sandburg Place",male,N/A,"Adult 18+",N/A
+"July 1, 2014",Delaware,Newark,"300 block of Sandburg Place",male,"Jyaire Smith","Adult 18+",N/A
+"July 1, 2014",Delaware,Newark,"300 block of Sandburg Place",male,"Isaac LeCompte","Adult 18+",N/A
+"June 30, 2014",Delaware,Middletown,"2111 Dupont Hwy",male,"Jacob Taylor III","Adult 18+",N/A
+"June 30, 2014",Delaware,Newark,"50 block of Heron Ct",male,"Dewayne Barfield","Adult 18+",N/A
+"June 30, 2014",Delaware,Newark,"50 block of Heron Ct",male,"Michael Walley","Teen 12-17",N/A
+"June 30, 2014",Delaware,Wilmington,"Pine and Taylor Streets",male,"Brian Rivers","Adult 18+",N/A
+"June 30, 2014",Delaware,Newark,"Heron Court",male,N/A,"Adult 18+",N/A
+"June 29, 2014",Delaware,Townsend,"6300 block of Summit Bridge Road",male,N/A,"Adult 18+",N/A
+"June 29, 2014",Delaware,Townsend,"6300 block of Summit Bridge Road",male,N/A,"Adult 18+",N/A
+"June 29, 2014",Delaware,Townsend,"6300 block of Summit Bridge Road",male,N/A,"Adult 18+",N/A
+"June 28, 2014",Delaware,Elsmere,"1950 Maryland Avenue",male,N/A,"Adult 18+",N/A
+"June 28, 2014",Delaware,Elsmere,"1950 Maryland Avenue",male,N/A,"Adult 18+",N/A
+"June 28, 2014",Delaware,Wilmington,"Maryland Avenue",male,N/A,"Adult 18+",N/A
+"June 28, 2014",Delaware,Wilmington,"Maryland Avenue",male,N/A,"Adult 18+",N/A
+"June 27, 2014",Delaware,Bear,"1800 block of Pulaski Highway",male,N/A,"Adult 18+",N/A
+"June 25, 2014",Delaware,Magnolia,"Bay Hill  Ln and W Birdie Ln",male,"Corporal Lloyd McMann","Adult 18+",N/A
+"June 25, 2014",Delaware,Magnolia,"Bay Hill  Ln and W Birdie Ln",male,"Dennis Hicks","Adult 18+",N/A
+"June 25, 2014",Delaware,Wilmington,"10th Street and Jackson",male,N/A,"Adult 18+",N/A
+"June 23, 2014",Delaware,Wilmington,"500 block of West Sixth Street",male,N/A,"Adult 18+",N/A
+"June 23, 2014",Delaware,Wilmington,"500 block of West Sixth Street",male,"Demarius Bradley","Adult 18+",N/A
+"June 23, 2014",Delaware,"New Castle","DuPont Highway",male,N/A,"Adult 18+",N/A
+"June 23, 2014",Delaware,"New Castle","DuPont Highway",male,N/A,"Adult 18+",N/A
+"June 22, 2014",Delaware,Wilmington,"700 block of North Spruce Street",male,N/A,"Adult 18+",N/A
+"June 22, 2014",Delaware,Wilmington,"700 block of North Spruce Street",male,N/A,"Adult 18+",N/A
+"June 21, 2014",Delaware,Wilmington,"800 block of North Pine Street",male,N/A,"Adult 18+",N/A
+"June 19, 2014",Delaware,Wilmington,"300 block of North Pine Street",male,"Charles May","Adult 18+",N/A
+"June 18, 2014",Delaware,Townsend,"6300 block of Summit Bridge Road",male,N/A,"Adult 18+",N/A
+"June 18, 2014",Delaware,Townsend,"6300 block of Summit Bridge Road",N/A,N/A,"Adult 18+",N/A
+"June 18, 2014",Delaware,Townsend,"6300 block of Summit Bridge Road",N/A,N/A,"Adult 18+",N/A
+"June 17, 2014",Delaware,Newark,"Stanton-Ogletown Road and Churchmans Road",male,"Preston Smith","Adult 18+",N/A
+"June 16, 2014",Delaware,Dover,"100 block of Vera Way",male,"Turhan Blenman","Adult 18+",N/A
+"June 15, 2014",Delaware,Wilmington,"200 block of Murphy Road",male,"Peter Muench","Adult 18+",N/A
+"June 13, 2014",Delaware,Bear,"Rivers End Drive",male,N/A,"Teen 12-17",N/A
+"June 11, 2014",Delaware,Dover,"Becky Lane",female,N/A,"Adult 18+",N/A
+"June 11, 2014",Delaware,Dover,"Becky Lane",male,N/A,"Adult 18+",N/A
+"June 11, 2014",Delaware,Dover,"Becky Lane",N/A,N/A,"Child 0-11",N/A
+"June 11, 2014",Delaware,Dover,"Becky Lane",male,N/A,"Adult 18+",N/A
+"June 11, 2014",Delaware,Dover,"Becky Lane",male,N/A,"Adult 18+",N/A
+"June 10, 2014",Delaware,Newark,"Harlech Hall",female,N/A,"Adult 18+",N/A
+"June 10, 2014",Delaware,Newark,"Harlech Hall",male,N/A,"Adult 18+",N/A
+"June 10, 2014",Delaware,Newark,"Harlech Hall",male,"Jason Brunson","Adult 18+",N/A
+"June 10, 2014",Delaware,Newark,"50 block of Harlech Hall",female,N/A,"Adult 18+",N/A
+"June 10, 2014",Delaware,Newark,"50 block of Harlech Hall",male,N/A,"Adult 18+",N/A
+"June 10, 2014",Delaware,Newark,"50 block of Harlech Hall",male,"Jason Brunson","Adult 18+",N/A
+"June 10, 2014",Delaware,Claymont,"Ridge Road",male,N/A,"Adult 18+",N/A
+"June 10, 2014",Delaware,Claymont,"Ridge Road",male,N/A,"Adult 18+",N/A
+"June 10, 2014",Delaware,Wilmington,"100 block of West 31st Street",male,N/A,"Adult 18+",N/A
+"June 10, 2014",Delaware,Wilmington,"400 block of North Broom Street",male,N/A,"Adult 18+",N/A
+"June 10, 2014",Delaware,Wilmington,"400 block of North Broom Street",male,N/A,"Adult 18+",N/A
+"June 10, 2014",Delaware,Wilmington,"400 block of North Broom Street",male,N/A,"Adult 18+",N/A
+"June 8, 2014",Delaware,Dover,"Voshells Mill Star Hill Road",male,N/A,"Adult 18+",N/A
+"June 8, 2014",Delaware,Dover,"Voshells Mill Star Hill Road",male,N/A,"Adult 18+",N/A
+"June 7, 2014",Delaware,Dover,"51 Webbs Lane",male,"Christopher A. Gillis","Adult 18+",N/A
+"June 7, 2014",Delaware,Dover,"51 Webbs Lane",male,N/A,"Adult 18+",N/A
+"June 6, 2014",Delaware,Newark,"Martell Rd and Matthews Rd",male,N/A,"Adult 18+",N/A
+"June 6, 2014",Delaware,Newark,"Martell Rd and Matthews Rd",male,N/A,"Adult 18+",N/A
+"June 6, 2014",Delaware,Wilmington,"1601 Kirkwood Hwy",male,"Charles Jobe","Adult 18+",N/A
+"June 5, 2014",Delaware,Claymont,"700 block of Peachtree Road",male,N/A,"Adult 18+",N/A
+"June 4, 2014",Delaware,Newark,"100 Continental Dr",female,N/A,"Adult 18+",N/A
+"June 4, 2014",Delaware,Newark,"100 Continental Dr",male,"Datwan Nelson","Adult 18+",N/A
+"June 4, 2014",Delaware,"New Castle","713 East Basin Road",N/A,N/A,"Teen 12-17",N/A
+"June 4, 2014",Delaware,"New Castle","713 East Basin Road",N/A,N/A,"Teen 12-17",N/A
+"June 4, 2014",Delaware,"New Castle","713 East Basin Road",N/A,N/A,"Teen 12-17",N/A
+"June 4, 2014",Delaware,Bear,"Printz Drive",male,"Domonick Richards","Adult 18+",N/A
+"June 3, 2014",Delaware,Bridgeville,"Chaplins Chapel Road",male,"Marc Muse","Adult 18+",N/A
+"June 3, 2014",Delaware,Bridgeville,"Chaplins Chapel Road",female,"Sharnice U. Harris","Adult 18+",N/A
+"June 1, 2014",Delaware,Wilmington,"200 block of North Broom Street",male,N/A,"Adult 18+",N/A
+"May 30, 2014",Delaware,Dover,"Barnsley Ct",male,N/A,"Adult 18+",N/A
+"May 30, 2014",Delaware,Dover,"Barnsley Ct",male,N/A,"Adult 18+",N/A
+"May 30, 2014",Delaware,Dover,"Barnsley Ct",male,N/A,"Adult 18+",N/A
+"May 29, 2014",Delaware,Wilmington,"1000 block of North Madison Street",male,N/A,"Adult 18+",N/A
+"May 29, 2014",Delaware,Wilmington,"2700 block of Bowers Street",female,N/A,"Adult 18+",N/A
+"May 29, 2014",Delaware,Wilmington,"2700 block of Bowers Street",male,N/A,"Adult 18+",N/A
+"May 29, 2014",Delaware,"Delaware City","100 block of Fifth Street",female,N/A,"Adult 18+",N/A
+"May 29, 2014",Delaware,"Delaware City","100 block of Fifth Street",male,"Robert Love","Adult 18+",N/A
+"May 29, 2014",Delaware,"Delaware City","Clinton Street",male,"Robert Love","Adult 18+",N/A
+"May 28, 2014",Delaware,Smyrna,"Sugar Maple Ln",male,"James King","Adult 18+",N/A
+"May 28, 2014",Delaware,Smyrna,"Sugar Maple Ln",female,"Amanda King","Adult 18+",N/A
+"May 28, 2014",Delaware,Smyrna,"500 block of West Commerce Street",male,N/A,"Adult 18+",N/A
+"May 27, 2014",Delaware,Wilmington,"1100 block of Conrad St",male,"Alphonso Boyd","Adult 18+",N/A
+"May 27, 2014",Delaware,Wilmington,"1100 block of Conrad St",male,"Demonte Johnson","Adult 18+",N/A
+"May 27, 2014",Delaware,Dover,"200 block of South Governors Avenue",male,N/A,"Adult 18+",N/A
+"May 27, 2014",Delaware,Dover,"200 block of South Governors Avenue",male,N/A,"Adult 18+",N/A
+"May 27, 2014",Delaware,Dover,"200 block of South Governors Avenue",male,N/A,"Adult 18+",N/A
+"May 27, 2014",Delaware,Townsend,"200 block of Aberdeen Way",male,N/A,"Adult 18+",N/A
+"May 27, 2014",Delaware,Townsend,"200 block of Aberdeen Way",male,N/A,"Adult 18+",N/A
+"May 27, 2014",Delaware,Townsend,"200 block of Aberdeen Way",male,N/A,"Adult 18+",N/A
+"May 26, 2014",Delaware,Camden,"7000 block of Willow Grove Road",male,"Charles W. Semans","Adult 18+",N/A
+"May 26, 2014",Delaware,Camden,"7000 block of Willow Grove Road",male,"John Rash","Teen 12-17",N/A
+"May 25, 2014",Delaware,Dover,"North New and Division Streets",male,N/A,"Adult 18+",N/A
+"May 25, 2014",Delaware,Dover,"North New and Division Streets",male,N/A,"Adult 18+",N/A
+"May 22, 2014",Delaware,Wilmington,"500 block of North Jefferson Street",male,"Daron Allen","Adult 18+",N/A
+"May 19, 2014",Delaware,Selbyville,N/A,male,"Edward Watkins, Sr.","Adult 18+",N/A
+"May 19, 2014",Delaware,Selbyville,N/A,female,"Robin Watkins","Adult 18+",N/A
+"May 19, 2014",Delaware,Harrington,"2000 block of Bloomfield Drive",male,N/A,"Adult 18+",N/A
+"May 18, 2014",Delaware,Dover,"200 block of Presidents Drive",male,N/A,"Adult 18+",N/A
+"May 18, 2014",Delaware,Dover,"200 block of Presidents Drive",female,N/A,"Adult 18+",N/A
+"May 18, 2014",Delaware,Dover,"200 block of Presidents Drive",female,N/A,"Adult 18+",N/A
+"May 17, 2014",Delaware,Dover,"New Castle Avenue and East Water Street",male,"Alfonzo White","Adult 18+",N/A
+"May 17, 2014",Delaware,Dover,"New Castle Avenue and East Water Street",male,N/A,"Adult 18+",N/A
+"May 16, 2014",Delaware,Wilmington,"500 block of North Broom Street",male,N/A,"Adult 18+",N/A
+"May 16, 2014",Delaware,Wilmington,"500 block of North Broom Street",male,N/A,"Adult 18+",N/A
+"May 16, 2014",Delaware,Wilmington,"500 block of North Broom Street",male,N/A,"Adult 18+",N/A
+"May 15, 2014",Delaware,Wilmington,"400 Claymont Street",male,N/A,"Adult 18+",N/A
+"May 14, 2014",Delaware,Wilmington,"610 East 17th Street",male,N/A,"Teen 12-17",N/A
+"May 14, 2014",Delaware,Wilmington,"1800 block of West Third Street",male,"Weusi Johnson","Adult 18+",N/A
+"May 13, 2014",Delaware,Wilmington,"300 block of Linden Street",male,N/A,"Adult 18+",N/A
+"May 13, 2014",Delaware,Wilmington,"300 block of Linden Street",male,N/A,"Adult 18+",N/A
+"May 12, 2014",Delaware,Bear,"200 block of Deep Creek Terrace",male,N/A,"Adult 18+",N/A
+"May 12, 2014",Delaware,Bear,"200 block of Deep Creek Terrace",male,N/A,"Adult 18+",N/A
+"May 12, 2014",Delaware,Bear,"200 block of Deep Creek Terrace",male,N/A,"Adult 18+",N/A
+"May 8, 2014",Delaware,Wilmington,"1600 block of West Fifth Street",male,N/A,"Adult 18+",N/A
+"May 8, 2014",Delaware,Wilmington,"1600 block of West Fifth Street",male,N/A,"Adult 18+",N/A
+"May 8, 2014",Delaware,Wilmington,"1600 block of West Fifth Street",male,N/A,"Adult 18+",N/A
+"May 8, 2014",Delaware,Seaford,"Sussex Avenue and Stein Highway",male,"James Markell Frazier","Adult 18+",N/A
+"May 8, 2014",Delaware,Dover,"6 W. Lebanon Road",N/A,N/A,Unknown,N/A
+"May 8, 2014",Delaware,Dover,"6 W. Lebanon Road",female,N/A,"Adult 18+",N/A
+"May 8, 2014",Delaware,Wilmington,"East 10th and North Spruce Streets",male,"Dewayne Brown","Adult 18+",N/A
+"May 6, 2014",Delaware,Wilmington,"1000 block of South Market Street",male,N/A,"Adult 18+",N/A
+"May 6, 2014",Delaware,Wilmington,"1000 block of South Market Street",N/A,N/A,"Adult 18+",N/A
+"May 6, 2014",Delaware,Dover,"1210 White Oak Road",male,N/A,"Adult 18+",N/A
+"May 6, 2014",Delaware,Dover,"1210 White Oak Road",male,"Robert Hawkes","Adult 18+",N/A
+"May 6, 2014",Delaware,Dover,"1210 White Oak Road",male,N/A,"Adult 18+",N/A
+"May 6, 2014",Delaware,Dover,"1019 Walker Road",male,N/A,"Teen 12-17",N/A
+"May 6, 2014",Delaware,Dover,"1019 Walker Road",male,N/A,"Teen 12-17",N/A
+"May 5, 2014",Delaware,Wilmington,"400 block West 25th Street",female,N/A,"Adult 18+",N/A
+"May 5, 2014",Delaware,Wilmington,"400 block West 25th Street",male,N/A,"Adult 18+",N/A
+"May 5, 2014",Delaware,Wilmington,"400 block West 25th Street",male,N/A,"Adult 18+",N/A
+"May 4, 2014",Delaware,Newark,"15 Fox Hall",male,"Brandon Carrigan","Adult 18+",N/A
+"May 4, 2014",Delaware,Newark,"15 Fox Hall",male,"Jason Scott","Adult 18+",N/A
+"May 1, 2014",Delaware,Wilmington,"East 24th and Market Streets",male,"Tracy Green","Adult 18+",N/A
+"May 1, 2014",Delaware,Wilmington,"200 block of North Rodney Street",male,N/A,"Teen 12-17",N/A
+"May 1, 2014",Delaware,Seaford,"24000 Jewell St",male," Kevin E. Barnes","Adult 18+",N/A
+"May 1, 2014",Delaware,Seaford,"24000 Jewell St",female,"Laura L. Taylor","Adult 18+",N/A
+"April 30, 2014",Delaware,Dover,"700 block of North West Street",male,"David Kimmick","Adult 18+",N/A
+"April 30, 2014",Delaware,Wilmington,"Sherman and Lombard Streets",male,"Wayne Howard","Adult 18+",N/A
+"April 28, 2014",Delaware,Lewes,"33000 block of Camilla Drive",male,N/A,"Adult 18+",N/A
+"April 28, 2014",Delaware,Lewes,"33000 block of Camilla Drive",female,N/A,"Adult 18+",N/A
+"April 28, 2014",Delaware,Lewes,"33000 block of Camilla Drive",male,N/A,"Child 0-11",N/A
+"April 28, 2014",Delaware,Lewes,"33000 block of Camilla Drive",male,"Nicholas Beardsley","Adult 18+",N/A
+"April 28, 2014",Delaware,Lewes,"33000 block of Camilla Drive",male,"Matthias Kellner","Adult 18+",N/A
+"April 27, 2014",Delaware,Wilmington,"2700 block of Lancaster Avenue",male,N/A,"Adult 18+",N/A
+"April 27, 2014",Delaware,Wilmington,"2700 block of Lancaster Avenue",male,N/A,"Adult 18+",N/A
+"April 27, 2014",Delaware,Elsmere,"2110 Kirkwood Highway",male,N/A,"Adult 18+",N/A
+"April 27, 2014",Delaware,Elsmere,"2110 Kirkwood Highway",male,N/A,"Adult 18+",N/A
+"April 27, 2014",Delaware,Elsmere,"2110 Kirkwood Highway",male,"Charles Jaegers","Adult 18+",N/A
+"April 25, 2014",Delaware,Wilmington,"3100 New  Castle",male,"Manuel Ramierez","Adult 18+",N/A
+"April 24, 2014",Delaware,Dover,"12th and Melrose",male,"Javon Williams","Adult 18+",N/A
+"April 22, 2014",Delaware,"New Castle","3100 block of New Castle Ave",male,"Manuel Ramirez","Adult 18+",N/A
+"April 21, 2014",Delaware,Dover,"145 Haman Dr",female,N/A,"Adult 18+",N/A
+"April 21, 2014",Delaware,Dover,"145 Haman Dr",male,"Alexis Alriche","Adult 18+",N/A
+"April 20, 2014",Delaware,Wilmington,"500 block of Clayton Street",female,N/A,"Adult 18+",N/A
+"April 18, 2014",Delaware,Wilmington,"400 block of W 31st Street",male,N/A,"Adult 18+",N/A
+"April 14, 2014",Delaware,Wilmington,"W. 2nd and N. Van Buren streets",male,N/A,"Adult 18+",N/A
+"April 14, 2014",Delaware,Wilmington,"W. 2nd and N. Van Buren streets",male,N/A,"Adult 18+",N/A
+"April 13, 2014",Delaware,Wilmington,"West 25th and Washington",female,N/A,"Adult 18+",N/A
+"April 11, 2014",Delaware,Claymont,"Everett Ave",male,N/A,Unknown,N/A
+"April 11, 2014",Delaware,Claymont,"Everett Ave",male,N/A,"Adult 18+",N/A
+"April 11, 2014",Delaware,Claymont,"Everett Ave",male,N/A,Unknown,N/A
+"April 9, 2014",Delaware,Milford,"100 block of Montgomery Street",male,N/A,"Adult 18+",N/A
+"April 9, 2014",Delaware,Milford,"100 block of Montgomery Street",male,"Jhavon R. Goode","Adult 18+",N/A
+"April 8, 2014",Delaware,"New Castle","1627 New Jersey Ave",male,N/A,"Adult 18+",N/A
+"April 8, 2014",Delaware,"New Castle","1627 New Jersey Ave",male,N/A,"Adult 18+",N/A
+"April 8, 2014",Delaware,"New Castle","1627 New Jersey Ave",male,"DJavon Holland","Adult 18+",N/A
+"April 8, 2014",Delaware,"Wilmington Manor","1600 New Jersey Avenue",N/A,N/A,"Adult 18+",N/A
+"April 8, 2014",Delaware,"Wilmington Manor","1600 New Jersey Avenue",N/A,N/A,"Adult 18+",N/A
+"April 8, 2014",Delaware,"Wilmington Manor","1600 New Jersey Avenue",male,N/A,"Adult 18+",N/A
+"April 8, 2014",Delaware,Newark,"S Chapel Street",male,N/A,"Adult 18+",N/A
+"April 8, 2014",Delaware,Newark,"S Chapel Street",male,N/A,"Adult 18+",N/A
+"April 8, 2014",Delaware,Newark,"S Chapel Street",male,N/A,"Adult 18+",N/A
+"April 3, 2014",Delaware,Dover,"100 block of Spruance Road",male,N/A,"Adult 18+",N/A
+"April 3, 2014",Delaware,Dover,"100 block of Spruance Road",male,"Khiheim Hanzer","Adult 18+",N/A
+"April 3, 2014",Delaware,Wilmington,"Elm and South Harrison ",male,"Theodore Jackson","Adult 18+",N/A
+"April 2, 2014",Delaware,Wilmington,"East 28th Street and Claymont Street",male,"Sinque Hagler","Adult 18+",N/A
+"April 2, 2014",Delaware,Wilmington,"East 28th Street and Claymont Street",male,"Damiere D. Harris","Adult 18+",N/A
+"April 2, 2014",Delaware,Dover,"S State Street",male,N/A,"Adult 18+",N/A
+"April 2, 2014",Delaware,Dover,"S State Street",male,N/A,"Adult 18+",N/A
+"April 2, 2014",Delaware,Wilmington,"Eighth and Pine Streets",female,N/A,"Adult 18+",N/A
+"March 31, 2014",Delaware,Wilmington,"6th and Madison Streets",male,N/A,"Adult 18+",N/A
+"March 30, 2014",Delaware,Claymont,"200 block of Harbor Drive",male,N/A,"Teen 12-17",N/A
+"March 29, 2014",Delaware,Middletown,"2111 Dupont Hwy",N/A,N/A,"Adult 18+",N/A
+"March 29, 2014",Delaware,Middletown,"2111 Dupont Hwy",N/A,N/A,"Adult 18+",N/A
+"March 29, 2014",Delaware,Middletown,"2111 Dupont Hwy",N/A,N/A,"Adult 18+",N/A
+"March 29, 2014",Delaware,Middletown,"2111 Dupont Hwy",N/A,N/A,"Adult 18+",N/A
+"March 29, 2014",Delaware,Middletown,"2111 Dupont Hwy",male,N/A,"Adult 18+",N/A
+"March 29, 2014",Delaware,Middletown,"2111 Dupont Hwy",N/A,N/A,"Adult 18+",N/A
+"March 27, 2014",Delaware,Talleyville,"4800 block of Governor Printz Boulevard",male,N/A,"Adult 18+",N/A
+"March 27, 2014",Delaware,Talleyville,"4800 block of Governor Printz Boulevard",male,N/A,"Adult 18+",N/A
+"March 27, 2014",Delaware,Talleyville,"4800 block of Governor Printz Boulevard",male,N/A,"Adult 18+",N/A
+"March 27, 2014",Delaware,Wilmington,"600 Naamans Road",male,N/A,"Adult 18+",N/A
+"March 24, 2014",Delaware,Seaford,"23000 block of East Middlecord Circle",female,N/A,"Adult 18+",N/A
+"March 24, 2014",Delaware,Seaford,"23000 block of East Middlecord Circle",female,N/A,"Adult 18+",N/A
+"March 24, 2014",Delaware,Seaford,"23000 block of East Middlecord Circle",female,N/A,"Adult 18+",N/A
+"March 24, 2014",Delaware,Seaford,"23000 block of East Middlecord Circle",male,N/A,"Adult 18+",N/A
+"March 24, 2014",Delaware,Seaford,"23000 block of East Middlecord Circle",male,N/A,"Adult 18+",N/A
+"March 24, 2014",Delaware,Seaford,"23000 block of East Middlecord Circle",male,N/A,"Adult 18+",N/A
+"March 23, 2014",Delaware,Newark,"17 New London Rd",male,"Alex R. Marshall","Adult 18+",N/A
+"March 23, 2014",Delaware,Wilmington,"1030 S. Market St. ",male,N/A,"Adult 18+",N/A
+"March 14, 2014",Delaware,Wilmington,"West 23rd Street",male,N/A,"Adult 18+",N/A
+"March 7, 2014",Delaware,Wilmington,"2100 N Jefferson Street",male,N/A,"Adult 18+",N/A
+"March 7, 2014",Delaware,Wilmington,"2100 N Jefferson Street",male,N/A,"Adult 18+",N/A
+"March 7, 2014",Delaware,Wilmington,"2100 N Jefferson Street",male,N/A,"Adult 18+",N/A
+"March 6, 2014",Delaware,Wilmington,"1200 Lancaster Avenue",male,N/A,"Adult 18+",N/A
+"March 6, 2014",Delaware,Wilmington,"1200 Lancaster Avenue",male,N/A,"Adult 18+",N/A
+"March 4, 2014",Delaware,Wilmington,"700 N Pine Street",male,N/A,"Adult 18+",N/A
+"March 4, 2014",Delaware,Wilmington,"700 N Pine Street",male,N/A,"Adult 18+",N/A
+"February 24, 2014",Delaware,Wilmington,"E 35th and N Church Street",male,N/A,"Adult 18+",N/A
+"February 22, 2014",Delaware,Wilmington,"1300 block of Vandever Avenue ",N/A,N/A,"Adult 18+",N/A
+"February 22, 2014",Delaware,Wilmington,"1300 block of Vandever Avenue ",male,"Qudree Warren","Adult 18+",N/A
+"February 22, 2014",Delaware,Wilmington,"North Union Street",male,"Dennis Williams","Adult 18+",N/A
+"February 18, 2014",Delaware,Wilmington,"500 N Madison Street",male,N/A,"Adult 18+",N/A
+"February 16, 2014",Delaware,Wilmington,"500 block of N. Rodney Street",male,"Kevin Banner ","Adult 18+",N/A
+"February 16, 2014",Delaware,Wilmington,"South Market Street ",male,N/A,"Adult 18+",N/A
+"February 11, 2014",Delaware,Wilmington,"600 N Lincoln Street",male,N/A,"Adult 18+",N/A
+"February 4, 2014",Delaware,Newark,"750 East Delaware Avenue",male,"Zakeer Washington","Adult 18+",N/A
+"February 3, 2014",Delaware,Laurel,"Johnson Road",female,N/A,"Adult 18+",N/A
+"February 3, 2014",Delaware,Laurel,"Johnson Road",male,N/A,Unknown,N/A
+"February 3, 2014",Delaware,Wilmington,"500 block of S. Harrison Street",female,N/A,"Adult 18+",N/A
+"February 3, 2014",Delaware,Wilmington,"500 block of S. Harrison Street",male,"Jahlil Lewis","Adult 18+",N/A
+"February 3, 2014",Delaware,Wilmington,"500 block of S. Harrison Street",female,"Kina Madric","Adult 18+",N/A
+"February 2, 2014",Delaware,Dover,"800 block of Woodcrest Dr",female,N/A,"Adult 18+",N/A
+"February 2, 2014",Delaware,Dover,"800 block of Woodcrest Dr",male,"Jameson Hoxter","Adult 18+",N/A
+"February 1, 2014",Delaware,Wilmington,"2100 block of N. Spruce Street",male,"Tommier Dendy","Adult 18+",N/A
+"January 30, 2014",Delaware,Georgetown,"U.S. 113 and County Seat Highway",male,N/A,"Adult 18+",N/A
+"January 30, 2014",Delaware,Georgetown,"U.S. 113 and County Seat Highway",male,"Kevin M. King II","Adult 18+",N/A
+"January 27, 2014",Delaware,Felton,"700 block of Walnut Shade Rd",male,"Franklin E. Morris","Adult 18+",N/A
+"January 27, 2014",Delaware,Felton,"700 block of Walnut Shade Rd",male,"Nathan E. Morris","Adult 18+",N/A
+"January 25, 2014",Delaware,Dover,"Division Street and New Street",male,N/A,"Adult 18+",N/A
+"January 24, 2014",Delaware,Wilmington,"Harpers Place",male,N/A,"Adult 18+",N/A
+"January 24, 2014",Delaware,Wilmington,"Harpers Place",male,N/A,"Adult 18+",N/A
+"January 24, 2014",Delaware,Wilmington,"Harpers Place",male,"Jabbar Shy","Adult 18+",N/A
+"January 20, 2014",Delaware,Dover,"200 block of N Wilson Dr",male,N/A,"Adult 18+",N/A
+"January 20, 2014",Delaware,Dover,"200 block of N Wilson Dr",male,N/A,"Adult 18+",N/A
+"January 20, 2014",Delaware,Dover,"200 block of N Wilson Dr",male,N/A,"Adult 18+",N/A
+"January 20, 2014",Delaware,Dover,"200 block of N Wilson Dr",male,N/A,"Adult 18+",N/A
+"January 18, 2014",Delaware,Wilmington,"700 block of South Broom Street",male,N/A,"Adult 18+",N/A
+"January 18, 2014",Delaware,Wilmington,"500 block of Springer Street",N/A,N/A,Unknown,N/A
+"January 18, 2014",Delaware,Wilmington,"500 block of Springer Street",N/A,N/A,Unknown,N/A
+"January 17, 2014",Delaware,Wilmington,"200 block of N. Van Buren Street",male,"Jacob Santiago","Adult 18+",N/A
+"January 16, 2014",Delaware,Wilmington,"26th and Monroe Streets",male,N/A,"Adult 18+",N/A
+"January 16, 2014",Delaware,Wilmington,"900 block of E. 12th Street",male,"Deontay Willingham","Adult 18+",N/A
+"January 14, 2014",Delaware,Millsboro,"28000 block of Harmons Hill Rd",male,"Cletis Nelson","Adult 18+",N/A
+"January 14, 2014",Delaware,Millsboro,"28000 block of Harmons Hill Rd",male,"William Hopkins","Adult 18+",N/A
+"January 14, 2014",Delaware,Millsboro,"28000 block of Harmons Hill Rd",male,"Rhamir Waples","Adult 18+",N/A
+"January 14, 2014",Delaware,Millsboro,"28000 block of Harmons Hill Rd",male,"Richard Robinson","Adult 18+",N/A
+"January 14, 2014",Delaware,Millsboro,"28000 block of Harmons Hill Rd",male,"Steven Kellam","Adult 18+",N/A
+"January 14, 2014",Delaware,Millsboro,"28000 block of Harmons Hill Rd",male,"Carlton Gibbs","Adult 18+",N/A
+"January 14, 2014",Delaware,Millsboro,"28000 block of Harmons Hill Rd",N/A,"Shamir A. Stratton","Adult 18+",N/A
+"January 13, 2014",Delaware,Felton,"US 13 and Walnut Shade Rd",male,"Stephen Obeda","Adult 18+",N/A
+"January 13, 2014",Delaware,Dover,"2 Capitol Ave",male,"Kishai Sylvester","Adult 18+",N/A
+"January 13, 2014",Delaware,Wilmington,"1300 block of Vandever Ave. ",male,N/A,"Adult 18+",N/A
+"January 10, 2014",Delaware,Wilmington,N/A,female,N/A,"Teen 12-17",N/A
+"January 9, 2014",Delaware,Magnolia,"200 block of Lambert Dr",male,N/A,"Adult 18+",N/A
+"January 9, 2014",Delaware,Magnolia,"200 block of Lambert Dr",female,"Jacqueline Hughes","Adult 18+",N/A
+"January 7, 2014",Delaware,Wilmington,"200 block of N Broom St",male,N/A,"Adult 18+",N/A
+"January 7, 2014",Delaware,Wilmington,"200 block of N Broom St",male,N/A,"Adult 18+",N/A
+"January 7, 2014",Delaware,Wilmington,"200 block of N Broom St",male,N/A,"Adult 18+",N/A
+"January 7, 2014",Delaware,Wilmington,"1500 block of W 5th St",male,N/A,"Teen 12-17",N/A
+"January 7, 2014",Delaware,Wilmington,"1200 block of Forrest Drive",N/A,N/A,Unknown,N/A
+"January 6, 2014",Delaware,Dover,"McDaniel Dr",male,N/A,"Adult 18+",N/A
+"January 6, 2014",Delaware,Dover,"McDaniel Dr",N/A,N/A,"Teen 12-17",N/A
+"January 6, 2014",Delaware,Dover,"McDaniel Dr",N/A,N/A,"Child 0-11",N/A
+"January 6, 2014",Delaware,Dover,"McDaniel Dr",N/A,N/A,"Child 0-11",N/A
+"January 6, 2014",Delaware,Dover,"McDaniel Dr",male,N/A,"Adult 18+",N/A
+"January 6, 2014",Delaware,Dover,"McDaniel Dr",male,N/A,"Adult 18+",N/A
+"January 6, 2014",Delaware,Dover,"McDaniel Dr",male,N/A,"Adult 18+",N/A
+"January 5, 2014",Delaware,Wilmington,N/A,male,"Qudree Warren",Unknown,N/A
+"January 5, 2014",Delaware,Wilmington,N/A,male,N/A,"Teen 12-17",N/A
+"January 5, 2014",Delaware,Wilmington,N/A,male,N/A,"Adult 18+",N/A
+"January 4, 2014",Delaware,Wilmington,"2400 block of Carter Street",male,N/A,"Adult 18+",N/A
+"January 4, 2014",Delaware,Wilmington,"2100 block of Washington Street",male,N/A,"Adult 18+",N/A
+"January 4, 2014",Delaware,Wilmington,"2100 block of Washington Street",male,N/A,"Adult 18+",N/A
+"January 4, 2014",Delaware,Wilmington,"2100 block of Washington Street",male,N/A,"Adult 18+",N/A
+"January 1, 2014",Delaware,Wilmington,"1400 block of West 3rd",male,"Allen Whitt","Adult 18+",N/A
+"December 7, 2013",Delaware,Wilmington,"3421 Kirkwood Hwy",male,N/A,"Adult 18+",N/A
+"December 7, 2013",Delaware,Wilmington,"3421 Kirkwood Hwy",male,N/A,"Adult 18+",N/A
+"December 7, 2013",Delaware,Wilmington,"3421 Kirkwood Hwy",male,N/A,"Adult 18+",N/A
+"December 7, 2013",Delaware,Wilmington,"3421 Kirkwood Hwy",female,N/A,"Adult 18+",N/A
+"August 10, 2013",Delaware,Wilmington,"1200 block of Second Street",female,N/A,"Teen 12-17",N/A
+"August 10, 2013",Delaware,Wilmington,"1200 block of Second Street",female,N/A,"Teen 12-17",N/A
+"August 10, 2013",Delaware,Wilmington,"1200 block of Second Street",female,N/A,"Adult 18+",N/A
+"August 10, 2013",Delaware,Wilmington,"1200 block of Second Street",male,N/A,"Adult 18+",N/A
+"February 11, 2013",Delaware,Wilmington,"500 North King St",female,"Laura Elizabeth ""Beth"" Mulford","Adult 18+",N/A
+"February 11, 2013",Delaware,Wilmington,"500 North King St",female,"Christine Belford","Adult 18+",N/A
+"February 11, 2013",Delaware,Wilmington,"500 North King St",male,"Ofc. Steven Rinehart","Adult 18+",N/A
+"February 11, 2013",Delaware,Wilmington,"500 North King St",male,"Officer Michael Manley","Adult 18+",N/A
+"February 11, 2013",Delaware,Wilmington,"500 North King St",male,"Thomas F Matusiewicz","Adult 18+",N/A

--- a/data/participants/2016-07-05 - 2019-03-16.csv
+++ b/data/participants/2016-07-05 - 2019-03-16.csv
@@ -1,0 +1,2001 @@
+"Incident Date",State,"City Or County",Address,"Participant Gender","Participant Name","Participant Age Group",Operations
+"March 16, 2019",Delaware,Wilmington,"2200 block of Baynard Blvd",male,N/A,"Teen 12-17",N/A
+"March 15, 2019",Delaware,Wilmington,"2900 block of Tatnall St",male,"Lloyd Tomlinson","Adult 18+",N/A
+"March 15, 2019",Delaware,Wilmington,"2900 block of Tatnall St",female,"Kelli Brisco","Adult 18+",N/A
+"March 13, 2019",Delaware,Wilmington,"104 Richards Dr",female,"Laura Connell","Adult 18+",N/A
+"March 13, 2019",Delaware,Wilmington,"400 block of W 7th St",male,"Richard Iverson","Adult 18+",N/A
+"March 12, 2019",Delaware,Wilmington,"300 block of S Union St",male,"Michael Bijansky","Adult 18+",N/A
+"March 12, 2019",Delaware,Wilmington,"1100 block of E 14th St",male,"Andre Church","Adult 18+",N/A
+"March 12, 2019",Delaware,Wilmington,"1100 block of E 14th St",male,"Andre Church","Adult 18+",N/A
+"March 11, 2019",Delaware,Townsend,"200 block of Saw Mill Rd",male,"Daniel J. Ford","Adult 18+",N/A
+"March 11, 2019",Delaware,Wilmington,"50 block of W 26th St",male,"Christian Coffield","Teen 12-17",N/A
+"March 11, 2019",Delaware,Wilmington,"50 block of W 26th St",female,"Janiya Henry","Teen 12-17",N/A
+"March 11, 2019",Delaware,Wilmington,"50 block of W 26th St",male,N/A,Unknown,N/A
+"March 11, 2019",Delaware,Wilmington,"50 block of W 26th St",male,N/A,Unknown,N/A
+"March 11, 2019",Delaware,Wilmington,"50 block of W 26th St",male,N/A,Unknown,N/A
+"March 9, 2019",Delaware,Laurel,"S Shell Bridge Rd and Holly Branch Dr",female,"Tia A. Tucker","Adult 18+",N/A
+"March 9, 2019",Delaware,Laurel,"S Shell Bridge Rd and Holly Branch Dr",male,"Joseph Beck","Adult 18+",N/A
+"March 9, 2019",Delaware,Newark,"W Main St and Hillside Rd",male,"Keith Johnson","Adult 18+",N/A
+"March 9, 2019",Delaware,Wilmington,"400 block of W 8th St",male,"Dawan Devlin","Adult 18+",N/A
+"March 7, 2019",Delaware,Wilmington,"800 block of N Grant Ave",male,N/A,"Adult 18+",N/A
+"March 7, 2019",Delaware,Marydel,"300 block of Grygo Rd",female,"Amanda Husfelt","Adult 18+",N/A
+"March 7, 2019",Delaware,Marydel,"300 block of Grygo Rd",male,"Quioly Demby","Adult 18+",N/A
+"March 7, 2019",Delaware,Wilmington,"3500 block of Washington St",female,N/A,"Adult 18+",N/A
+"March 7, 2019",Delaware,Wilmington,"3500 block of Washington St",male,"Keith Waters","Adult 18+",N/A
+"March 6, 2019",Delaware,Wilmington,"700 block of Tatnall St",male,N/A,"Adult 18+",N/A
+"March 6, 2019",Delaware,Wilmington,"700 block of Tatnall St",female,N/A,"Adult 18+",N/A
+"March 6, 2019",Delaware,Dover,"400 block of Barrister Pl",male,"Donald Brown","Adult 18+",N/A
+"March 6, 2019",Delaware,Newark,"50 block of Raven Turn",male,"Dyron Nuriddin","Adult 18+",N/A
+"March 4, 2019",Delaware,Dover,"50 Block of Village Dr",male,"Zykee Bull","Adult 18+",N/A
+"March 2, 2019",Delaware,Smyrna,"699 S Carter Rd",male,N/A,"Teen 12-17",N/A
+"March 1, 2019",Delaware,Milton,"28000 block of Carpenter Rd",male,"Deion Ayers","Adult 18+",N/A
+"March 1, 2019",Delaware,"Wilmington (Stanton)","106 Main St",female,N/A,"Adult 18+",N/A
+"March 1, 2019",Delaware,"Wilmington (Stanton)","106 Main St",female,N/A,"Adult 18+",N/A
+"February 26, 2019",Delaware,Wilmington,"Northeast Blvd and Thatcher St",male,N/A,"Adult 18+",N/A
+"February 25, 2019",Delaware,Wilmington,"600 block of N Jefferson St",male,N/A,"Adult 18+",N/A
+"February 25, 2019",Delaware,Wilmington,"600 block of N Jefferson St",male,"Barry Felton","Adult 18+",N/A
+"February 23, 2019",Delaware,Seaford,"20300 block of Wesley Church Rd",female,"Donisha Holland","Adult 18+",N/A
+"February 23, 2019",Delaware,Seaford,"20300 block of Wesley Church Rd",male,"Reginald L. Sample","Adult 18+",N/A
+"February 23, 2019",Delaware,Seaford,"20300 block of Wesley Church Rd",male,"James M. Frazier","Adult 18+",N/A
+"February 23, 2019",Delaware,Seaford,"20300 block of Wesley Church Rd",female,"Trivette A. Jackson","Adult 18+",N/A
+"February 22, 2019",Delaware,Frederica,"200 block of Market St",male,"Joseph Whaley","Adult 18+",N/A
+"February 22, 2019",Delaware,Dover,"55 Loockerman Plaza",male,"Michael Palmer Jr.","Adult 18+",N/A
+"February 22, 2019",Delaware,Dover,"55 Loockerman Plaza",male,"Sheldon Claud","Adult 18+",N/A
+"February 21, 2019",Delaware,Bear,"13 S Cedar Creek Ct",male,N/A,"Adult 18+",N/A
+"February 21, 2019",Delaware,Bear,"13 S Cedar Creek Ct",male,"Parish Lloyd","Adult 18+",N/A
+"February 21, 2019",Delaware,Bear,"13 S Cedar Creek Ct",male,"Erogers Bey","Adult 18+",N/A
+"February 21, 2019",Delaware,Seaford,"300 block of N Pine St",male,"Djemsley Florestal","Adult 18+",N/A
+"February 21, 2019",Delaware,Smyrna,"1069 McQuail Rd",male,"Melvin J. Durand","Adult 18+",N/A
+"February 18, 2019",Delaware,Dover,"400 block of New Castle Ave",male,"Joseph Carter","Adult 18+",N/A
+"February 16, 2019",Delaware,Felton,"11 S Lombard St",male,"William J. Paskey","Adult 18+",N/A
+"February 16, 2019",Delaware,Lewes,"32000 block of Spruce Ct",male,"Christopher B. Lare","Adult 18+",N/A
+"February 16, 2019",Delaware,"Ocean View","50 block of Dorothy Cir",male,"Joshua Welsh","Adult 18+",N/A
+"February 14, 2019",Delaware,Harrington,"8700 block of Park Brown Rd",male,"Donte Demunguia","Adult 18+",N/A
+"February 14, 2019",Delaware,Harrington,"8700 block of Park Brown Rd",male,"Devon Emfinger","Adult 18+",N/A
+"February 14, 2019",Delaware,Wilmington,"2nd St and Van Buren St",male,"Frank Butts","Adult 18+",N/A
+"February 14, 2019",Delaware,Wilmington,"2nd St and Van Buren St",male,"Emanuel Stackhouse","Adult 18+",N/A
+"February 14, 2019",Delaware,Wilmington,"1100 block of Kirkwood St",male,"Andrew Charles","Adult 18+",N/A
+"February 13, 2019",Delaware,Dover,"200 block of S Governors Blvd",male,"Dewayne Bordley","Adult 18+",N/A
+"February 12, 2019",Delaware,"Rehoboth Beach","36179 Palace Ln",male,"Michael R. Henry","Adult 18+",N/A
+"February 8, 2019",Delaware,Wilmington,"400 block of Heald St",male,N/A,"Adult 18+",N/A
+"February 8, 2019",Delaware,Wilmington,"400 block of Heald St",male,"Nathaniel Bunch","Adult 18+",N/A
+"February 7, 2019",Delaware,Bear,"50 block of Wildfields Ct",male,"Benjamin Boudart","Adult 18+",N/A
+"February 7, 2019",Delaware,Dover,"383 N DuPont Hwy",male,"Keith Landry","Adult 18+",N/A
+"February 6, 2019",Delaware,Wilmington,"50 block of Jensen Dr",male,N/A,"Teen 12-17",N/A
+"February 5, 2019",Delaware,Newark,N/A,male,N/A,"Teen 12-17",N/A
+"February 4, 2019",Delaware,Wilmington,"1400 block of N Walnut St",male,N/A,"Teen 12-17",N/A
+"February 4, 2019",Delaware,Wilmington,"1400 block of N Walnut St",male,N/A,"Teen 12-17",N/A
+"February 3, 2019",Delaware,Wilmington,"DE 4 and Champlain Ave",male,N/A,"Teen 12-17",N/A
+"February 2, 2019",Delaware,Dover,"51 Webbs Ln",female,N/A,"Adult 18+",N/A
+"February 2, 2019",Delaware,Dover,"51 Webbs Ln",male,N/A,"Adult 18+",N/A
+"February 2, 2019",Delaware,Wilmington,"W 27th St and Moore St",male,"Yahim Harris","Adult 18+",N/A
+"February 2, 2019",Delaware,Wilmington,"W 27th St and Moore St",male,N/A,"Teen 12-17",N/A
+"February 2, 2019",Delaware,Wilmington,"2500 block of Bowers St",male,"Salvador Vasquez","Adult 18+",N/A
+"February 1, 2019",Delaware,"New Castle","Christiana Rd and Catherine St",male,"Thomas Porter","Adult 18+",N/A
+"January 31, 2019",Delaware,Wilmington,"1100 block of Pleasant St",male,"Aracelio Cruz","Adult 18+",N/A
+"January 31, 2019",Delaware,Wilmington,"1100 block of Pleasant St",male,"Frederick Trice","Adult 18+",N/A
+"January 31, 2019",Delaware,Wilmington,"W 7th St and N Monroe St",male,"Nazjheir Lloyd","Adult 18+",N/A
+"January 28, 2019",Delaware,Seaford,"400 block of N Pine St",male,N/A,"Adult 18+",N/A
+"January 28, 2019",Delaware,Seaford,"400 block of N Pine St",male,N/A,"Adult 18+",N/A
+"January 28, 2019",Delaware,Wilmington,"700 block of N Madison St",male,N/A,"Adult 18+",N/A
+"January 26, 2019",Delaware,Wilmington,"3700 block of N Van Buren St",male,N/A,"Adult 18+",N/A
+"January 26, 2019",Delaware,Wilmington,"3700 block of N Van Buren St",male,N/A,"Teen 12-17",N/A
+"January 26, 2019",Delaware,Wilmington,"3700 block of N Van Buren St",male,"Jamar Jackson","Adult 18+",N/A
+"January 25, 2019",Delaware,Wilmington,"W 39th St and Shipley St",male,N/A,"Adult 18+",N/A
+"January 25, 2019",Delaware,Bridgeville,"11000 block of Fisher Cir",male,"Ellis J Cannon II","Adult 18+",N/A
+"January 25, 2019",Delaware,Dagsboro,"30000 block of Squirrel Ln",male,"David Tharp","Adult 18+",N/A
+"January 24, 2019",Delaware,Wilmington,"2702 Jacqueline Dr",male,"Dametrius Benson","Teen 12-17",N/A
+"January 22, 2019",Delaware,Wilmington,"2300 block of Pine St",male,"Larry Lee","Adult 18+",N/A
+"January 18, 2019",Delaware,Bear,"1551 Pulaski Highway",male,N/A,"Teen 12-17",N/A
+"January 17, 2019",Delaware,Millville,"Railway Rd",male,"Paul E. Daisey","Adult 18+",N/A
+"January 17, 2019",Delaware,Wilmington,"400 block of E 11th St",male,N/A,"Adult 18+",N/A
+"January 17, 2019",Delaware,Wilmington,"400 block of E 11th St",male,"Artemus Portis","Adult 18+",N/A
+"January 17, 2019",Delaware,Wilmington,"400 block of E 11th St",male,"Antwine Jackson","Adult 18+",N/A
+"January 16, 2019",Delaware,Wilmington,"600 block of E 5th St",male,N/A,"Adult 18+",N/A
+"January 16, 2019",Delaware,Wilmington,"600 block of E 5th St",male,N/A,"Adult 18+",N/A
+"January 15, 2019",Delaware,Wilmington,"1200 block of Conrad St",male,"Kellier Flamer","Adult 18+",N/A
+"January 13, 2019",Delaware,Dover,"300 block of Frear Dr",male,"Nathaniel Hampton","Adult 18+",N/A
+"January 13, 2019",Delaware,Dover,"300 block of Frear Dr",female,"Chelsie Cooper","Adult 18+",N/A
+"January 10, 2019",Delaware,Dover,"35 E Loockerman St",N/A,N/A,"Teen 12-17",N/A
+"January 10, 2019",Delaware,Dover,"35 E Loockerman St",male,"Jayaire Brittingham","Adult 18+",N/A
+"January 7, 2019",Delaware,Wilmington,"700 block of N Dupont St",female,N/A,"Adult 18+",N/A
+"January 7, 2019",Delaware,Wilmington,"700 block of N Dupont St",male,"Marcellis Dandy","Adult 18+",N/A
+"January 7, 2019",Delaware,Wilmington,"700 block of N Dupont St",male,"Aaron Jackson","Adult 18+",N/A
+"January 7, 2019",Delaware,Wilmington,"700 block of N Dupont St",male,"Messiah Woodall","Adult 18+",N/A
+"January 6, 2019",Delaware,Frederica,"50 block of 3rd St",male,"William H. Cloak IV","Adult 18+",N/A
+"January 5, 2019",Delaware,Dover,"200 block of Kentwood Dr",male,"Jesse Stanford","Adult 18+",N/A
+"January 5, 2019",Delaware,Dover,"200 block of Kentwood Dr",N/A,"Cahlil Simmons","Adult 18+",N/A
+"January 5, 2019",Delaware,Dover,"200 block of Kentwood Dr",male,"Jaquell A. McDonald","Adult 18+",N/A
+"January 3, 2019",Delaware,"Kent (county)",N/A,male,"Ricardo L. Barnaby","Adult 18+",N/A
+"January 3, 2019",Delaware,"Kent (county)",N/A,male,"Barry V. Haith","Adult 18+",N/A
+"January 3, 2019",Delaware,"Kent (county)",N/A,male,"Lamont K. McCove","Adult 18+",N/A
+"January 2, 2019",Delaware,Newark,"1120 S College Ave",male,N/A,"Adult 18+",N/A
+"January 2, 2019",Delaware,Felton,"100 block of Gelden Rd",male,N/A,"Adult 18+",N/A
+"January 2, 2019",Delaware,Felton,"100 block of Gelden Rd",male,N/A,"Adult 18+",N/A
+"January 2, 2019",Delaware,Felton,"100 block of Gelden Rd",male,N/A,"Adult 18+",N/A
+"January 2, 2019",Delaware,Felton,"100 block of Gelden Rd",male,N/A,"Adult 18+",N/A
+"January 1, 2019",Delaware,Wilmington,"1101 E 8th St",male,N/A,"Adult 18+",N/A
+"December 30, 2018",Delaware,Wilmington,"500 block of W 11th St",male,"Nyhe Toston","Adult 18+",N/A
+"December 30, 2018",Delaware,Wilmington,"500 block of W 11th St",male,"Kenai Truitt","Adult 18+",N/A
+"December 30, 2018",Delaware,Wilmington,"500 block of W 11th St",male,"Stephan Curtis","Teen 12-17",N/A
+"December 30, 2018",Delaware,Wilmington,"500 block of W 11th St",male,"Mohamed Conde","Teen 12-17",N/A
+"December 29, 2018",Delaware,Newark,"91 Thorn Ln",male,N/A,"Adult 18+",N/A
+"December 29, 2018",Delaware,Newark,"91 Thorn Ln",male,"Nicholas Hulsey","Adult 18+",N/A
+"December 28, 2018",Delaware,Wilmington,"600 block of W 7th St",male,N/A,"Teen 12-17",N/A
+"December 28, 2018",Delaware,Wilmington,"600 block of W 7th St",male,N/A,"Adult 18+",N/A
+"December 28, 2018",Delaware,Wilmington,"600 block of W 7th St",female,N/A,"Adult 18+",N/A
+"December 25, 2018",Delaware,Lincoln,"19000 block of Pine St",female,N/A,"Adult 18+",N/A
+"December 25, 2018",Delaware,Lincoln,"19000 block of Pine St",male,"Javaghn D. Waples","Adult 18+",N/A
+"December 24, 2018",Delaware,"Rehoboth Beach","Munchy Branch Rd and Coastal Hwy",male,"Tre Jamal Edwards","Adult 18+",N/A
+"December 23, 2018",Delaware,Wilmington,"800 block of E 13th St",male,N/A,"Adult 18+",N/A
+"December 23, 2018",Delaware,Wilmington,"800 block of E 13th St",male,"Derro Smith","Adult 18+",N/A
+"December 23, 2018",Delaware,Milford,"300 Aurora Pl",female,N/A,"Child 0-11",N/A
+"December 23, 2018",Delaware,Milford,"300 Aurora Pl",male,"Derrick Morris","Adult 18+",N/A
+"December 23, 2018",Delaware,Wilmington,"2300 block of West St",male,N/A,"Teen 12-17",N/A
+"December 23, 2018",Delaware,Wilmington,"100 block of N Harrison St",female,N/A,"Adult 18+",N/A
+"December 20, 2018",Delaware,Millsboro,"28000 block of Mount Joy Rd",male,"Clarence Mobley","Adult 18+",N/A
+"December 20, 2018",Delaware,Millsboro,"28000 block of Mount Joy Rd",male,"Daquon Johnson","Adult 18+",N/A
+"December 20, 2018",Delaware,Millsboro,"28000 block of Mount Joy Rd",male,"Jerrontae Holden","Adult 18+",N/A
+"December 19, 2018",Delaware,Dover,"3000 block of William St",male,"Gary Stanley","Adult 18+",N/A
+"December 17, 2018",Delaware,Newark,"41 Winterhaven Dr",male,N/A,"Teen 12-17",N/A
+"December 17, 2018",Delaware,Dagsboro,"30000 block of Iron Branch Rd",male,"Christopher L. Sturgis","Adult 18+",N/A
+"December 12, 2018",Delaware,Dover,"700 block of Bacon Ave",male,"Bradley Parker","Adult 18+",N/A
+"December 11, 2018",Delaware,Millsboro,N/A,male,"Brendon Dibble","Adult 18+",N/A
+"December 11, 2018",Delaware,Millsboro,N/A,male,"William Novello","Adult 18+",N/A
+"December 7, 2018",Delaware,Seaford,"23450 Sussex Hwy",male,"Trevor Savage","Adult 18+",N/A
+"December 7, 2018",Delaware,Seaford,"23450 Sussex Hwy",male,"Montez Lake","Adult 18+",N/A
+"December 7, 2018",Delaware,Seaford,"23450 Sussex Hwy",N/A,N/A,"Teen 12-17",N/A
+"December 5, 2018",Delaware,Harrington,"101 W Center St",male,"James McNeil","Adult 18+",N/A
+"November 29, 2018",Delaware,Milford,"S DuPont Blvd and Lakeview Ave",male,"Mike A. Chavez","Adult 18+",N/A
+"November 28, 2018",Delaware,Dover,"89 Kings Hwy",N/A,N/A,"Adult 18+",N/A
+"November 28, 2018",Delaware,Dover,"89 Kings Hwy",N/A,N/A,"Adult 18+",N/A
+"November 28, 2018",Delaware,Dover,"89 Kings Hwy",N/A,N/A,"Adult 18+",N/A
+"November 28, 2018",Delaware,Dover,"89 Kings Hwy",N/A,N/A,"Adult 18+",N/A
+"November 28, 2018",Delaware,Dagsboro,"32000 block of Swamp Rd",male,"Sean Johnson","Adult 18+",N/A
+"November 28, 2018",Delaware,Dover,"200 block of N Kirkwood St",male,"Nathan Ward","Adult 18+",N/A
+"November 27, 2018",Delaware,Wilmington,"900 block of N Pine St",male,N/A,"Adult 18+",N/A
+"November 25, 2018",Delaware,"Wilmington (Edgemoor)","E Salisbury Dr and Bedford Dr",male,N/A,"Adult 18+",N/A
+"November 23, 2018",Delaware,Wilmington,"Centerville Rd and Boxwood Rd",male,"Jason W. Carroll","Adult 18+",N/A
+"November 23, 2018",Delaware,Harrington,"S Rehoboth Blvd",male,"Kaleb M. Tribek","Adult 18+",N/A
+"November 22, 2018",Delaware,Milton,"18647 Rd 281",N/A,N/A,Unknown,N/A
+"November 20, 2018",Delaware,Smyrna,"South St and East St",male,N/A,"Adult 18+",N/A
+"November 20, 2018",Delaware,Wilmington,"2300 block of Jessup St",male,N/A,"Adult 18+",N/A
+"November 20, 2018",Delaware,Wilmington,"2300 block of Jessup St",male,N/A,"Adult 18+",N/A
+"November 20, 2018",Delaware,Wilmington,"2300 block of Jessup St",male,"Jameel Anderson","Adult 18+",N/A
+"November 18, 2018",Delaware,Seaford,"Park Dr",male,"Teron West","Adult 18+",N/A
+"November 18, 2018",Delaware,Dover,"400 block of E Water St",male,N/A,"Adult 18+",N/A
+"November 18, 2018",Delaware,Dover,"400 block of E Water St",male,N/A,"Adult 18+",N/A
+"November 18, 2018",Delaware,Dover,"400 block of E Water St",male,N/A,"Adult 18+",N/A
+"November 18, 2018",Delaware,Dover,"400 block of E Water St",male,N/A,"Adult 18+",N/A
+"November 18, 2018",Delaware,Dover,"400 block of E Water St",male,N/A,"Adult 18+",N/A
+"November 18, 2018",Delaware,Dover,"400 block of E Water St",male,N/A,"Adult 18+",N/A
+"November 16, 2018",Delaware,"Wilmington (Newport)","500 block of Essex Ave",male,"Master Cpl. Michael Ballard","Adult 18+",N/A
+"November 16, 2018",Delaware,"Camden Wyoming (Camden)","155 S West St",female,"Ahyanna Baker-Griffin","Adult 18+",N/A
+"November 16, 2018",Delaware,"Camden Wyoming (Camden)","155 S West St",male,"Dishiem Johnson","Adult 18+",N/A
+"November 15, 2018",Delaware,Middletown,"US 13 and DE 1",male,"Stanley L. Bates","Adult 18+",N/A
+"November 14, 2018",Delaware,Townsend,"100 block of Esch St",male,"Edward W. Benson","Adult 18+",N/A
+"November 12, 2018",Delaware,Wilmington,"W 5th St and N Franklin St",male,N/A,"Teen 12-17",N/A
+"November 11, 2018",Delaware,Dover,"400 block of Barrister Pl",female,N/A,"Adult 18+",N/A
+"November 10, 2018",Delaware,Wilmington,"N Lake St and Matthes Ave",male,N/A,"Adult 18+",N/A
+"November 8, 2018",Delaware,Claymont,"50 block of New York Ave",female,"Mary Ellen Slider","Adult 18+",N/A
+"November 8, 2018",Delaware,Claymont,"50 block of New York Ave",male,"Joseph R. Slider","Adult 18+",N/A
+"November 8, 2018",Delaware,Dover,"200 block of W Reed St",male,"Abdul Tillery","Adult 18+",N/A
+"November 8, 2018",Delaware,Dover,"200 block of W Reed St",male,"Adriene Stevenson","Adult 18+",N/A
+"November 6, 2018",Delaware,"New Castle","4000 N DuPont Hwy",N/A,"Ronald E. Maddrey","Adult 18+",N/A
+"November 5, 2018",Delaware,Smyrna,"400 block of Baldwin Dr",male,N/A,"Adult 18+",N/A
+"November 5, 2018",Delaware,Smyrna,"400 block of Baldwin Dr",male,N/A,"Teen 12-17",N/A
+"November 5, 2018",Delaware,Smyrna,"400 block of Baldwin Dr",male,"Jeffrey T Thomas","Adult 18+",N/A
+"November 5, 2018",Delaware,Smyrna,"400 block of Baldwin Dr",male,"Devante Blocker","Adult 18+",N/A
+"November 5, 2018",Delaware,Harrington,N/A,male,"Joshua P. Dorrell","Adult 18+",N/A
+"November 5, 2018",Delaware,Wilmington,"300 block of W 7th St",male,N/A,"Adult 18+",N/A
+"November 1, 2018",Delaware,Wilmington,"200 block of S Franklin St",male,"Dwayne Wright","Adult 18+",N/A
+"November 1, 2018",Delaware,Wilmington,"200 block of S Franklin St",male,N/A,"Adult 18+",N/A
+"October 29, 2018",Delaware,Wilmington,"2300 block of N Washington St",male,N/A,"Adult 18+",N/A
+"October 29, 2018",Delaware,Seaford,"24000 block of German Rd",male,N/A,"Adult 18+",N/A
+"October 29, 2018",Delaware,Dover,"W Division St and S New St",male,"Arthur Darden Jr.","Adult 18+",N/A
+"October 29, 2018",Delaware,Dover,"W Division St and S New St",male,"Phillip Waters","Adult 18+",N/A
+"October 28, 2018",Delaware,Wilmington,"1701 Delaware Ave",male,"Tyler Vega","Adult 18+",N/A
+"October 28, 2018",Delaware,Newark,"900 block of Harmony Rd",male,N/A,"Adult 18+",N/A
+"October 26, 2018",Delaware,Wilmington,"600 block of W 6th St",male,"Sean Hammond","Adult 18+",N/A
+"October 25, 2018",Delaware,Wilmington,"900 block of Spruce St",female,"Shirley Coleman","Adult 18+",N/A
+"October 25, 2018",Delaware,Wilmington,"900 block of Spruce St",male,N/A,"Teen 12-17",N/A
+"October 23, 2018",Delaware,Dover,"400 block of E Water St",male,"Damir Hughes-Warren","Adult 18+",N/A
+"October 23, 2018",Delaware,Dover,"400 block of E Water St",female,"Louella Cooper","Adult 18+",N/A
+"October 23, 2018",Delaware,"New Castle","111 S DuPont Hwy",male,"Angel L. Arbolay","Adult 18+",N/A
+"October 22, 2018",Delaware,Wilmington,"100 block of 24th St",male,N/A,"Adult 18+",N/A
+"October 19, 2018",Delaware,Wilmington,"900 block of Linden St",male,"Ethan Keller","Adult 18+",N/A
+"October 18, 2018",Delaware,Wilmington,"400 block of E 2nd St",male,"Andre Richards","Adult 18+",N/A
+"October 18, 2018",Delaware,Dover,"200 block of N Governor Blvd",male,"Lamar J. Dozier","Adult 18+",N/A
+"October 18, 2018",Delaware,Wilmington,"300 N Walnut St",N/A,"Joseph Brown","Adult 18+",N/A
+"October 18, 2018",Delaware,Wilmington,"400 block of N Clayton St",male,N/A,"Adult 18+",N/A
+"October 17, 2018",Delaware,Wilmington,"2300 block of N Market St",male,"Blayton Palmer","Adult 18+",N/A
+"October 16, 2018",Delaware,Newark,"800 block of Coventry Ln",male,"Clifton Armstead","Adult 18+",N/A
+"October 16, 2018",Delaware,Newark,"800 block of Coventry Ln",male,"Sequoyah Harris","Adult 18+",N/A
+"October 15, 2018",Delaware,Dover,"Bay Tree Rd",male,"James Rochester","Adult 18+",N/A
+"October 14, 2018",Delaware,Dover,"428 N DuPont Hwy",male,N/A,"Adult 18+",N/A
+"October 14, 2018",Delaware,Dover,"428 N DuPont Hwy",male,"Antonio Bynum","Adult 18+",N/A
+"October 11, 2018",Delaware,Lewes,"19000 block of Ward Rd",N/A,N/A,Unknown,N/A
+"October 11, 2018",Delaware,Lewes,"19000 block of Ward Rd",N/A,N/A,Unknown,N/A
+"October 11, 2018",Delaware,Wilmington,"600 block of W 8th St",male,"Maurice Williams","Adult 18+",N/A
+"October 11, 2018",Delaware,Wilmington,"600 block of W 8th St",male,"Parrish Brown","Adult 18+",N/A
+"October 11, 2018",Delaware,Wilmington,"600 block of W 8th St",male,N/A,"Adult 18+",N/A
+"October 11, 2018",Delaware,Dover,"800 S Governors Ave",male,"Aaron L. Williams","Adult 18+",N/A
+"October 11, 2018",Delaware,Wilmington,"1300 block of Lancaster Ave",male,"Chaze Peete","Adult 18+",N/A
+"October 10, 2018",Delaware,Dover,"1492 N Little Creek Rd",male,"Kenneth Holland","Adult 18+",N/A
+"October 8, 2018",Delaware,Smyrna,"DE 9 and Lighthouse Rd",male,"Joseph Reyes","Adult 18+",N/A
+"October 6, 2018",Delaware,Clayton,"Lion Hope Rd",male,"David L Moser","Adult 18+",N/A
+"October 5, 2018",Delaware,Wilmington,"1000 Bennett St",male,"Charles Riley","Adult 18+",N/A
+"October 3, 2018",Delaware,Wilmington,"700 block of W 5th St",male,N/A,"Adult 18+",N/A
+"October 3, 2018",Delaware,Wilmington,"Taylor St and N Spruce St",male,N/A,"Adult 18+",N/A
+"October 2, 2018",Delaware,Dover,"50 Webbs Ln",male,N/A,"Adult 18+",N/A
+"October 2, 2018",Delaware,Wilmington,"200 block of N Clayton St",male,"Grayson Ewell","Adult 18+",N/A
+"October 2, 2018",Delaware,Wilmington,"200 block of N Clayton St",male,"Terrell Mobley","Adult 18+",N/A
+"October 2, 2018",Delaware,"Camden Wyoming","Pony Track Rd",male,N/A,"Adult 18+",N/A
+"October 2, 2018",Delaware,"Camden Wyoming","Pony Track Rd",male,"Adelio A. Guzman","Adult 18+",N/A
+"September 30, 2018",Delaware,Seaford,"26000 block of Kelly Cir",N/A,N/A,Unknown,N/A
+"September 30, 2018",Delaware,Dover,"298 S DuPont Hwy",male,"Tyrell Joseph","Adult 18+",N/A
+"September 29, 2018",Delaware,Harrington,"200 block of Delaware Ave",female,N/A,"Adult 18+",N/A
+"September 29, 2018",Delaware,Harrington,"200 block of Delaware Ave",male,N/A,"Teen 12-17",N/A
+"September 29, 2018",Delaware,Harrington,"200 block of Delaware Ave",male,N/A,"Teen 12-17",N/A
+"September 28, 2018",Delaware,Dover,"915 S DuPont Hwy",male,"Jeremy Thompson","Adult 18+",N/A
+"September 26, 2018",Delaware,Laurel,"Portsville Rd and Dogwood Ln",male,"Isaac Hatton","Adult 18+",N/A
+"September 26, 2018",Delaware,Laurel,"Portsville Rd and Dogwood Ln",male,"Jerry L. Reed","Adult 18+",N/A
+"September 26, 2018",Delaware,Laurel,"Portsville Rd and Dogwood Ln",male,"Traevon Dixon","Adult 18+",N/A
+"September 20, 2018",Delaware,Dover,"100 block of S Governors Blvd",male,N/A,"Adult 18+",N/A
+"September 20, 2018",Delaware,Harrington,"200 block of Hanley St",male,"Kevin Hughes","Adult 18+",N/A
+"September 20, 2018",Delaware,Harrington,"200 block of Hanley St",male,"Lavar Smith","Adult 18+",N/A
+"September 20, 2018",Delaware,Magnolia,N/A,male,N/A,"Adult 18+",N/A
+"September 20, 2018",Delaware,Seaford,"22588 Bridgeville Hwy",male,"Jose Cabrera-Malpica","Adult 18+",N/A
+"September 20, 2018",Delaware,Seaford,"22588 Bridgeville Hwy",male,"Arslan Chaudhary","Adult 18+",N/A
+"September 20, 2018",Delaware,Wilmington,"400 block of N Adams St",N/A,N/A,Unknown,N/A
+"September 19, 2018",Delaware,Dover,"SR 1",male,"Jason D. Calhum","Teen 12-17",N/A
+"September 19, 2018",Delaware,Dover,"SR 1",female,"Tilaiya M. Holland","Adult 18+",N/A
+"September 19, 2018",Delaware,Dover,"SR 1",female,"Kiara N. Watkins","Adult 18+",N/A
+"September 18, 2018",Delaware,Milford,"7000 block of Elgin Dr",male,"Bernard Wison","Adult 18+",N/A
+"September 17, 2018",Delaware,Dover,"428 DuPont Hwy",male,"Thomas Bolden","Adult 18+",N/A
+"September 17, 2018",Delaware,Dover,"428 DuPont Hwy",male,"Derrick Wilcox","Adult 18+",N/A
+"September 17, 2018",Delaware,Dover,"428 DuPont Hwy",male,"Bobby Pitts","Adult 18+",N/A
+"September 15, 2018",Delaware,Marydel,"300 block of Grygo Rd",male,"Anthony Jones","Adult 18+",N/A
+"September 15, 2018",Delaware,Marydel,"300 block of Grygo Rd",female,"Angela D. Greenwood","Adult 18+",N/A
+"September 15, 2018",Delaware,Dover,"51 Webbs Ln",male,N/A,"Adult 18+",N/A
+"September 15, 2018",Delaware,Dover,"51 Webbs Ln",male,N/A,"Adult 18+",N/A
+"September 13, 2018",Delaware,Milford,"900 Block of N Walnut St",male,"Kevin Woods","Adult 18+",N/A
+"September 13, 2018",Delaware,Milford,"900 Block of N Walnut St",female,"Marshay Johnson","Adult 18+",N/A
+"September 10, 2018",Delaware,Harrington,"966 Jackson Ditch Rd",male,"David Frasier","Adult 18+",N/A
+"September 8, 2018",Delaware,Bridgeville,"Mill Park Dr and Coverdale Rd",male,"Monte D. Murray","Adult 18+",N/A
+"September 8, 2018",Delaware,Bridgeville,"Mill Park Dr and Coverdale Rd",female,"Tashyra N. Scott","Adult 18+",N/A
+"September 8, 2018",Delaware,Dover,"50 block of Nicholas Dr",male,N/A,"Adult 18+",N/A
+"September 8, 2018",Delaware,Dover,"50 block of Nicholas Dr",female,N/A,"Adult 18+",N/A
+"September 8, 2018",Delaware,Dover,"50 block of Nicholas Dr",male,"Marquis Harris","Adult 18+",N/A
+"September 8, 2018",Delaware,Seaford,"400 Block of Phillips St",male,"William A. Torres Jr.","Adult 18+",N/A
+"September 7, 2018",Delaware,Bear,"1800 block of Pulaski Hwy",male,"Tymier Byrd","Teen 12-17",N/A
+"September 6, 2018",Delaware,Wilmington,"500 block of Vandever Ave",male,"Dion Brooks","Adult 18+",N/A
+"September 5, 2018",Delaware,Middletown,"100 block of Rosie Dr",male,"Bryce Holton","Adult 18+",N/A
+"September 4, 2018",Delaware,Wilmington,"50 block of 6th Ave",N/A,N/A,"Adult 18+",N/A
+"September 4, 2018",Delaware,Wilmington,"50 block of 6th Ave",male,"David Lumb","Adult 18+",N/A
+"September 3, 2018",Delaware,Hartly,"2000 block of Slaughter Station Rd",male,N/A,"Adult 18+",N/A
+"September 3, 2018",Delaware,Hartly,"2000 block of Slaughter Station Rd",male,N/A,"Adult 18+",N/A
+"August 31, 2018",Delaware,Harbeson,"18000 block of Indian Mission Rd",male,"Wesley J. Fagg","Adult 18+",N/A
+"August 31, 2018",Delaware,Wilmington,"1100 block of Conrad St",male,"Phillip Chapman","Adult 18+",N/A
+"August 31, 2018",Delaware,Wilmington,"1100 block of Conrad St",male,"Qy-Mere Maddrey","Adult 18+",N/A
+"August 30, 2018",Delaware,"Wilmington (Edgemoor)","Rysing Dr and Polk Rd",male,N/A,"Adult 18+",N/A
+"August 30, 2018",Delaware,Middletown,"2111 Dupont Hwy",male,"James L Bouchat","Adult 18+",N/A
+"August 29, 2018",Delaware,Bridgeville,"Evans Dr and Iris Field Ln",male,"Gregory A. Dukes","Adult 18+",N/A
+"August 29, 2018",Delaware,Claymont,"50 block of Balfour Ave",male,N/A,"Teen 12-17",N/A
+"August 29, 2018",Delaware,Claymont,"50 block of Balfour Ave",male,"Travis Shaw","Adult 18+",N/A
+"August 29, 2018",Delaware,Claymont,"50 block of Balfour Ave",N/A,N/A,"Adult 18+",N/A
+"August 29, 2018",Delaware,Claymont,"50 block of Balfour Ave",N/A,N/A,"Adult 18+",N/A
+"August 29, 2018",Delaware,Claymont,"50 block of Balfour Ave",N/A,N/A,"Adult 18+",N/A
+"August 29, 2018",Delaware,Greenwood,"100 block of Unity Ln",male,N/A,"Adult 18+",N/A
+"August 28, 2018",Delaware,Harbeson,"22000 block of Harbeson Rd",male,"Robert Knox","Adult 18+",N/A
+"August 28, 2018",Delaware,Harbeson,"22000 block of Harbeson Rd",male,"Andrew Knox","Adult 18+",N/A
+"August 28, 2018",Delaware,Harbeson,"22000 block of Harbeson Rd",male,"Andrew Ayers","Adult 18+",N/A
+"August 28, 2018",Delaware,Dover,"629 Buckson Dr",male,"Rodney West","Adult 18+",N/A
+"August 28, 2018",Delaware,Dover,"629 Buckson Dr",male,"Derrick Combs","Adult 18+",N/A
+"August 27, 2018",Delaware,"New Castle","2034 New Castle Ave",male,"David R. Ramirez","Adult 18+",N/A
+"August 27, 2018",Delaware,"New Castle","2034 New Castle Ave",male,"Elliott S. Colon","Adult 18+",N/A
+"August 27, 2018",Delaware,"New Castle","2034 New Castle Ave",female,"Maria D. Simpson","Adult 18+",N/A
+"August 26, 2018",Delaware,Selbyville,"W McCabe St and Rodgers Ave",male,"Michael R. Smith","Adult 18+",N/A
+"August 24, 2018",Delaware,Dover,"S State St and Webbs Ln",male,"Stevie S. Cornwell","Adult 18+",N/A
+"August 23, 2018",Delaware,"New Castle","4000 N DuPont Hwy",male,"Devin K. Chavis","Adult 18+",N/A
+"August 22, 2018",Delaware,Smyrna,"400 block of S Carter Rd",female,"Melanie Ballard","Adult 18+",N/A
+"August 22, 2018",Delaware,Wilmington,"Philadelphia Pike",male,"Shane Williams",Unknown,N/A
+"August 21, 2018",Delaware,Dover,"Reed St and New St",female,N/A,"Adult 18+",N/A
+"August 21, 2018",Delaware,Wilmington,"2400 block of Lamotte St",male,N/A,"Adult 18+",N/A
+"August 21, 2018",Delaware,Wilmington,"3800 block of N Madison St",male,N/A,"Adult 18+",N/A
+"August 20, 2018",Delaware,Wilmington,"2000 block of N Jefferson St",male,N/A,"Adult 18+",N/A
+"August 17, 2018",Delaware,"New Castle","1 block of Revelle St",male,"Kevin Moore","Adult 18+",N/A
+"August 17, 2018",Delaware,"New Castle","1 block of Revelle St",female,"Mahogany Felton","Adult 18+",N/A
+"August 17, 2018",Delaware,"New Castle","1 block of Revelle St",male,"Charles Moore","Adult 18+",N/A
+"August 17, 2018",Delaware,"New Castle","1 block of Revelle St",female,"Kayla Judkins","Adult 18+",N/A
+"August 17, 2018",Delaware,"New Castle","1 block of Revelle St",male,"Richard Thomas","Adult 18+",N/A
+"August 17, 2018",Delaware,Dover,"1300 block of Rose Valley School Rd",male,N/A,"Adult 18+",N/A
+"August 16, 2018",Delaware,"New Castle","Second Ave and Valley Rd",male,"Warren May","Adult 18+",N/A
+"August 15, 2018",Delaware,Dover,"63 Stoney Dr",male,"Larry Harris","Adult 18+",N/A
+"August 15, 2018",Delaware,Dover,"63 Stoney Dr",male,"Dewayne Scott","Teen 12-17",N/A
+"August 15, 2018",Delaware,Dover,"63 Stoney Dr",male,"Derek Johnson","Adult 18+",N/A
+"August 15, 2018",Delaware,Dover,"63 Stoney Dr",female,"Lutricia Ingram","Adult 18+",N/A
+"August 15, 2018",Delaware,Dover,"63 Stoney Dr",female,"Katherine Howard","Adult 18+",N/A
+"August 15, 2018",Delaware,Dover,"63 Stoney Dr",female,"Michele Machado","Adult 18+",N/A
+"August 13, 2018",Delaware,Wilmington,"200 block of N Lincoln St",male,N/A,"Adult 18+",N/A
+"August 8, 2018",Delaware,Dover,"900 block of Simon Cir",male,"Maurice Butler","Adult 18+",N/A
+"August 8, 2018",Delaware,Dover,"900 block of Simon Cir",female,"Mary Honey","Adult 18+",N/A
+"August 7, 2018",Delaware,Newark,"6 N Skyward Dr",female,"Rachel Roberts","Adult 18+",N/A
+"August 7, 2018",Delaware,Newark,"6 N Skyward Dr",male,"Probyn Morris","Adult 18+",N/A
+"August 5, 2018",Delaware,Dagsboro,"30000 block of Power Plant Rd",male,N/A,"Adult 18+",N/A
+"August 5, 2018",Delaware,Dagsboro,"30000 block of Power Plant Rd",male,N/A,"Adult 18+",N/A
+"August 5, 2018",Delaware,Dagsboro,"30000 block of Power Plant Rd",male,N/A,"Adult 18+",N/A
+"August 5, 2018",Delaware,Dagsboro,"30000 block of Power Plant Rd",male,N/A,"Adult 18+",N/A
+"August 5, 2018",Delaware,Dagsboro,"30000 block of Power Plant Rd",male,N/A,"Adult 18+",N/A
+"August 5, 2018",Delaware,"New Castle","1200 West Ave",male,N/A,"Adult 18+",N/A
+"August 4, 2018",Delaware,Smyrna,"300 block of Southern View Dr",male,"Brian Sadler","Adult 18+",N/A
+"August 4, 2018",Delaware,Smyrna,"300 block of Southern View Dr",male,"Kashar McIvor","Adult 18+",N/A
+"August 4, 2018",Delaware,Smyrna,"300 block of Southern View Dr",male,"Douglas Hodges","Adult 18+",N/A
+"August 4, 2018",Delaware,Bear,"1607 Pulaski Hwy",male,N/A,"Adult 18+",N/A
+"August 3, 2018",Delaware,Wilmington,"1300 block of E 27th St",male,"Tymier Shelby","Teen 12-17",N/A
+"August 2, 2018",Delaware,"Rehoboth Beach","37000 of Johnson St",male,"Marvin Burton","Adult 18+",N/A
+"August 2, 2018",Delaware,"Rehoboth Beach","37000 of Johnson St",male,N/A,"Adult 18+",N/A
+"August 2, 2018",Delaware,"Rehoboth Beach","37000 of Johnson St",female,"Delilah Boyernd","Adult 18+",N/A
+"July 30, 2018",Delaware,"New Castle","I-95 and Airport Rd",male,N/A,"Adult 18+",N/A
+"July 30, 2018",Delaware,"New Castle","I-95 and Airport Rd",male,N/A,"Adult 18+",N/A
+"July 27, 2018",Delaware,Georgetown,"20000 block of Donovans Rd",male,"Leeron Sabb","Adult 18+",N/A
+"July 25, 2018",Delaware,"New Castle","West Ave and New Castle Ave",male,"Christopher Longstaff","Adult 18+",N/A
+"July 24, 2018",Delaware,Dover,"Cherry St and Lincoln St",male,"Christopher Brewer",Unknown,N/A
+"July 21, 2018",Delaware,Georgetown,"Old Furnace Rd",male,"Ethan A. Mulford","Adult 18+",N/A
+"July 21, 2018",Delaware,Georgetown,"Old Furnace Rd",male,"Mark J. Smith Jr.","Adult 18+",N/A
+"July 21, 2018",Delaware,Georgetown,"Old Furnace Rd",male,"Matthew R. King Jr.","Adult 18+",N/A
+"July 20, 2018",Delaware,Milton,"Coastal Hwy",male,"Ricky D. Waters","Adult 18+",N/A
+"July 20, 2018",Delaware,Wilmington,"W 5th St and Delamore Pl",male,N/A,"Adult 18+",N/A
+"July 20, 2018",Delaware,Dover,"S Old Mill Rd",male,N/A,"Adult 18+",N/A
+"July 20, 2018",Delaware,Dover,"S Old Mill Rd",male,N/A,"Adult 18+",N/A
+"July 20, 2018",Delaware,Dover,"S Old Mill Rd",female,N/A,"Adult 18+",N/A
+"July 18, 2018",Delaware,Wilmington,"800 block of W 5th St",male,"Sean Spencer","Adult 18+",N/A
+"July 15, 2018",Delaware,Seaford,"Chandler St",male,"Donald White Jr.","Adult 18+",N/A
+"July 13, 2018",Delaware,"New Castle","1200 West Ave",male,N/A,"Adult 18+",N/A
+"July 12, 2018",Delaware,Wilmington,"500 block of E 10th St",male,N/A,"Adult 18+",N/A
+"July 12, 2018",Delaware,Wilmington,"500 block of E 10th St",male,N/A,"Adult 18+",N/A
+"July 12, 2018",Delaware,Wilmington,"2100 block of Lamotte St",male,N/A,"Adult 18+",N/A
+"July 9, 2018",Delaware,Wilmington,"2709 Ferris Rd",male,"Julie Burton Edwards","Adult 18+",N/A
+"July 9, 2018",Delaware,Wilmington,"2709 Ferris Rd",N/A,"Jacob Edwards","Child 0-11",N/A
+"July 9, 2018",Delaware,Wilmington,"2709 Ferris Rd",female,"Brinley Edwards","Child 0-11",N/A
+"July 9, 2018",Delaware,Wilmington,"2709 Ferris Rd",male,"Paxton Edwards","Child 0-11",N/A
+"July 9, 2018",Delaware,Wilmington,"2709 Ferris Rd",male,"Matthew Edwards","Adult 18+",N/A
+"July 9, 2018",Delaware,Laurel,"801 Daniel St",female,N/A,"Adult 18+",N/A
+"July 9, 2018",Delaware,Laurel,"801 Daniel St",male,"Trevor McClements","Adult 18+",N/A
+"July 9, 2018",Delaware,Laurel,"801 Daniel St",male,"Dwayne A. Dotson","Adult 18+",N/A
+"July 9, 2018",Delaware,Laurel,"801 Daniel St",female,N/A,"Adult 18+",N/A
+"July 8, 2018",Delaware,Wilmington,"2600 block of Jessup St",male,"Rashaad Wisher","Adult 18+",N/A
+"July 6, 2018",Delaware,Newark,"1 block of Hanna Dr",male,"Nathanial Harmon","Adult 18+",N/A
+"July 6, 2018",Delaware,Georgetown,"S DuPont Blvd and Old Laurel Rd",male,"Devynne Hobbs","Adult 18+",N/A
+"July 5, 2018",Delaware,Wilmington,"200 block of S Harrison St",male,N/A,"Adult 18+",N/A
+"July 5, 2018",Delaware,Smyrna,"US 13 and Hickory Ridge Rd",male,"Lawrence D. Baily","Adult 18+",N/A
+"July 5, 2018",Delaware,Dover,"S Governors Ave and Reed St",male,N/A,"Adult 18+",N/A
+"July 4, 2018",Delaware,Frankford,"Jones Church Rd",male,"Charles N. West Jr.","Adult 18+",N/A
+"July 2, 2018",Delaware,Wilmington,"400 block of W 6th St",male,N/A,"Adult 18+",N/A
+"July 1, 2018",Delaware,Middletown,"38 E Main St",male,"Ramaj Thompson","Adult 18+",N/A
+"July 1, 2018",Delaware,Middletown,"38 E Main St",male,"Marquis James","Adult 18+",N/A
+"June 30, 2018",Delaware,Wilmington,"I-495 and E 12th St",male,"Robert A. Powell","Adult 18+",N/A
+"June 25, 2018",Delaware,Lewes,"30000 block of Pine Town Rd",male,"Jhareed Ayers","Adult 18+",N/A
+"June 25, 2018",Delaware,Millsboro,"34000 block of Tugboat Ct",male,"Dwayne A. Barnes","Adult 18+",N/A
+"June 24, 2018",Delaware,Wilmington,"700 block of Broom St",male,"Curtis Gregory","Adult 18+",N/A
+"June 23, 2018",Delaware,Wilmington,"5th St and Monroe St",female,N/A,"Adult 18+",N/A
+"June 23, 2018",Delaware,Wilmington,"5th St and Monroe St",male,"Tymir Walley","Adult 18+",N/A
+"June 23, 2018",Delaware,Wilmington,"200 block of W 26th St",male,N/A,"Adult 18+",N/A
+"June 22, 2018",Delaware,Dover,"1289 Walker Rd",male,"Sylvester Lee","Adult 18+",N/A
+"June 22, 2018",Delaware,Dover,"1289 Walker Rd",male,"Timothy L. Safford","Adult 18+",N/A
+"June 20, 2018",Delaware,Dover,"100 block of President Dr",male,N/A,"Adult 18+",N/A
+"June 20, 2018",Delaware,Dover,"100 block of President Dr",N/A,N/A,Unknown,N/A
+"June 17, 2018",Delaware,Wilmington,"50 block of Lloyd St",female,"Doris Dorsey","Teen 12-17",N/A
+"June 17, 2018",Delaware,Wilmington,"50 block of Lloyd St",male,"Vincent DiMenco","Adult 18+",N/A
+"June 17, 2018",Delaware,Wilmington,"50 block of Lloyd St",male,"Doris Dorsey (same name as daughter)","Adult 18+",N/A
+"June 17, 2018",Delaware,Wilmington,"50 block of Lloyd St",male,"Glenford Blackwood","Adult 18+",N/A
+"June 13, 2018",Delaware,"New Castle","50 block of Rambo Terrace",male,N/A,"Adult 18+",N/A
+"June 13, 2018",Delaware,"New Castle","50 block of Rambo Terrace",female,N/A,"Adult 18+",N/A
+"June 13, 2018",Delaware,"New Castle","50 block of Rambo Terrace",N/A,"Daquan Hammond","Adult 18+",N/A
+"June 13, 2018",Delaware,"New Castle","50 block of Rambo Terrace",N/A,"Evan Dayton","Adult 18+",N/A
+"June 13, 2018",Delaware,"New Castle","50 block of Rambo Terrace",N/A,"Jarryd Blankenbiller","Adult 18+",N/A
+"June 13, 2018",Delaware,"New Castle","50 block of Rambo Terrace",N/A,"George Lomas","Adult 18+",N/A
+"June 12, 2018",Delaware,Dover,"Periwinkle Dr and Caroline Pl",male,N/A,"Adult 18+",N/A
+"June 12, 2018",Delaware,Dover,"Periwinkle Dr and Caroline Pl",male,N/A,"Adult 18+",N/A
+"June 12, 2018",Delaware,"New Castle","117 Wilton Blvd",male,N/A,"Adult 18+",N/A
+"June 12, 2018",Delaware,"New Castle","117 Wilton Blvd",female,N/A,"Adult 18+",N/A
+"June 11, 2018",Delaware,Wilmington,"1100 block of Flint Hill Rd",male,"Elijah Gordy-Stith","Adult 18+",N/A
+"June 11, 2018",Delaware,Greenwood,"10900 block of Webb Farm Rd",male,"Jeffrey Allen","Adult 18+",N/A
+"June 11, 2018",Delaware,Greenwood,"10900 block of Webb Farm Rd",male,"Patrick J. Rafferty","Adult 18+",N/A
+"June 11, 2018",Delaware,Greenwood,"10900 block of Webb Farm Rd",male,"Eric C. Howard","Adult 18+",N/A
+"June 11, 2018",Delaware,Greenwood,"10900 block of Webb Farm Rd",male,"Kenneth J. Passwaters","Adult 18+",N/A
+"June 11, 2018",Delaware,Greenwood,"10900 block of Webb Farm Rd",male,N/A,"Adult 18+",N/A
+"June 11, 2018",Delaware,Greenwood,"10900 block of Webb Farm Rd",female,N/A,"Adult 18+",N/A
+"June 10, 2018",Delaware,Clayton,"Sudlersville Rd",female,"Destiny Thomas","Adult 18+",N/A
+"June 10, 2018",Delaware,Clayton,"Sudlersville Rd",male,"George Thomas III","Adult 18+",N/A
+"June 10, 2018",Delaware,Wilmington,"200 block of W 29th St",male,N/A,"Adult 18+",N/A
+"June 7, 2018",Delaware,Dover,"50 block of Village Dr",male,N/A,"Adult 18+",N/A
+"June 7, 2018",Delaware,Wilmington,"Northeast Blvd and E 28th St",male,N/A,"Teen 12-17",N/A
+"June 6, 2018",Delaware,Dover,"50 block of Stevenson Dr",male,N/A,"Adult 18+",N/A
+"May 31, 2018",Delaware,Wilmington,"E 23rd St and Lamotte St",male,"Raquis Deburnure","Teen 12-17",N/A
+"May 30, 2018",Delaware,Wilmington,"1400 block of Lancaster Ave",male,N/A,"Adult 18+",N/A
+"May 30, 2018",Delaware,Wilmington,"1400 block of Lancaster Ave",male,N/A,"Adult 18+",N/A
+"May 30, 2018",Delaware,"New Castle","200 block of Christiana Rd",male,"Shawn G. Madden","Adult 18+",N/A
+"May 30, 2018",Delaware,Newark,"400 block of Wollaston Ave",male,"Kyle Wallace","Adult 18+",N/A
+"May 29, 2018",Delaware,Wilmington,"35th St and Church St",male,N/A,"Adult 18+",N/A
+"May 29, 2018",Delaware,Wilmington,"35th St and Church St",male,"Jy-Aire Dennis","Adult 18+",N/A
+"May 29, 2018",Delaware,Dover,"S Bradford St and Loockerman St",male,"Dareus Anderson","Adult 18+",N/A
+"May 29, 2018",Delaware,Hartly,"4000 block of Arthursville Rd",female,"Mary James","Adult 18+",N/A
+"May 29, 2018",Delaware,Hartly,"4000 block of Arthursville Rd",male,"John James","Adult 18+",N/A
+"May 27, 2018",Delaware,Dover,"300 block of W Division St",male,"Alex Durham","Adult 18+",N/A
+"May 26, 2018",Delaware,Wilmington,"2300 block of Lamotte St",male,N/A,"Adult 18+",N/A
+"May 25, 2018",Delaware,Laurel,"N Poplar St and Maryland Ave",male,"Quandre Winder","Adult 18+",N/A
+"May 24, 2018",Delaware,Wilmington,"500 block of Madison St",male,"Jeremy Tunnell","Adult 18+",N/A
+"May 24, 2018",Delaware,Wilmington,"Kiamensi Rd and Rothwell Dr",female,"Isabel Cooper","Adult 18+",N/A
+"May 24, 2018",Delaware,Wilmington,"Kiamensi Rd and Rothwell Dr",male,"Thessalonians Berry","Adult 18+",N/A
+"May 24, 2018",Delaware,Wilmington,"Kiamensi Rd and Rothwell Dr",male,"Walter Lolley","Adult 18+",N/A
+"May 23, 2018",Delaware,Dover,"900 block of Whatcoat Dr",male,"Russell Ewell Jr.","Adult 18+",N/A
+"May 23, 2018",Delaware,Wilmington,"2800 block of N Claymont St",female,"Morgan Dixon","Adult 18+",N/A
+"May 22, 2018",Delaware,Dover,"Vera Way and College Rd",male,"Eric Lloyd","Adult 18+",N/A
+"May 19, 2018",Delaware,Wilmington,"2600 block of Moore St",male,N/A,"Adult 18+",N/A
+"May 19, 2018",Delaware,Seaford,"122 Seaford Meadows Dr",male,N/A,"Adult 18+",N/A
+"May 19, 2018",Delaware,Seaford,"122 Seaford Meadows Dr",male,N/A,"Adult 18+",N/A
+"May 18, 2018",Delaware,Middletown,"120 Silver Lake Rd",male,"Tymere Moore","Adult 18+",N/A
+"May 15, 2018",Delaware,Wilmington,"300 block of Shipley Rd",male,"Ruben P. Harper","Adult 18+",N/A
+"May 13, 2018",Delaware,Dover,"50 block of Mitscher Rd",male,"Jameir Vann-Robinson","Adult 18+",N/A
+"May 13, 2018",Delaware,Dover,"50 block of Mitscher Rd",male,"Eugene Riley","Adult 18+",N/A
+"May 13, 2018",Delaware,Dover,"50 block of Mitscher Rd",male,"Ahmir Bailey","Adult 18+",N/A
+"May 13, 2018",Delaware,Wilmington,"1300 block of Chestnut St",male,N/A,"Adult 18+",N/A
+"May 12, 2018",Delaware,Wilmington,"500 block of W 6th St",male,N/A,"Teen 12-17",N/A
+"May 11, 2018",Delaware,Bridgeville,"21000 block of Mill Park Dr",male,"Corey Bailey","Adult 18+",N/A
+"May 11, 2018",Delaware,Bridgeville,"21000 block of Mill Park Dr",male,"McArthur M. Risper Jr.","Adult 18+",N/A
+"May 11, 2018",Delaware,Bridgeville,"21000 block of Mill Park Dr",male,N/A,"Adult 18+",N/A
+"May 11, 2018",Delaware,Dover,"1061 S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"May 11, 2018",Delaware,Dover,"1061 S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"May 11, 2018",Delaware,Wilmington,"900 block of Anchorage St",male,N/A,"Adult 18+",N/A
+"May 10, 2018",Delaware,Wilmington,"W 8th St and Morrow St",male,"James Madlock","Adult 18+",N/A
+"May 10, 2018",Delaware,Wilmington,"601 Concord Ave",male,N/A,"Adult 18+",N/A
+"May 10, 2018",Delaware,Wilmington,"600 block of Monroe St",male,"James Madlock","Adult 18+",N/A
+"May 9, 2018",Delaware,Wilmington,"E 10th St and N Pine St",male,"Robert Pearsell","Adult 18+",N/A
+"May 7, 2018",Delaware,Wilmington,"700 block of E 5th St",male,"Khalif Friend","Adult 18+",N/A
+"May 5, 2018",Delaware,Milford,"S Washington St and SE 3rd St",male,"Ronnier Elmore","Adult 18+",N/A
+"May 5, 2018",Delaware,Wilmington,"700 block of E 11th St",male,"Zyaire Dubose","Adult 18+",N/A
+"May 4, 2018",Delaware,Wilmington,"500 block of Lombard St",male,"Joseph Steinmacher","Adult 18+",N/A
+"May 3, 2018",Delaware,Wilmington,"1000 block of N Lombard St",male,N/A,"Adult 18+",N/A
+"May 3, 2018",Delaware,Milford,"300 Aurora Pl",male,"Ronnier Elmore","Adult 18+",N/A
+"April 29, 2018",Delaware,"Rehoboth Beach (Dewey Beach)","2009 Highway One",male,"Alex Johnson","Adult 18+",N/A
+"April 28, 2018",Delaware,Dover,"Lakewood Dr and Columbia Ave",male,"Shabazz Barlow","Adult 18+",N/A
+"April 28, 2018",Delaware,Dover,"Lakewood Dr and Columbia Ave",male,"Jerry Green","Adult 18+",N/A
+"April 28, 2018",Delaware,Dover,"Lakewood Dr and Columbia Ave",male,N/A,"Teen 12-17",N/A
+"April 28, 2018",Delaware,Harrington,"US 13",male,"Michael D. Folmar","Adult 18+",N/A
+"April 24, 2018",Delaware,Magnolia,"100 block of Woodville Dr",male,"Kwamai Johnson","Adult 18+",N/A
+"April 24, 2018",Delaware,Dover,"200 block of W Reed St",male,"Shiheem Durham","Teen 12-17",N/A
+"April 24, 2018",Delaware,Dover,"200 block of W Reed St",male,"Zymire Martinez","Teen 12-17",N/A
+"April 24, 2018",Delaware,Dover,"200 block of W Reed St",male,N/A,"Adult 18+",N/A
+"April 24, 2018",Delaware,Dover,"200 block of W Reed St",male,"Khahiem Lewis","Teen 12-17",N/A
+"April 24, 2018",Delaware,Dover,"200 block of W Reed St",male,"Alton Kinsey","Teen 12-17",N/A
+"April 24, 2018",Delaware,Wilmington,"1000 block of N Heald St",male,N/A,"Adult 18+",N/A
+"April 24, 2018",Delaware,Wilmington,"1000 block of N Heald St",female,"Maya Lewis","Adult 18+",N/A
+"April 22, 2018",Delaware,Selbyville,"Shade Tree Ln",male,"Tristan Stone Kelly","Adult 18+",N/A
+"April 22, 2018",Delaware,Selbyville,"Shade Tree Ln",female,"Atlanta Blaze Crumbley","Teen 12-17",N/A
+"April 20, 2018",Delaware,Middletown,"Ash Blvd and Foxtail Ln",male,"Devantee Smith","Adult 18+",N/A
+"April 20, 2018",Delaware,Wilmington,"1200 block of E 22nd St",male,N/A,"Adult 18+",N/A
+"April 19, 2018",Delaware,Dover,"Old Forge Dr and Meadow Garden Ln",male,"Daquan Giddens","Adult 18+",N/A
+"April 19, 2018",Delaware,Newark,"200 block of Peach Rd",male,"Charles R. Dunagan","Adult 18+",N/A
+"April 17, 2018",Delaware,Dover,"400 Block of E Water St",male,"Syncere Friends","Adult 18+",N/A
+"April 17, 2018",Delaware,"New Castle","50 block of Birkshire Rd",male,"Lquan Reddon","Adult 18+",N/A
+"April 17, 2018",Delaware,Harrington,"50 block of Clark St",female,N/A,"Teen 12-17",N/A
+"April 17, 2018",Delaware,Harrington,"50 block of Clark St",male,"Daquan Walker","Adult 18+",N/A
+"April 17, 2018",Delaware,Harrington,"50 block of Clark St",female,"Christina D. Morgan","Adult 18+",N/A
+"April 17, 2018",Delaware,Dover,"50 block of Ann Ave",male,"David Austin","Adult 18+",N/A
+"April 17, 2018",Delaware,Smyrna,"200 block of Bryn Ln",male,"Joseph Swiggett","Adult 18+",N/A
+"April 17, 2018",Delaware,Smyrna,"200 block of Bryn Ln",male,"Anthony Price","Adult 18+",N/A
+"April 17, 2018",Delaware,Smyrna,"200 block of Bryn Ln",female,"Symone Brooks","Adult 18+",N/A
+"April 16, 2018",Delaware,Dover,"100 block of Mannering Dr",male,N/A,"Adult 18+",N/A
+"April 16, 2018",Delaware,Dover,"100 block of Mannering Dr",male,"David I. Brown","Adult 18+",N/A
+"April 15, 2018",Delaware,Wilmington,"3318 Kirkwood Hwy",male,"Robert C. Oldham","Adult 18+",N/A
+"April 14, 2018",Delaware,Magnolia,"McKinley Cir",male,"Davion Scott","Teen 12-17",N/A
+"April 14, 2018",Delaware,Wilmington,"Philadelphia Pike and Murphy Rd",male,"Donald C. Vavala III","Adult 18+",N/A
+"April 14, 2018",Delaware,Newark,"50 block of E Cherokee Dr",male,N/A,"Adult 18+",N/A
+"April 14, 2018",Delaware,Newark,"50 block of E Cherokee Dr",female,N/A,"Adult 18+",N/A
+"April 14, 2018",Delaware,Newark,"50 block of E Cherokee Dr",male,"Gregory Johnson","Adult 18+",N/A
+"April 13, 2018",Delaware,Milford,"300 Aurora Pl",N/A,N/A,Unknown,N/A
+"April 13, 2018",Delaware,Milford,"300 Aurora Pl",N/A,N/A,Unknown,N/A
+"April 13, 2018",Delaware,Smyrna,"SR 1 and Smyrna Leipsic Rd",male,"Quajan Daniels","Adult 18+",N/A
+"April 13, 2018",Delaware,Dover,"William St and Pear St",male,"David Austin","Adult 18+",N/A
+"April 9, 2018",Delaware,Wilmington,"1100 block of W 3rd St",male,N/A,"Teen 12-17",N/A
+"April 9, 2018",Delaware,Dover,"640 S DuPont Hwy",male,"Henry Ross","Adult 18+",N/A
+"April 9, 2018",Delaware,Dover,"640 S DuPont Hwy",male,"Donald Washington","Adult 18+",N/A
+"April 8, 2018",Delaware,Wilmington,"400 block of N Pine St",male,N/A,"Adult 18+",N/A
+"April 8, 2018",Delaware,Wilmington,"400 block of N Pine St",male,N/A,"Adult 18+",N/A
+"April 7, 2018",Delaware,Milford,"Park Ave and N Washington St",male,N/A,"Adult 18+",N/A
+"April 7, 2018",Delaware,Milford,"Park Ave and N Washington St",male,"Charles Larsen, Jr.","Adult 18+",N/A
+"April 7, 2018",Delaware,Dover,"1 block of Headstart Ln",male,N/A,"Adult 18+",N/A
+"April 7, 2018",Delaware,Dover,"1 block of Headstart Ln",male,N/A,"Adult 18+",N/A
+"April 5, 2018",Delaware,Wilmington,"100 block of North Clayton St",male,N/A,"Adult 18+",N/A
+"April 3, 2018",Delaware,Felton,"S Dupont Hwy",male,"Robert Harding","Adult 18+",N/A
+"April 1, 2018",Delaware,Dover,"295 S Dupont Hwy",male,N/A,Unknown,N/A
+"April 1, 2018",Delaware,Dover,"295 S Dupont Hwy",male,N/A,Unknown,N/A
+"April 1, 2018",Delaware,Dover,"26 S Governors Ave",male,N/A,"Adult 18+",N/A
+"April 1, 2018",Delaware,Wilmington,"Brookside Dr",male,N/A,"Adult 18+",N/A
+"March 31, 2018",Delaware,Townsend,"US 13 and DE 71",N/A,"Raymond C. Robinson Jr.","Adult 18+",N/A
+"March 31, 2018",Delaware,Townsend,"US 13 and DE 71",male,"Mark A. Lee","Adult 18+",N/A
+"March 28, 2018",Delaware,Wilmington,"50 block of W 27th St",male,N/A,"Adult 18+",N/A
+"March 27, 2018",Delaware,Dover,"Lepore Rd and N DuPont Hwy",female,"Shakera Williams","Adult 18+",N/A
+"March 27, 2018",Delaware,Wilmington,"900 block of Vandever Ave",male,N/A,"Adult 18+",N/A
+"March 24, 2018",Delaware,Dover,"N Dupont Hwy and Messina Hill Rd",male,"Marcos Vinicio Godoy","Adult 18+",N/A
+"March 20, 2018",Delaware,Seaford,"Chandler Heights",male,"Davion Lewis","Adult 18+",N/A
+"March 20, 2018",Delaware,Newark,"S Main St",male,"Isaiah Cheeks","Adult 18+",N/A
+"March 20, 2018",Delaware,Newark,"S Main St",male,"Malcolm Cheeks","Adult 18+",N/A
+"March 19, 2018",Delaware,Newark,"750 E Delaware Ave",female,N/A,"Teen 12-17",N/A
+"March 19, 2018",Delaware,Milford,"1029 S Walnut St",male,N/A,"Adult 18+",N/A
+"March 17, 2018",Delaware,Newark,"1119 S College Ave",male,"Sajhid Goldson","Adult 18+",N/A
+"March 17, 2018",Delaware,Dover,"S Governors Ave and W Division St",male,N/A,"Adult 18+",N/A
+"March 17, 2018",Delaware,Dover,"S Governors Ave and W Division St",male,N/A,Unknown,N/A
+"March 15, 2018",Delaware,Milford,"50 block of Causey Ave",male,"Carlos Feliciano-Concepcion","Adult 18+",N/A
+"March 15, 2018",Delaware,Milford,"50 block of Causey Ave",male,"Amilcar Jose Merced-Centeno","Adult 18+",N/A
+"March 15, 2018",Delaware,Dover,"Buckson Dr and Bacon Ave",male,"Alfred Terry","Adult 18+",N/A
+"March 14, 2018",Delaware,Wilmington,"100 block of N Broom St",male,"William Teasley III","Adult 18+",N/A
+"March 13, 2018",Delaware,Wilmington,"900 block of Vandever Ave",male,N/A,"Adult 18+",N/A
+"March 12, 2018",Delaware,Newark,"900 Churchmans Rd",male,"Eric T. Dunn","Adult 18+",N/A
+"March 12, 2018",Delaware,Harrington,"Dorman St and Commerce St",male,"Ivory Brown","Adult 18+",N/A
+"March 11, 2018",Delaware,Dover,"Martin Luther King Jr Blvd",male,"Gerald Bonanni","Adult 18+",N/A
+"March 11, 2018",Delaware,Dover,"S New St",male,"William Caldwell","Adult 18+",N/A
+"March 10, 2018",Delaware,Dover,"1365 N Dupont Hwy",male,"Jawan Custis","Adult 18+",N/A
+"March 9, 2018",Delaware,Wilmington,"300 block of N Van Buren St",male,"Stephan Minus","Adult 18+",N/A
+"March 9, 2018",Delaware,Newark,"Malvern Rd and Augusta Dr",male,"William Laws","Adult 18+",N/A
+"March 9, 2018",Delaware,Newark,"Malvern Rd and Augusta Dr",male,"Kalif Reeves","Adult 18+",N/A
+"March 9, 2018",Delaware,Newark,"Malvern Rd and Augusta Dr",male,"Shai Thodos","Adult 18+",N/A
+"March 9, 2018",Delaware,Newark,"Malvern Rd and Augusta Dr",male,"Noah Youngs","Adult 18+",N/A
+"March 9, 2018",Delaware,Newark,"Malvern Rd and Augusta Dr",male,"Edwin Rivera","Adult 18+",N/A
+"March 3, 2018",Delaware,Dover,"200 block of S Queen St",male,"Khalil Bratton","Adult 18+",N/A
+"March 3, 2018",Delaware,Wilmington,"800 block of N Pine St",male,N/A,"Adult 18+",N/A
+"March 2, 2018",Delaware,Bear,"Bear Christiana Rd",male,"Khalil Malloy","Adult 18+",N/A
+"February 27, 2018",Delaware,Lewes,"17000 block of N Brandt St",male,"Michael Gallo","Adult 18+",N/A
+"February 27, 2018",Delaware,Dover,"White Oak Rd and Stevenson Dr",N/A,N/A,"Teen 12-17",N/A
+"February 27, 2018",Delaware,Dover,"White Oak Rd and Stevenson Dr",N/A,N/A,"Teen 12-17",N/A
+"February 25, 2018",Delaware,Wilmington,"2300 block of N Market St",male,"Richard Young","Adult 18+",N/A
+"February 25, 2018",Delaware,Dover,"50 block of S State St",male,"Benjamin Wilson","Adult 18+",N/A
+"February 24, 2018",Delaware,Wilmington,"900 block of Bennett St",male,N/A,"Adult 18+",N/A
+"February 24, 2018",Delaware,Wilmington,N/A,male,N/A,"Teen 12-17",N/A
+"February 21, 2018",Delaware,Wilmington,"Lancaster Ave and S Clayton St",male,N/A,"Adult 18+",N/A
+"February 21, 2018",Delaware,Dover,"50 block of Periwinkle Ct",N/A,N/A,Unknown,N/A
+"February 21, 2018",Delaware,Dover,"50 block of Periwinkle Ct",N/A,N/A,Unknown,N/A
+"February 20, 2018",Delaware,Dover,"Saulsbury Rd and Forrest Ave",male,"Larry Benson","Adult 18+",N/A
+"February 20, 2018",Delaware,Dover,"Saulsbury Rd and Forrest Ave",female,"Makia Benson","Adult 18+",N/A
+"February 18, 2018",Delaware,Middletown,"500 block of New St",male,"Todd Dorn","Adult 18+",N/A
+"February 18, 2018",Delaware,Middletown,"500 block of New St",male,"Derrick Caudle","Teen 12-17",N/A
+"February 16, 2018",Delaware,Wilmington,"4th St and Clayton St",male,N/A,"Adult 18+",N/A
+"February 16, 2018",Delaware,Ellendale,"Dupont Blvd and Beach Hwy",male,"Dakwan Taylor","Adult 18+",N/A
+"February 15, 2018",Delaware,Wilmington,"23rd St and N Pine St",male,N/A,"Adult 18+",N/A
+"February 13, 2018",Delaware,Felton,"100 block of Sandalwood Dr",male,N/A,"Adult 18+",N/A
+"February 13, 2018",Delaware,Felton,"100 block of Sandalwood Dr",male,N/A,"Adult 18+",N/A
+"February 13, 2018",Delaware,Felton,"100 block of Sandalwood Dr",male,N/A,"Adult 18+",N/A
+"February 13, 2018",Delaware,Felton,"100 block of Sandalwood Dr",male,N/A,"Adult 18+",N/A
+"February 13, 2018",Delaware,Dover,"50 block of Kentwood Dr",male,N/A,"Adult 18+",N/A
+"February 13, 2018",Delaware,Dover,"50 block of Kentwood Dr",male,N/A,"Adult 18+",N/A
+"February 13, 2018",Delaware,Dover,"50 block of Kentwood Dr",male,N/A,"Adult 18+",N/A
+"February 12, 2018",Delaware,Wilmington,"2100 block of N Pine St",male,N/A,"Adult 18+",N/A
+"February 12, 2018",Delaware,Wilmington,"2100 block of N Pine St",N/A,N/A,Unknown,N/A
+"February 12, 2018",Delaware,Harrington,"S DuPont Hwy",male,"Christian Baines","Adult 18+",N/A
+"February 12, 2018",Delaware,"Rehoboth Beach","19000 block of Norwood St",male,N/A,"Adult 18+",N/A
+"February 11, 2018",Delaware,Dover,"200 block of Cecil St",male,N/A,Unknown,N/A
+"February 11, 2018",Delaware,Dover,"200 block of Cecil St",male,N/A,Unknown,N/A
+"February 11, 2018",Delaware,Seaford,N/A,female,"Marissa Schurman","Adult 18+",N/A
+"February 11, 2018",Delaware,Seaford,N/A,male,"Roland C Wainwright","Adult 18+",N/A
+"February 11, 2018",Delaware,Seaford,N/A,male,"Marc Johnson","Adult 18+",N/A
+"February 10, 2018",Delaware,Harrington,N/A,male,"Randy T. Combs","Adult 18+",N/A
+"February 9, 2018",Delaware,Wilmington,"200 block of W 23rd St",male,N/A,"Teen 12-17",N/A
+"February 8, 2018",Delaware,Newark,"1 block of Aldershot Dr",male,"Malique Howell","Adult 18+",N/A
+"February 8, 2018",Delaware,Newark,"1 block of Aldershot Dr",male,"Harrison Dorsey","Adult 18+",N/A
+"February 7, 2018",Delaware,Milford,"619 N Dupont Blvd",male,"Jon Henry","Adult 18+",N/A
+"February 6, 2018",Delaware,"New Castle","Christiana Rd and Fresconi Ct",male,"Michael T. Davis Jr.","Adult 18+",N/A
+"February 6, 2018",Delaware,Seaford,"8774 Concord Rd",male,"James M. Finney","Adult 18+",N/A
+"February 6, 2018",Delaware,Newark,"Thayer Ct",male,"Hakeem Evans","Adult 18+",N/A
+"February 5, 2018",Delaware,Wilmington,"2200 block of Lamotte St",male,"Neki Gibbs","Adult 18+",N/A
+"February 5, 2018",Delaware,Wilmington,"2200 block of Lamotte St",male,"Dejuan Cruz","Adult 18+",N/A
+"February 5, 2018",Delaware,Wilmington,"2200 block of Lamotte St",male,"Greg Jenkins","Adult 18+",N/A
+"February 5, 2018",Delaware,Wilmington,"2200 block of Lamotte St",female,"Kelli Snow","Adult 18+",N/A
+"February 1, 2018",Delaware,Dover,"400 block of S New St",male,"Qadir Mosley-Thomas","Adult 18+",N/A
+"February 1, 2018",Delaware,Wilmington,"801 W 5th St",male,"Kiyare Braxton","Adult 18+",N/A
+"January 31, 2018",Delaware,"New Castle (Dunleith)","400 block of Morehouse Dr",male,N/A,"Adult 18+",N/A
+"January 28, 2018",Delaware,Hartly,"1200 block of Crystal Rd",male,N/A,"Adult 18+",N/A
+"January 28, 2018",Delaware,Hartly,"1200 block of Crystal Rd",male,"Jeffrey Smith","Adult 18+",N/A
+"January 26, 2018",Delaware,Wilmington,"2300 block of N Pine St",male,"Zahviaire Berry Shivers","Adult 18+",N/A
+"January 26, 2018",Delaware,Wilmington,"2300 block of N Pine St",male,"Andre Fletcher-Hargrow","Adult 18+",N/A
+"January 26, 2018",Delaware,"New Castle","550 S Dupont Hwy",male,"Mayhew Watson","Adult 18+",N/A
+"January 25, 2018",Delaware,Middletown,"100 block of Liborio Ln",male,"Richard A. Thorpe Jr.","Adult 18+",N/A
+"January 25, 2018",Delaware,Wilmington,"50 block of W Salisbury Dr",female,N/A,"Adult 18+",N/A
+"January 25, 2018",Delaware,Bridgeville,"E Newton Rd and Adams Rd",male,"Tayvon M Sykes","Adult 18+",N/A
+"January 25, 2018",Delaware,Bridgeville,"E Newton Rd and Adams Rd",male,"Jared C Mitchell","Adult 18+",N/A
+"January 25, 2018",Delaware,Hartly,"700 block of Fords Corner Rd",male,"Curtis J Kearney","Adult 18+",N/A
+"January 24, 2018",Delaware,"Camden Wyoming","50 block of Apple Blossom Dr",male,"Timothy S. Walters III","Teen 12-17",N/A
+"January 24, 2018",Delaware,Dover,"2200 block of S State St",male,"Sylvester E. Gould Jr","Adult 18+",N/A
+"January 24, 2018",Delaware,Dover,"2200 block of S State St",female,"Kimberly A. Martin","Adult 18+",N/A
+"January 24, 2018",Delaware,Milford,"5 Linstone Ln",male,"Kaliph Miller","Adult 18+",N/A
+"January 24, 2018",Delaware,Milford,"5 Linstone Ln",male,"Samuel Horton","Adult 18+",N/A
+"January 24, 2018",Delaware,Milford,"5 Linstone Ln",male,"Douglas Moon","Adult 18+",N/A
+"January 24, 2018",Delaware,Middletown,"900 block of Janvier Ct",male,"Gary E. Earl Jr.","Adult 18+",N/A
+"January 23, 2018",Delaware,Milford,"300 Aurora Pl",male,"Treyvon L. Bowman","Adult 18+",N/A
+"January 23, 2018",Delaware,Milford,"300 Aurora Pl",male,"Robert D. Pierce","Adult 18+",N/A
+"January 18, 2018",Delaware,Wilmington,"200 block of N Madison St",male,N/A,"Adult 18+",N/A
+"January 17, 2018",Delaware,Newark,"100 block of Madison Dr",male,"Dawane Warren","Adult 18+",N/A
+"January 17, 2018",Delaware,"Wilmington (Edgemoor)","50 block of Polk Rd",N/A,N/A,Unknown,N/A
+"January 17, 2018",Delaware,Wilmington,"2300 block of N Market St",male,N/A,"Adult 18+",N/A
+"January 17, 2018",Delaware,Dover,"43 S Kirkwood St",male,"Dustin Skinner","Adult 18+",N/A
+"January 17, 2018",Delaware,Middletown,"100 block of E Lockwood St",male,N/A,"Adult 18+",N/A
+"January 17, 2018",Delaware,Middletown,"100 block of E Lockwood St",male,"Howard Watkins","Adult 18+",N/A
+"January 15, 2018",Delaware,Dagsboro,N/A,male,"Sean K. Moore","Adult 18+",N/A
+"January 15, 2018",Delaware,Frederica,"100 block of Jackson St",male,"Eric Huffstutler","Adult 18+",N/A
+"January 14, 2018",Delaware,Newark,"50 block of White Clay Crescent Dr",male,N/A,"Adult 18+",N/A
+"January 10, 2018",Delaware,Lincoln,"22000 block of Pine Haven Rd",male,N/A,"Adult 18+",N/A
+"January 10, 2018",Delaware,Wilmington,"2700 block of N Claymont St",male,N/A,"Adult 18+",N/A
+"January 10, 2018",Delaware,Frederica,"80 Block of Barefoot Ln",male,"Eric V. Garrison","Adult 18+",N/A
+"January 10, 2018",Delaware,Frederica,"80 Block of Barefoot Ln",male,"Charles L. Melvin Jr.","Adult 18+",N/A
+"January 10, 2018",Delaware,Frederica,"80 Block of Barefoot Ln",male,"Eric Huffstutler","Adult 18+",N/A
+"January 9, 2018",Delaware,Newark,"50 block of North St",male,"Rasean Henry","Adult 18+",N/A
+"January 9, 2018",Delaware,Newark,"50 block of North St",male,"Curtis Bridges","Adult 18+",N/A
+"January 9, 2018",Delaware,Newark,"50 block of North St",male,"John K. Sarmousakis","Teen 12-17",N/A
+"January 9, 2018",Delaware,Milton,"Fisher Rd and Hudson Rd",male,N/A,"Adult 18+",N/A
+"January 9, 2018",Delaware,Milton,"Fisher Rd and Hudson Rd",male,N/A,Unknown,N/A
+"January 2, 2018",Delaware,Wilmington,"2700 block of W 5th St",male,N/A,"Adult 18+",N/A
+"January 1, 2018",Delaware,Dover,"Charles Polk Rd",male,"Caleb Ford","Adult 18+",N/A
+"January 1, 2018",Delaware,Dover,"Charles Polk Rd",male,"Dasmen Fullman","Adult 18+",N/A
+"January 1, 2018",Delaware,Dover,"Charles Polk Rd",female,"Alicia Young","Adult 18+",N/A
+"December 31, 2017",Delaware,Wilmington,"1300 block of Banning St",male,"Brian Lewis","Adult 18+",N/A
+"December 29, 2017",Delaware,Wilmington,"2800 block of Washington St",male,"Bryan Steger","Adult 18+",N/A
+"December 28, 2017",Delaware,Wilmington,"201 S Heald St",male,N/A,"Adult 18+",N/A
+"December 27, 2017",Delaware,Dover,"Martin Luther King Blvd",male,"Stephen Obeda","Adult 18+",N/A
+"December 27, 2017",Delaware,Wilmington,"200 block of S Madison St",male,N/A,"Adult 18+",N/A
+"December 27, 2017",Delaware,Newark,"1232 Capitol Trl",male,N/A,"Adult 18+",N/A
+"December 27, 2017",Delaware,Newark,"1232 Capitol Trl",male,"Benjamin Lepore","Adult 18+",N/A
+"December 27, 2017",Delaware,"New Castle","113 Parma Ave",male,"Antoine Terry","Adult 18+",N/A
+"December 27, 2017",Delaware,"New Castle","113 Parma Ave",male,"Shaheed Matthews","Adult 18+",N/A
+"December 26, 2017",Delaware,Wilmington,"Todds Ln and N Claymont St",male,"Kyon Miller","Adult 18+",N/A
+"December 21, 2017",Delaware,Magnolia,"50 W Birdie Ln",female,"Shaniqua Saunders","Adult 18+",N/A
+"December 21, 2017",Delaware,Magnolia,"50 W Birdie Ln",male,N/A,"Adult 18+",N/A
+"December 21, 2017",Delaware,Newark,"301 College Sq",male,"Jonathan Audiffred","Adult 18+",N/A
+"December 17, 2017",Delaware,Wilmington,"E 17th St",male,N/A,"Adult 18+",N/A
+"December 16, 2017",Delaware,Wilmington,"800 block of Vandever Ave",male,"Keanan Samuels","Adult 18+",N/A
+"December 15, 2017",Delaware,Wilmington,"Farrand Dr and Kirkwood Hwy",male,"Adam Radcliffe","Adult 18+",N/A
+"December 15, 2017",Delaware,Frederica,"100 block of Jackson St",male,"Dazzel J King","Adult 18+",N/A
+"December 15, 2017",Delaware,Frederica,"100 block of Jackson St",female,"Kaylia Custis","Adult 18+",N/A
+"December 15, 2017",Delaware,Frederica,"100 block of Jackson St",male,"Jerry L Warren Sr","Adult 18+",N/A
+"December 14, 2017",Delaware,Wilmington,"300 block of N Van Buren St",male,N/A,"Adult 18+",N/A
+"December 13, 2017",Delaware,"New Castle","Freedom Trl",male,N/A,Unknown,N/A
+"December 12, 2017",Delaware,Bear,"1645 Pulaski Hwy",male,N/A,"Adult 18+",N/A
+"December 10, 2017",Delaware,Wilmington,"200 block of N Rodney St",male,"Lionel Benson","Adult 18+",N/A
+"December 10, 2017",Delaware,Wilmington,"200 block of N Rodney St",male,"Trevie Burrell","Adult 18+",N/A
+"December 9, 2017",Delaware,Dover,"Fieldstone Ct and Kenton Rd",male,"Juliun Pitcher","Teen 12-17",N/A
+"December 9, 2017",Delaware,Dover,"Fieldstone Ct and Kenton Rd",male,N/A,"Adult 18+",N/A
+"December 5, 2017",Delaware,Wilmington,"800 block of N Jackson St",male,"Shawn Lockhart","Adult 18+",N/A
+"December 5, 2017",Delaware,Dover,"Unit block of S New St",female,N/A,"Adult 18+",N/A
+"December 5, 2017",Delaware,Wilmington,"500 Block of Main St",male,N/A,Unknown,N/A
+"December 5, 2017",Delaware,Wilmington,"500 Block of Main St",male,N/A,Unknown,N/A
+"December 4, 2017",Delaware,Milford,"200 block of S Washington St",male,N/A,Unknown,N/A
+"December 4, 2017",Delaware,Milford,"200 block of S Washington St",male,N/A,Unknown,N/A
+"December 4, 2017",Delaware,Wilmington,"5029 Governor Printz Blvd",male,N/A,"Adult 18+",N/A
+"December 4, 2017",Delaware,Wilmington,"5029 Governor Printz Blvd",male,N/A,"Adult 18+",N/A
+"December 2, 2017",Delaware,Wilmington,"W 27th St and Tatnall St",female,N/A,"Adult 18+",N/A
+"December 1, 2017",Delaware,Lewes,"Breakwater St",male,N/A,"Adult 18+",N/A
+"December 1, 2017",Delaware,Lewes,"Breakwater St",male,"Spencer Coffin","Adult 18+",N/A
+"November 29, 2017",Delaware,Wilmington,"1300 N Claymont St",female,N/A,"Adult 18+",N/A
+"November 29, 2017",Delaware,Wilmington,"1300 N Claymont St",male,N/A,"Adult 18+",N/A
+"November 29, 2017",Delaware,Wilmington,"1300 N Claymont St",male,N/A,"Adult 18+",N/A
+"November 28, 2017",Delaware,Newark,"Freedom Rd and Penman Seventy 6 St",male,"Anthony Phippin","Adult 18+",N/A
+"November 27, 2017",Delaware,"New Castle","700 block of W 11th St",male,N/A,"Adult 18+",N/A
+"November 24, 2017",Delaware,Wilmington,"E 23rd St",male,N/A,"Adult 18+",N/A
+"November 22, 2017",Delaware,Wilmington,"W 7th St and N Tatnall St",male,"Davon Crosby-Avant","Adult 18+",N/A
+"November 22, 2017",Delaware,Wilmington,"W 7th St and N Tatnall St",male,"Razzaq A. Muhammad","Adult 18+",N/A
+"November 21, 2017",Delaware,Newark,"1 block of Lawrence Ave",male,"David Ashby","Adult 18+",N/A
+"November 19, 2017",Delaware,Georgetown,"20762 Dupont Blvd",male,"David Tharp","Adult 18+",N/A
+"November 19, 2017",Delaware,Milford,"200 block of NW 3rd St",male,N/A,Unknown,N/A
+"November 19, 2017",Delaware,Milford,"200 block of NW 3rd St",male,N/A,Unknown,N/A
+"November 19, 2017",Delaware,Wilmington,"1200 block of W 3rd St",male,"Andrew Pennewell","Adult 18+",N/A
+"November 19, 2017",Delaware,Wilmington,"1200 block of W 3rd St",male,N/A,"Adult 18+",N/A
+"November 18, 2017",Delaware,Middletown,"400 block of W Harvest Ln",male,N/A,"Adult 18+",N/A
+"November 18, 2017",Delaware,Middletown,"400 block of W Harvest Ln",male,N/A,Unknown,N/A
+"November 18, 2017",Delaware,Middletown,"400 block of W Harvest Ln",male,N/A,Unknown,N/A
+"November 18, 2017",Delaware,Middletown,"400 block of W Harvest Ln",male,N/A,Unknown,N/A
+"November 18, 2017",Delaware,Middletown,"400 block of W Harvest Ln",male,N/A,Unknown,N/A
+"November 17, 2017",Delaware,Newark,"1 block of Teal Cir",male,N/A,"Adult 18+",N/A
+"November 17, 2017",Delaware,Newark,"1 block of Teal Cir",male,N/A,"Adult 18+",N/A
+"November 15, 2017",Delaware,Middletown,"E Lake Street",female,N/A,"Adult 18+",N/A
+"November 13, 2017",Delaware,Wilmington,"700 block of Townsend Pl",female,N/A,Unknown,N/A
+"November 13, 2017",Delaware,Wilmington,"700 block of Townsend Pl",male,"Khalid Mack","Adult 18+",N/A
+"November 13, 2017",Delaware,Wilmington,"100 block of E. 24th st",male,N/A,"Teen 12-17",N/A
+"November 13, 2017",Delaware,Wilmington,"100 block of E. 24th st",male,N/A,"Adult 18+",N/A
+"November 11, 2017",Delaware,Dover,"Martin Luther King Blvd and River Rd",male,N/A,"Adult 18+",N/A
+"November 9, 2017",Delaware,Wilmington,"500 block of South Franklin St",male,"Justin McDermott","Adult 18+",N/A
+"November 8, 2017",Delaware,Dover,"800 block of Paul St",male,"Godfrey Webb","Adult 18+",N/A
+"November 6, 2017",Delaware,Wilmington,"2400 block of N Market St",male,N/A,"Teen 12-17",N/A
+"November 6, 2017",Delaware,Wilmington,"2400 block of N Market St",male,N/A,"Adult 18+",N/A
+"November 5, 2017",Delaware,Dover,"1200 N Dupont Hwy",N/A,N/A,Unknown,N/A
+"October 31, 2017",Delaware,Wilmington,"700 block of N Van Buren St",male,N/A,"Adult 18+",N/A
+"October 30, 2017",Delaware,Bridgeville,"Mill Park Dr",N/A,N/A,"Adult 18+",N/A
+"October 29, 2017",Delaware,Wilmington,"23rd and Washington",female,N/A,"Adult 18+",N/A
+"October 27, 2017",Delaware,Dover,"865 N DuPont Hwy",male,N/A,"Adult 18+",N/A
+"October 27, 2017",Delaware,Dover,"865 N DuPont Hwy",male,N/A,"Adult 18+",N/A
+"October 26, 2017",Delaware,Wilmington,"320 E 5th St",male,"Kalin Jackson","Adult 18+",N/A
+"October 26, 2017",Delaware,Claymont,"281 Harbor Dr",male,N/A,"Teen 12-17",N/A
+"October 25, 2017",Delaware,Seaford,"11000 block of Orange Blossom Ln",male,N/A,"Adult 18+",N/A
+"October 23, 2017",Delaware,"Rehoboth Beach","37000 block of Johnston St",male,N/A,"Adult 18+",N/A
+"October 23, 2017",Delaware,Frankford,"Roxana Rd and Burbage Rd",male,N/A,"Adult 18+",N/A
+"October 23, 2017",Delaware,Frankford,"Roxana Rd and Burbage Rd",male,N/A,"Adult 18+",N/A
+"October 23, 2017",Delaware,Frankford,"Roxana Rd and Burbage Rd",male,N/A,"Adult 18+",N/A
+"October 21, 2017",Delaware,Wilmington,"1600 block of W 4th St",male,N/A,"Adult 18+",N/A
+"October 19, 2017",Delaware,Kenton,"Cooper St",female,N/A,"Adult 18+",N/A
+"October 19, 2017",Delaware,Kenton,"Cooper St",male,N/A,"Adult 18+",N/A
+"October 17, 2017",Delaware,"New Castle","200 block of Highland Blvd",male,"Anshawn Griffon","Adult 18+",N/A
+"October 17, 2017",Delaware,"New Castle","200 block of Highland Blvd",male,N/A,"Teen 12-17",N/A
+"October 17, 2017",Delaware,"New Castle","200 block of Highland Blvd",female,"Takeerah Britton","Adult 18+",N/A
+"October 17, 2017",Delaware,Wilmington,"W 6th St and N Jefferson St",male,"Derrick Braxton","Adult 18+",N/A
+"October 17, 2017",Delaware,Wilmington,"W 6th St and N Jefferson St",male,N/A,"Adult 18+",N/A
+"October 16, 2017",Delaware,Wilmington,"500 block of W 6th St",male,"Dwayne Grimes","Adult 18+",N/A
+"October 16, 2017",Delaware,Wilmington,"500 block of W 6th St",male,N/A,"Teen 12-17",N/A
+"October 15, 2017",Delaware,Dover,"865 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"October 15, 2017",Delaware,Dover,"865 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"October 15, 2017",Delaware,Wilmington,"600 block of Pine Street",female,N/A,"Teen 12-17",N/A
+"October 14, 2017",Delaware,Bear,"1241 Quintillo Dr",male,N/A,"Adult 18+",N/A
+"October 14, 2017",Delaware,Bear,"1241 Quintillo Dr",male,"Alyjah Thomas","Teen 12-17",N/A
+"October 13, 2017",Delaware,Wilmington,"27th and Claymont",male,N/A,"Adult 18+",N/A
+"October 13, 2017",Delaware,Wilmington,"27th and Claymont",male,N/A,"Adult 18+",N/A
+"October 12, 2017",Delaware,Bridgeville,N/A,male,"Elijah Desir","Adult 18+",N/A
+"October 11, 2017",Delaware,Newark,"50 block of Raven Turn",male,N/A,"Adult 18+",N/A
+"October 11, 2017",Delaware,Dover,"100 block of Presidents Dr",male,N/A,"Adult 18+",N/A
+"October 11, 2017",Delaware,Dover,"100 block of Presidents Dr",male,"Khalil-Mahlik T. Hanzer","Adult 18+",N/A
+"October 10, 2017",Delaware,Laurel,"Market St and Railroad Ave",male,N/A,"Child 0-11",N/A
+"October 10, 2017",Delaware,Laurel,"Market St and Railroad Ave",male,N/A,"Teen 12-17",N/A
+"October 10, 2017",Delaware,Laurel,"Market St and Railroad Ave",male,N/A,"Teen 12-17",N/A
+"October 9, 2017",Delaware,"New Castle","50 block of Briarcliff Dr",male,N/A,"Teen 12-17",N/A
+"October 8, 2017",Delaware,Wilmington,"600 block of Concord Ave",male,N/A,"Adult 18+",N/A
+"October 7, 2017",Delaware,"New Castle","I-495 and Hessler Blvd",male,"Tyler Nepa","Adult 18+",N/A
+"October 6, 2017",Delaware,Wilmington,"400 block of W 32nd St",male,"Bakr Dillard","Adult 18+",N/A
+"October 5, 2017",Delaware,Wilmington,"400 block of Townsend Street",male,N/A,"Teen 12-17",N/A
+"October 5, 2017",Delaware,Milton,"13000 block of Sunland Drive",female,N/A,"Adult 18+",N/A
+"October 5, 2017",Delaware,Milton,"13000 block of Sunland Drive",male,"John Pinto III","Adult 18+",N/A
+"October 4, 2017",Delaware,Wilmington,"Van Buren and Pleasant street",male,N/A,"Adult 18+",N/A
+"October 2, 2017",Delaware,Wilmington,"W 7th and N Monroe",N/A,N/A,Unknown,N/A
+"October 2, 2017",Delaware,Wilmington,"W 7th and N Monroe",N/A,N/A,Unknown,N/A
+"October 1, 2017",Delaware,Wilmington,"600 block of S Van Buren",male,N/A,"Adult 18+",N/A
+"September 30, 2017",Delaware,Wilmington,"1200 block of Lobdell St",male,N/A,"Adult 18+",N/A
+"September 30, 2017",Delaware,Wilmington,"30th and Market",male,N/A,"Teen 12-17",N/A
+"September 30, 2017",Delaware,Wilmington,"30th and Market",male,N/A,"Teen 12-17",N/A
+"September 30, 2017",Delaware,Wilmington,"30th and Market",male,N/A,"Adult 18+",N/A
+"September 29, 2017",Delaware,"Wilmington (Elsmere)","103 S Maryland Ave",N/A,N/A,"Adult 18+",N/A
+"September 29, 2017",Delaware,"Wilmington (Elsmere)","103 S Maryland Ave",male,N/A,"Adult 18+",N/A
+"September 29, 2017",Delaware,Wilmington,"3806 Governor Printz Boulevard",male,N/A,"Adult 18+",N/A
+"September 28, 2017",Delaware,Wilmington,"4300 block of Miller Rd",male,"Albert K. Hazzard Jr.","Adult 18+",N/A
+"September 27, 2017",Delaware,Wilmington,"1000 block of Pine Street",male,N/A,"Adult 18+",N/A
+"September 26, 2017",Delaware,Dover,"Fulton St and New St",male,"Rodney Morris","Adult 18+",N/A
+"September 26, 2017",Delaware,Wilmington,"37th St and Monroe St",male,N/A,"Adult 18+",N/A
+"September 26, 2017",Delaware,Wilmington,"37th St and Monroe St",male,N/A,"Adult 18+",N/A
+"September 26, 2017",Delaware,Dover,"400 block of Kent St",male,"Jerome Miller","Adult 18+",N/A
+"September 25, 2017",Delaware,Wilmington,"2600 block of N Harrison St",male,N/A,"Adult 18+",N/A
+"September 24, 2017",Delaware,Wilmington,"2400 block of N Monroe St",male,N/A,Unknown,N/A
+"September 24, 2017",Delaware,Wilmington,"2400 block of N Monroe St",male,"Diandre L. Polk","Adult 18+",N/A
+"September 24, 2017",Delaware,Wilmington,"2400 block of N Monroe St",male,"Josiah Morgan","Adult 18+",N/A
+"September 24, 2017",Delaware,Bridgeville,"11000 block of Iris Field Ln",male,N/A,"Adult 18+",N/A
+"September 24, 2017",Delaware,Bridgeville,"11000 block of Iris Field Ln",male,"Larry T Hobbs","Adult 18+",N/A
+"September 24, 2017",Delaware,Bridgeville,"11000 block of Iris Field Ln",male,N/A,"Adult 18+",N/A
+"September 24, 2017",Delaware,Wilmington,N/A,male,N/A,"Adult 18+",N/A
+"September 23, 2017",Delaware,Wilmington,"1100 block of Beech St",male,N/A,"Adult 18+",N/A
+"September 23, 2017",Delaware,Wilmington,"1100 block of Beech St",male,N/A,"Adult 18+",N/A
+"September 23, 2017",Delaware,Wilmington,"1100 block of Beech St",male,N/A,"Adult 18+",N/A
+"September 21, 2017",Delaware,Dover,"1700 E Lebanon Rd",male,"Cameron Norwood","Adult 18+",N/A
+"September 21, 2017",Delaware,Dover,"1700 E Lebanon Rd",male,"Natasha Morris","Adult 18+",N/A
+"September 20, 2017",Delaware,"Rehoboth Beach","21000 block of Catalina Cir",female,"Kimberley C. Cook","Adult 18+",N/A
+"September 19, 2017",Delaware,Newark,"Four Seasons Pkwy",male,"Gregory Wright","Adult 18+",N/A
+"September 18, 2017",Delaware,Wilmington,"1000 block of N Spruce St",male,N/A,"Adult 18+",N/A
+"September 18, 2017",Delaware,Wilmington,"E 10th St and N Pine St",male,N/A,"Adult 18+",N/A
+"September 18, 2017",Delaware,Wilmington,"E 10th St and N Pine St",male,N/A,"Adult 18+",N/A
+"September 17, 2017",Delaware,Wilmington,"900 block of E 17th",male,N/A,"Adult 18+",N/A
+"September 15, 2017",Delaware,Seaford,"23000 block of Dove Rd",male,"Donnell Davis","Adult 18+",N/A
+"September 15, 2017",Delaware,Seaford,"23000 block of Dove Rd",male,"Michael C. Moore","Adult 18+",N/A
+"September 14, 2017",Delaware,Dover,"100 block of N New St",male,N/A,"Adult 18+",N/A
+"September 14, 2017",Delaware,Dover,"100 block of N New St",male,"Jahmelle Taylor","Adult 18+",N/A
+"September 14, 2017",Delaware,Wilmington,"2600 block of N Market St",male,N/A,"Adult 18+",N/A
+"September 12, 2017",Delaware,Wilmington,"W 27th St",male,N/A,"Adult 18+",N/A
+"September 11, 2017",Delaware,Wilmington,"2600 block of Zebley Pl",male,N/A,"Adult 18+",N/A
+"September 11, 2017",Delaware,Smyrna,"500 block of Barley Ct",male,"Calvin Boyd Jr.","Adult 18+",N/A
+"September 7, 2017",Delaware,Wilmington,"100 block of Cedar St",male,"Allen Melton","Adult 18+",N/A
+"September 7, 2017",Delaware,Wilmington,"100 block of Cedar St",male,"Sandy Lashley","Adult 18+",N/A
+"September 4, 2017",Delaware,Wilmington,"Maryland Ave",male,N/A,"Adult 18+",N/A
+"September 4, 2017",Delaware,Wilmington,"1900 block of 5th St",female,N/A,"Child 0-11",N/A
+"September 4, 2017",Delaware,Wilmington,"1900 block of 5th St",male,"Malik Richards","Adult 18+",N/A
+"September 4, 2017",Delaware,Wilmington,"700 block of Townsend Pl",male,"Rasheen Congo","Adult 18+",N/A
+"September 4, 2017",Delaware,Wilmington,"700 block of Townsend Pl",male,"Tylir Clark","Adult 18+",N/A
+"September 3, 2017",Delaware,Dover,"360 Webbs Ln",male,"Jamar A. Wilson","Adult 18+",N/A
+"September 3, 2017",Delaware,Wilmington,"50 block of W 26th St",male,"Barry White","Adult 18+",N/A
+"September 3, 2017",Delaware,Wilmington,"50 block of W 26th St",male,"Andre Johnson","Adult 18+",N/A
+"September 2, 2017",Delaware,Wilmington,"800 block of N. Adams St.",male,"Kaimel Ennals","Adult 18+",N/A
+"September 1, 2017",Delaware,Dover,"51 Webbs Ln",female,N/A,"Adult 18+",N/A
+"September 1, 2017",Delaware,Dover,"51 Webbs Ln",male,N/A,"Adult 18+",N/A
+"September 1, 2017",Delaware,Dover,"51 Webbs Ln",male,N/A,"Adult 18+",N/A
+"September 1, 2017",Delaware,Dover,"51 Webbs Ln",male,"Khalil-Mahl T. Hanzer","Adult 18+",N/A
+"August 30, 2017",Delaware,Georgetown,"1309 Lee Ave",male,"Tre Edwards","Adult 18+",N/A
+"August 28, 2017",Delaware,"Dover (Leipsic)","168 E Denny St",male,"Leonard H Voss Jr","Adult 18+",N/A
+"August 28, 2017",Delaware,Wilmington,"100 block of E. 23rd St.",male,N/A,"Adult 18+",N/A
+"August 24, 2017",Delaware,Wilmington,"300 block of Concord Avenue",male,N/A,"Adult 18+",N/A
+"August 24, 2017",Delaware,Wilmington,"S Scott St and Tulip St",male,N/A,"Adult 18+",N/A
+"August 24, 2017",Delaware,Bridgeville,"Appletree Road",male,"Tyron Lake","Adult 18+",N/A
+"August 24, 2017",Delaware,Bridgeville,"Appletree Road",male,N/A,"Adult 18+",N/A
+"August 23, 2017",Delaware,Wilmington,"114 E 24th St",male,N/A,"Adult 18+",N/A
+"August 22, 2017",Delaware,Wilmington,"934 Clifford Brown Walk",male,N/A,"Adult 18+",N/A
+"August 22, 2017",Delaware,Wilmington,"934 Clifford Brown Walk",female,N/A,"Adult 18+",N/A
+"August 20, 2017",Delaware,Newark,"Barnwell Ln",male,"Timothy Showell","Adult 18+",N/A
+"August 20, 2017",Delaware,Newark,"200 block of Barnwell Ln",male,"Timothy Showell","Adult 18+",N/A
+"August 18, 2017",Delaware,Wilmington,"1800 block of N. Tatnall St.",male,N/A,"Adult 18+",N/A
+"August 15, 2017",Delaware,Dover,"Maple Parkway and North Du Pont Highway",male,"Thomas Clark","Adult 18+",N/A
+"August 11, 2017",Delaware,Bear,"100 block of Carlotta Dr",female,"Laura Stanley","Adult 18+",N/A
+"August 11, 2017",Delaware,Bear,"100 block of Carlotta Dr",male,"Tyrone Gardner","Adult 18+",N/A
+"August 11, 2017",Delaware,Bear,"100 block of Carlotta Dr",male,"Jamir Waters","Adult 18+",N/A
+"August 9, 2017",Delaware,Wilmington,"600 block of N Pine St",male,"Nycire Mills","Adult 18+",N/A
+"August 8, 2017",Delaware,Wilmington,"W 4th and N Monroe",male,N/A,"Adult 18+",N/A
+"August 8, 2017",Delaware,Wilmington,"W 4th and N Monroe",male,"Darius Wrenn","Adult 18+",N/A
+"August 8, 2017",Delaware,Wilmington,"W 4th and N Monroe",male,"Luis Velazquez","Teen 12-17",N/A
+"August 8, 2017",Delaware,Dover,"1426 N Dupont Hwy",male,"Daekwon Hoskins","Adult 18+",N/A
+"August 8, 2017",Delaware,Wilmington,"Lancaster and Van Buren",male,N/A,"Adult 18+",N/A
+"August 6, 2017",Delaware,"New Castle","Bunker Hill Rd",male,"Craig Jones","Adult 18+",N/A
+"August 3, 2017",Delaware,Seaford,"1 Chandler St",male,N/A,"Adult 18+",N/A
+"August 3, 2017",Delaware,Wilmington,"1100 block of Maryland Ave",male,N/A,"Adult 18+",N/A
+"August 3, 2017",Delaware,Wilmington,"1100 block of Maryland Ave",male,N/A,"Adult 18+",N/A
+"August 3, 2017",Delaware,Wilmington,"1100 block of Maryland Ave",male,"Tevin ""Taz"" Beatty","Adult 18+",N/A
+"July 30, 2017",Delaware,Wilmington,"2300 block of N Locust St",female,N/A,"Adult 18+",N/A
+"July 30, 2017",Delaware,Wilmington,"400 block of Townsend St",male,N/A,"Adult 18+",N/A
+"July 30, 2017",Delaware,Wilmington,"23rd St and Pine St",male,N/A,"Adult 18+",N/A
+"July 30, 2017",Delaware,Lewes,"15099 Cape Henlopen Dr",male,"Trey S Mata","Adult 18+",N/A
+"July 29, 2017",Delaware,Newark,"630 Suburban Dr",male,N/A,"Adult 18+",N/A
+"July 29, 2017",Delaware,Newark,"630 Suburban Dr",male,"Thomas Ellerbe","Adult 18+",N/A
+"July 29, 2017",Delaware,Newark,"630 Suburban Dr",male,"James A. Brooks","Adult 18+",N/A
+"July 28, 2017",Delaware,Wilmington,"400 block of N Washington St",male,N/A,"Adult 18+",N/A
+"July 28, 2017",Delaware,Wilmington,"400 block of N Washington St",female,N/A,"Adult 18+",N/A
+"July 28, 2017",Delaware,Wilmington,"400 block of N Washington St",male,N/A,"Adult 18+",N/A
+"July 28, 2017",Delaware,Wilmington,"400 block of N Washington St",male,N/A,"Adult 18+",N/A
+"July 28, 2017",Delaware,Wilmington,N/A,male,N/A,"Teen 12-17",N/A
+"July 28, 2017",Delaware,Wilmington,"700 block of S Van Buren St",male,"David Bailey","Adult 18+",N/A
+"July 28, 2017",Delaware,Wilmington,"700 block of S Van Buren St",male,"Aaron L. Miles","Teen 12-17",N/A
+"July 27, 2017",Delaware,Wilmington,"2400 block of N Madison St",female,"Kieshonna Rollins","Adult 18+",N/A
+"July 27, 2017",Delaware,Wilmington,"2400 block of N Madison St",male,"Keshon Rollins","Teen 12-17",N/A
+"July 27, 2017",Delaware,Wilmington,"2400 block of N Madison St",male,"Rahe Walker","Adult 18+",N/A
+"July 27, 2017",Delaware,Wilmington,"1100 block of Westover Rd",male,"Jonathan Dryburgh","Adult 18+",N/A
+"July 27, 2017",Delaware,Wilmington,"2400 block of MacDonough Rd",male,"Jonathan Dryburgh","Adult 18+",N/A
+"July 22, 2017",Delaware,Wilmington,"100 block of E 24th St",male,N/A,"Adult 18+",N/A
+"July 22, 2017",Delaware,Wilmington,"100 block of E 24th St",male,N/A,"Adult 18+",N/A
+"July 22, 2017",Delaware,Wilmington,"1200 block of E 27th St",female,N/A,"Teen 12-17",N/A
+"July 22, 2017",Delaware,Wilmington,"1200 block of E 27th St",male,N/A,"Adult 18+",N/A
+"July 20, 2017",Delaware,Dover,"400 block of River Road",male,N/A,"Adult 18+",N/A
+"July 19, 2017",Delaware,Dover,"400 block of River Rd",male,N/A,"Adult 18+",N/A
+"July 19, 2017",Delaware,Dover,"400 block of River Rd",male,"Dahhpy Brewah","Adult 18+",N/A
+"July 16, 2017",Delaware,Wilmington,"7th St and N Monroe St",male,N/A,"Adult 18+",N/A
+"July 14, 2017",Delaware,Wilmington,"1200 block of W 3rd St",male,"Cyree Watson","Adult 18+",N/A
+"July 14, 2017",Delaware,Wilmington,"1200 block of W 3rd St",male,"Clarence Rivera","Adult 18+",N/A
+"July 12, 2017",Delaware,"New Castle","Baylis Street",male,"Daqwan Vincent","Adult 18+",N/A
+"July 12, 2017",Delaware,Wilmington,"300 block of E. 26th Street",male,N/A,"Adult 18+",N/A
+"July 8, 2017",Delaware,Wilmington,"W 4th St",male,N/A,"Adult 18+",N/A
+"July 6, 2017",Delaware,Claymont,"609 Naamans Rd",male,"Jihad Amaad Rashaad Morris","Adult 18+",N/A
+"July 6, 2017",Delaware,Wilmington,"1300 block of Cedar St",male,N/A,"Adult 18+",N/A
+"July 6, 2017",Delaware,"New Castle","260 Christiana Rd",female,N/A,"Adult 18+",N/A
+"July 6, 2017",Delaware,"New Castle","260 Christiana Rd",male,"Clement Taylor","Adult 18+",N/A
+"July 5, 2017",Delaware,Dover,"51 Webbs Ln",male,N/A,"Adult 18+",N/A
+"July 5, 2017",Delaware,Milton,"Reynolds Road",male,N/A,"Adult 18+",N/A
+"July 5, 2017",Delaware,"New Castle","3125 New Castle Avenue",male,N/A,"Adult 18+",N/A
+"July 5, 2017",Delaware,"New Castle","3125 New Castle Avenue",male,"Kenneth Holmes","Adult 18+",N/A
+"July 4, 2017",Delaware,Wilmington,"400 block of E 9th St",male,N/A,"Teen 12-17",N/A
+"July 3, 2017",Delaware,Newark,"2000 block of Capitol Trl",male,"Ralph A Walsh","Adult 18+",N/A
+"July 1, 2017",Delaware,Wilmington,"1700 Block of W Third St",male,N/A,"Adult 18+",N/A
+"July 1, 2017",Delaware,Wilmington,"1700 Block of W Third St",male,N/A,"Adult 18+",N/A
+"July 1, 2017",Delaware,Milford,"5 Linstone Ln",male,"Kevin M. King","Adult 18+",N/A
+"July 1, 2017",Delaware,Milford,"5 Linstone Ln",male,N/A,"Adult 18+",N/A
+"July 1, 2017",Delaware,Milford,"5 Linstone Ln",male,"Don R. Martinez","Adult 18+",N/A
+"June 30, 2017",Delaware,"New Castle (county)",N/A,male,N/A,"Adult 18+",N/A
+"June 29, 2017",Delaware,Wilmington,"Rysing Drive and S Cannon Drive",female,N/A,"Teen 12-17",N/A
+"June 29, 2017",Delaware,Wilmington,"23rd St and Market St",male,N/A,"Adult 18+",N/A
+"June 28, 2017",Delaware,Seaford,"Rt 13 Alternate and Virginia Ave",male,N/A,"Adult 18+",N/A
+"June 28, 2017",Delaware,Seaford,"Rt 13 Alternate and Virginia Ave",male,N/A,"Adult 18+",N/A
+"June 28, 2017",Delaware,"Rehoboth Beach","Oak Ave",male,"Joshua Abele","Adult 18+",N/A
+"June 28, 2017",Delaware,Wilmington,"9th St and Jefferson St",male,N/A,"Adult 18+",N/A
+"June 27, 2017",Delaware,Dover,"255 Webbs Ln",male,"Dequan Dukes","Adult 18+",N/A
+"June 27, 2017",Delaware,Dover,"255 Webbs Ln",male,"Brett Scott","Adult 18+",N/A
+"June 27, 2017",Delaware,Dover,"255 Webbs Ln",male,"Gregory Sellers","Adult 18+",N/A
+"June 27, 2017",Delaware,Dover,"255 Webbs Ln",male,"Raymond Ward","Adult 18+",N/A
+"June 27, 2017",Delaware,Dover,"255 Webbs Ln",female,"Lisa Wagaman","Adult 18+",N/A
+"June 26, 2017",Delaware,Wilmington,"131 Scarborough Park Dr",male,N/A,"Adult 18+",N/A
+"June 26, 2017",Delaware,Wilmington,"131 Scarborough Park Dr",N/A,N/A,Unknown,N/A
+"June 26, 2017",Delaware,Wilmington,"131 Scarborough Park Dr",N/A,N/A,Unknown,N/A
+"June 25, 2017",Delaware,Wilmington,"1600 block of West 3rd Street",male,N/A,"Adult 18+",N/A
+"June 25, 2017",Delaware,Wilmington,"699 Robinson Ln",male,N/A,"Adult 18+",N/A
+"June 24, 2017",Delaware,"New Castle","Chesterfield Dr",male,N/A,"Adult 18+",N/A
+"June 23, 2017",Delaware,Wilmington,"2700 block of Thompson Pl",male,N/A,"Adult 18+",N/A
+"June 22, 2017",Delaware,Magnolia,"400 Block of Cherry Dr E",male,"Marc A Romano","Adult 18+",N/A
+"June 22, 2017",Delaware,Magnolia,"400 Block of Cherry Dr E",male,"Juan A Matos","Adult 18+",N/A
+"June 22, 2017",Delaware,Magnolia,"400 Block of Cherry Dr E",male,"Jason D Gilbert","Adult 18+",N/A
+"June 21, 2017",Delaware,Wilmington,"2900 block of Tatnall Street",male,N/A,"Adult 18+",N/A
+"June 20, 2017",Delaware,Bear,"Pulaski Highway",male,N/A,"Adult 18+",N/A
+"June 19, 2017",Delaware,Newark,"1232 Capitol Trail",male,"Christopher J. Caccavone","Adult 18+",N/A
+"June 18, 2017",Delaware,Wilmington,"400 block of W 7th",male,N/A,"Adult 18+",N/A
+"June 18, 2017",Delaware,Wilmington,"400 block of W 7th",female,N/A,"Adult 18+",N/A
+"June 18, 2017",Delaware,Wilmington,"400 block of W 7th",male,"Andre Crisden","Adult 18+",N/A
+"June 18, 2017",Delaware,Milford,"5 Linstone Ln",male,N/A,"Adult 18+",N/A
+"June 14, 2017",Delaware,Wilmington,"1800 block of Conrad St.",male,N/A,"Adult 18+",N/A
+"June 13, 2017",Delaware,Wilmington,"2600 block of N Jefferson St",male,"Michael Joe","Adult 18+",N/A
+"June 13, 2017",Delaware,Wilmington,"2600 block of N Jefferson St",male,"Bryant Booker","Adult 18+",N/A
+"June 13, 2017",Delaware,Wilmington,"2600 block of N Jefferson St",male,"Marcus Jamison","Adult 18+",N/A
+"June 13, 2017",Delaware,Wilmington,"300 block of W 29th St",male,N/A,"Adult 18+",N/A
+"June 13, 2017",Delaware,Wilmington,"1100 block of Read St",female,N/A,"Adult 18+",N/A
+"June 13, 2017",Delaware,Wilmington,"1100 block of Read St",female,N/A,"Adult 18+",N/A
+"June 13, 2017",Delaware,Georgetown,"North Bedford Street",male,"Paul Edwards","Adult 18+",N/A
+"June 12, 2017",Delaware,"Wilmington (Newport)","700 Block of Harwood Rd",male,N/A,Unknown,N/A
+"June 12, 2017",Delaware,"Wilmington (Newport)","700 Block of Harwood Rd",male,"Joseph Basher","Adult 18+",N/A
+"June 12, 2017",Delaware,"Wilmington (Newport)","700 Block of Harwood Rd",male,"Joshua Perry","Adult 18+",N/A
+"June 12, 2017",Delaware,Dover,"Stevenson Dr",male,"Denzel Braker","Adult 18+",N/A
+"June 11, 2017",Delaware,Dover,"Collins Drive",male,"Jonair Pollard","Adult 18+",N/A
+"June 9, 2017",Delaware,"New Castle","Briarcliff Dr",male,N/A,"Adult 18+",N/A
+"June 9, 2017",Delaware,"New Castle","Briarcliff Dr",male,"Churchill Christie","Adult 18+",N/A
+"June 7, 2017",Delaware,Wilmington,"1706 Oak St",male,"Giovanni Matos","Adult 18+",N/A
+"June 6, 2017",Delaware,Wilmington,"DE Rt 896",male,N/A,"Adult 18+",N/A
+"June 6, 2017",Delaware,Wilmington,"DE Rt 896",male,N/A,"Adult 18+",N/A
+"June 6, 2017",Delaware,Wilmington,"700 block of E 6th St",male,"Dontae Sykes","Adult 18+",N/A
+"June 6, 2017",Delaware,Wilmington,"700 block of E 6th St",male,"Dion Oliver","Adult 18+",N/A
+"June 6, 2017",Delaware,Wilmington,"700 block of E 6th St",male,"Maurice Cooper","Adult 18+",N/A
+"June 6, 2017",Delaware,Wilmington,"700 block of E 6th St",male,"Teres Tinnin","Adult 18+",N/A
+"June 6, 2017",Delaware,Wilmington,"700 block of E 6th St",male,"JaShown Banner","Child 0-11",N/A
+"June 6, 2017",Delaware,Wilmington,"700 block of E 6th St",male,"Michael Pritchett","Adult 18+",N/A
+"June 6, 2017",Delaware,Wilmington,"700 block of E 6th St",male,"Ryan Bacon","Adult 18+",N/A
+"June 5, 2017",Delaware,Wilmington,"1600 block of N Pine St",male,N/A,"Adult 18+",N/A
+"June 3, 2017",Delaware,Wilmington,"900 block of Kirkwood St",male,N/A,"Adult 18+",N/A
+"June 3, 2017",Delaware,Wilmington,"200 Block of N Rodney St",male,N/A,"Adult 18+",N/A
+"June 3, 2017",Delaware,Wilmington,"24th St and Lamotte St",male,N/A,"Adult 18+",N/A
+"June 1, 2017",Delaware,Dover,"1760 N DuPont Hwy",female,"Amber Buckler","Adult 18+",N/A
+"June 1, 2017",Delaware,Dover,"1760 N DuPont Hwy",male,"Darren Weiford","Adult 18+",N/A
+"May 30, 2017",Delaware,Wilmington,"2000 Block of Washington St",male,N/A,"Adult 18+",N/A
+"May 30, 2017",Delaware,"New Castle","Dallas Dr",male,"Ernest Anderson","Adult 18+",N/A
+"May 28, 2017",Delaware,Wilmington,"600 block of N Harrison",male,N/A,"Adult 18+",N/A
+"May 28, 2017",Delaware,Wilmington,"600 block of N Harrison",female,N/A,"Teen 12-17",N/A
+"May 27, 2017",Delaware,"New Castle","200 block of Keller Beyer Road",male,N/A,"Adult 18+",N/A
+"May 27, 2017",Delaware,"New Castle","200 block of Keller Beyer Road",male,"Andre Queen","Adult 18+",N/A
+"May 26, 2017",Delaware,"New Castle","44 Birkshire Rd",N/A,N/A,"Adult 18+",N/A
+"May 26, 2017",Delaware,Wilmington,"200 block of N. DuPont St",male,N/A,"Adult 18+",N/A
+"May 26, 2017",Delaware,Wilmington,"200 block of N. DuPont St",male,N/A,"Adult 18+",N/A
+"May 26, 2017",Delaware,Wilmington,"200 block of N. DuPont St",male,N/A,"Adult 18+",N/A
+"May 24, 2017",Delaware,Wilmington,"1200 block of Elm St",male,"Tariq Taylor","Adult 18+",N/A
+"May 24, 2017",Delaware,Wilmington,"1200 block of Elm St",male,"Shamar Lindsay","Adult 18+",N/A
+"May 24, 2017",Delaware,Wilmington,"200 block of West 7th Street",male,N/A,"Teen 12-17",N/A
+"May 24, 2017",Delaware,Dover,"16 Sussex Ave",male,N/A,"Adult 18+",N/A
+"May 24, 2017",Delaware,Dover,"16 Sussex Ave",male,N/A,"Adult 18+",N/A
+"May 23, 2017",Delaware,Dover,"Walker Rd and Saulsbury Rd",male,N/A,"Adult 18+",N/A
+"May 23, 2017",Delaware,Newark,"2700 block of Normandy Court",male,N/A,"Adult 18+",N/A
+"May 23, 2017",Delaware,Newark,"2700 block of Normandy Court",male,N/A,Unknown,N/A
+"May 23, 2017",Delaware,Dover,"50 block of S Kirkwood St",male,"Dexter Brown","Adult 18+",N/A
+"May 23, 2017",Delaware,Dover,"50 block of S Kirkwood St",male,"Azwan Blake","Adult 18+",N/A
+"May 23, 2017",Delaware,Dover,"50 block of S Kirkwood St",male,"Anthony Daniels","Adult 18+",N/A
+"May 23, 2017",Delaware,Dover,"50 block of S Kirkwood St",male,"Shamarr Willingham","Adult 18+",N/A
+"May 23, 2017",Delaware,Dover,"50 block of S Kirkwood St",male,"Tyrie Blake","Adult 18+",N/A
+"May 23, 2017",Delaware,Dover,"50 block of S Kirkwood St",male,"Andre Blake","Adult 18+",N/A
+"May 22, 2017",Delaware,Wilmington,"700 block of Windsor Street",male,"Haywood Johnson","Adult 18+",N/A
+"May 22, 2017",Delaware,Wilmington,"400 block of W 7th St",male,N/A,"Adult 18+",N/A
+"May 22, 2017",Delaware,Wilmington,"400 block of W 7th St",male,"Keenan Anderson","Adult 18+",N/A
+"May 21, 2017",Delaware,Wilmington,"3200 block of Champions Dr",female,Deputy,"Adult 18+",N/A
+"May 21, 2017",Delaware,Wilmington,"3200 block of Champions Dr",male,"Maurice Ifill","Adult 18+",N/A
+"May 19, 2017",Delaware,Dover,"1400 block of South Farm View Drive",male,N/A,"Adult 18+",N/A
+"May 19, 2017",Delaware,Wilmington,"Jill Court",male,"Shane Brown","Adult 18+",N/A
+"May 18, 2017",Delaware,Wilmington,"2400 Block of Claymont St",male,"Sherman Pride","Adult 18+",N/A
+"May 17, 2017",Delaware,Dover,"200 Block of N New St",male,N/A,"Adult 18+",N/A
+"May 17, 2017",Delaware,Wilmington,"4th Street and Rodney Street",male,N/A,"Adult 18+",N/A
+"May 17, 2017",Delaware,Wilmington,"4th Street and Rodney Street",male,N/A,Unknown,N/A
+"May 16, 2017",Delaware,Wilmington,"W 26th St and Tatnall St",male,N/A,"Adult 18+",N/A
+"May 16, 2017",Delaware,Wilmington,"W 26th St and Tatnall St",male,N/A,"Adult 18+",N/A
+"May 15, 2017",Delaware,Wilmington,"Shearman Street and N. Lombard Street",male,N/A,"Adult 18+",N/A
+"May 15, 2017",Delaware,Wilmington,"Shearman Street and N. Lombard Street",male,N/A,"Adult 18+",N/A
+"May 15, 2017",Delaware,Wilmington,"Shearman Street and N. Lombard Street",male,N/A,"Adult 18+",N/A
+"May 15, 2017",Delaware,Dover,"1st block of South New Street",male,N/A,"Adult 18+",N/A
+"May 15, 2017",Delaware,Dover,"1400 block of Woodmill Dr",male,"Jaquell McDonald","Adult 18+",N/A
+"May 15, 2017",Delaware,Dover,"1400 block of Woodmill Dr",male,"Davonte Dynum","Adult 18+",N/A
+"May 15, 2017",Delaware,Dover,"1400 block of Woodmill Dr",N/A,N/A,"Teen 12-17",N/A
+"May 14, 2017",Delaware,Wilmington,"A Street and Chapel Street",male,N/A,"Adult 18+",N/A
+"May 11, 2017",Delaware,Smyrna,"Lincoln St",male,N/A,"Adult 18+",N/A
+"May 10, 2017",Delaware,Wilmington,"Eighth and Windsor streets",female,N/A,"Adult 18+",N/A
+"May 10, 2017",Delaware,Wilmington,"Eighth and Windsor streets",male,N/A,"Teen 12-17",N/A
+"May 10, 2017",Delaware,Wilmington,"100 block of Elliot's Way",male,N/A,"Teen 12-17",N/A
+"May 10, 2017",Delaware,Wilmington,"100 block of Elliot's Way",male,"Daseonne Jones","Adult 18+",N/A
+"May 10, 2017",Delaware,Wilmington,"500 block of W 25th St",male,"Darrius Jackson-Paul","Adult 18+",N/A
+"May 10, 2017",Delaware,Wilmington,"500 block of W 25th St",male,"Yamir Harris","Adult 18+",N/A
+"May 8, 2017",Delaware,Wilmington,"50 block of E 23rd St",male,N/A,"Adult 18+",N/A
+"May 6, 2017",Delaware,Wilmington,"Beech St and S Van Buren St",male,N/A,"Adult 18+",N/A
+"May 5, 2017",Delaware,Wilmington,"24th St and Lamotte St",male,N/A,"Adult 18+",N/A
+"May 5, 2017",Delaware,Millsboro,"28547 DuPont Blvd",N/A,N/A,Unknown,N/A
+"May 5, 2017",Delaware,Millsboro,"28547 DuPont Blvd",male,"Brandon Williams","Adult 18+",N/A
+"May 5, 2017",Delaware,Wilmington,"W 2nd St and N Van Buren St",male,"Joquon Coverdale","Adult 18+",N/A
+"May 5, 2017",Delaware,Wilmington,"W 2nd St and N Van Buren St",male,"Naheem Gosa","Adult 18+",N/A
+"May 3, 2017",Delaware,Dover,"Webbs Lane",male,"Lamare Kiser","Adult 18+",N/A
+"May 1, 2017",Delaware,Newark,"24 Brookhill Dr",male,N/A,"Adult 18+",N/A
+"May 1, 2017",Delaware,Seaford,"10599 Concord Road",male,N/A,"Adult 18+",N/A
+"May 1, 2017",Delaware,Seaford,"10599 Concord Road",male,"Antonio Britt","Adult 18+",N/A
+"May 1, 2017",Delaware,Wilmington,"Maple and Porter streets",male,N/A,"Adult 18+",N/A
+"April 30, 2017",Delaware,Wilmington,"800 block of W. 9th St.",male,N/A,"Adult 18+",N/A
+"April 30, 2017",Delaware,Wilmington,"500 block of Taylor St.",male,N/A,"Teen 12-17",N/A
+"April 29, 2017",Delaware,Wilmington,"3rd and N Rodney",male,N/A,"Teen 12-17",N/A
+"April 28, 2017",Delaware,Wilmington,"500 block of West St",male,"Kevron Williams","Adult 18+",N/A
+"April 27, 2017",Delaware,"New Castle","500 S DuPont Hwy",male,N/A,"Adult 18+",N/A
+"April 26, 2017",Delaware,Seaford,"24057 Sussex Hwy",male,"Tojah D. Bacon","Adult 18+",N/A
+"April 26, 2017",Delaware,Seaford,"24057 Sussex Hwy",male,"Darren J. Bacon","Adult 18+",N/A
+"April 26, 2017",Delaware,Wilmington,"900 block of Kirkwood St",female,"Tynesia Cephas","Teen 12-17",N/A
+"April 26, 2017",Delaware,Wilmington,"900 block of Kirkwood St",male,"Shyheim Warren","Adult 18+",N/A
+"April 26, 2017",Delaware,Bear,"1693 Pulaski Hwy",male,"Cpl./1 Stephen J. Ballard","Adult 18+",N/A
+"April 26, 2017",Delaware,Bear,"1693 Pulaski Hwy",male,"Burgon Sealy Jr.","Adult 18+",N/A
+"April 25, 2017",Delaware,Wilmington,"1700 block of N. Pine St.",male,N/A,"Adult 18+",N/A
+"April 25, 2017",Delaware,Wilmington,"100 block of North Van Buren Street",male,N/A,"Adult 18+",N/A
+"April 25, 2017",Delaware,Wilmington,"900 block of Maryland Avenue",male,"Brian Brooks","Adult 18+",N/A
+"April 22, 2017",Delaware,Wilmington,"23rd and West",male,N/A,"Adult 18+",N/A
+"April 22, 2017",Delaware,Wilmington,"27th and Market",male,N/A,"Adult 18+",N/A
+"April 22, 2017",Delaware,Smyrna,"53 E Glenwood Ave",male,N/A,"Adult 18+",N/A
+"April 22, 2017",Delaware,Smyrna,"53 E Glenwood Ave",male,"Adryan Jean-Baptiste","Teen 12-17",N/A
+"April 22, 2017",Delaware,Smyrna,"53 E Glenwood Ave",male,"Micah Rothwell","Teen 12-17",N/A
+"April 21, 2017",Delaware,Wilmington,"Seventh and Monroe streets",male,N/A,"Adult 18+",N/A
+"April 21, 2017",Delaware,Dover,DE-1,male,"Dynzel Reed","Adult 18+",N/A
+"April 20, 2017",Delaware,Wilmington,"2900 block of N Washington St",male,N/A,"Teen 12-17",N/A
+"April 20, 2017",Delaware,Newark,"1100 Stanton Christiana Rd",male,"Brady T Rickard","Adult 18+",N/A
+"April 20, 2017",Delaware,Wilmington,"2nd St and Connell St",male,N/A,"Adult 18+",N/A
+"April 19, 2017",Delaware,Wilmington,"602 Philadelphia Pike",male,"Keith Price","Adult 18+",N/A
+"April 17, 2017",Delaware,Dover,"Collins Dr",male,N/A,"Adult 18+",N/A
+"April 17, 2017",Delaware,Dover,"820 Carvel Dr",male,N/A,"Adult 18+",N/A
+"April 17, 2017",Delaware,Dover,"820 Carvel Dr",male,N/A,"Adult 18+",N/A
+"April 17, 2017",Delaware,Dover,"820 Carvel Dr",male,N/A,"Adult 18+",N/A
+"April 17, 2017",Delaware,"Wilmington (Elsmere)","Faulkland Road and Del. 100",male,N/A,"Adult 18+",N/A
+"April 16, 2017",Delaware,Wilmington,"50 block of S Pennewell Dr",male,N/A,"Teen 12-17",N/A
+"April 16, 2017",Delaware,Wilmington,"50 block of S Pennewell Dr",male,N/A,"Teen 12-17",N/A
+"April 16, 2017",Delaware,Wilmington,"1400 block of W. 3rd Street",male,N/A,"Adult 18+",N/A
+"April 14, 2017",Delaware,Wilmington,"W. 27th St.",male,N/A,"Adult 18+",N/A
+"April 14, 2017",Delaware,Wilmington,"W. 27th St.",male,"Shaquille Brisco","Adult 18+",N/A
+"April 14, 2017",Delaware,Wilmington,"W. 27th St.",male,"Tyrone Brooks","Adult 18+",N/A
+"April 12, 2017",Delaware,Dover,"900 Block of W North St",male,N/A,"Adult 18+",N/A
+"April 12, 2017",Delaware,Dover,"900 Block of W North St",N/A,N/A,Unknown,N/A
+"April 11, 2017",Delaware,Wilmington,"Seventh St and West St",male,"Tyree Robinson","Adult 18+",N/A
+"April 11, 2017",Delaware,Milford,"4500 block of Summer Brook Way",female,"Renee Daniels","Adult 18+",N/A
+"April 11, 2017",Delaware,Milford,"4500 block of Summer Brook Way",male,N/A,"Teen 12-17",N/A
+"April 10, 2017",Delaware,Dover,"DuPont Highway and Division Street",male,"Michael Palmer Jr.","Adult 18+",N/A
+"April 10, 2017",Delaware,Wilmington,"600 block of West Sixth Street",female,N/A,"Teen 12-17",N/A
+"April 9, 2017",Delaware,"New Castle","Lambson Ln and E Hillview Ave",male,N/A,"Adult 18+",N/A
+"April 8, 2017",Delaware,Woodside,"S DuPont Hwy",male,"Andrew Edington","Adult 18+",N/A
+"April 8, 2017",Delaware,Wilmington,"4301 Kirkwood Highway",male,"Adam B. Radcliffe","Adult 18+",N/A
+"April 7, 2017",Delaware,Wilmington,"MLK Jr  Blvd and Justison St",male,N/A,"Adult 18+",N/A
+"April 7, 2017",Delaware,Millsboro,"27000 block of Sandy Dr",male,"Jamel S Gibbs","Adult 18+",N/A
+"April 7, 2017",Delaware,Millsboro,"27000 block of Sandy Dr",female,"Navonda D Farrow","Adult 18+",N/A
+"April 7, 2017",Delaware,Millsboro,"27000 block of Sandy Dr",male,"Pornell Farrow","Adult 18+",N/A
+"April 7, 2017",Delaware,Millsboro,"27000 block of Sandy Dr",female,"Krista M Gdowik","Adult 18+",N/A
+"April 6, 2017",Delaware,Magnolia,"West Walnut Street",male,N/A,Unknown,N/A
+"April 6, 2017",Delaware,Magnolia,"West Walnut Street",male,N/A,Unknown,N/A
+"April 6, 2017",Delaware,Magnolia,"West Walnut Street",male,N/A,Unknown,N/A
+"April 5, 2017",Delaware,Wilmington,"1300 block of E. 29th St.",male,N/A,"Teen 12-17",N/A
+"April 5, 2017",Delaware,Wilmington,"1300 block of E. 29th St.",male,N/A,"Adult 18+",N/A
+"April 4, 2017",Delaware,Dover,"400 block of S Governors Ave",male,"Bernard Alford","Adult 18+",N/A
+"April 3, 2017",Delaware,Bear,"1176 Pulaski Hwy",male,N/A,"Adult 18+",N/A
+"April 3, 2017",Delaware,Bear,"1176 Pulaski Hwy",male,N/A,Unknown,N/A
+"April 3, 2017",Delaware,Bear,"1176 Pulaski Hwy",male,N/A,Unknown,N/A
+"April 3, 2017",Delaware,Bear,"1176 Pulaski Hwy",female,N/A,Unknown,N/A
+"April 3, 2017",Delaware,Wilmington,"West 26th and West streets",male,N/A,"Adult 18+",N/A
+"April 3, 2017",Delaware,Dover,"S Governors Ave and S Bradford St",male,"Austin Ross","Adult 18+",N/A
+"April 2, 2017",Delaware,Wilmington,"400 block of Eastlawn Avenue",male,N/A,"Adult 18+",N/A
+"April 2, 2017",Delaware,Wilmington,"500 block of W. 7th Street",male,N/A,"Adult 18+",N/A
+"April 1, 2017",Delaware,Wilmington,"N Market St and 26th St",male,"Ryan Perez","Adult 18+",N/A
+"March 29, 2017",Delaware,Dover,"76 Stevenson Dr",male,N/A,"Teen 12-17",N/A
+"March 29, 2017",Delaware,Dover,"76 Stevenson Dr",male,N/A,"Teen 12-17",N/A
+"March 29, 2017",Delaware,Dover,"76 Stevenson Dr",male,N/A,"Adult 18+",N/A
+"March 29, 2017",Delaware,Wilmington,"2500 block of N Heald St",male,N/A,"Adult 18+",N/A
+"March 28, 2017",Delaware,Wilmington,"2300 block of N Claymont St",male,"Yaseem Powell","Adult 18+",N/A
+"March 27, 2017",Delaware,Wilmington,"100 block of Town Estates Drive",male,"Brandon Harris","Adult 18+",N/A
+"March 27, 2017",Delaware,Wilmington,"100 block of Town Estates Drive",male,"Miles Harris","Adult 18+",N/A
+"March 25, 2017",Delaware,Wilmington,"200 block of W 7th St",male,N/A,"Adult 18+",N/A
+"March 25, 2017",Delaware,Wilmington,"700 block of North Tatnall Street",male,"Richard Crosby","Adult 18+",N/A
+"March 24, 2017",Delaware,Dover,"S Kirkwood St and Forest Ave",male,"Larry Benson","Adult 18+",N/A
+"March 24, 2017",Delaware,Wilmington,"800 block of Vandever Ave",male,N/A,"Adult 18+",N/A
+"March 24, 2017",Delaware,Wilmington,"800 block of Vandever Ave",male,N/A,"Adult 18+",N/A
+"March 24, 2017",Delaware,Wilmington,"800 block of Vandever Ave",male,N/A,"Adult 18+",N/A
+"March 24, 2017",Delaware,Dover,"South DuPont Highway",male,"Brandon Thompson","Adult 18+",N/A
+"March 23, 2017",Delaware,Wilmington,"600 block of Pine St",male,N/A,"Teen 12-17",N/A
+"March 22, 2017",Delaware,Wilmington,"506 E 5th St",male,N/A,"Adult 18+",N/A
+"March 18, 2017",Delaware,"Ocean View","36000 block of Pine Grove Ln",male,"Troy Lee Short","Adult 18+",N/A
+"March 13, 2017",Delaware,Dover,"255 Webbs Ln.",male,N/A,"Adult 18+",N/A
+"March 13, 2017",Delaware,Dover,"255 Webbs Ln.",male,N/A,"Adult 18+",N/A
+"March 12, 2017",Delaware,Wilmington,"1000 block of W. 7th St.",male,N/A,"Adult 18+",N/A
+"March 8, 2017",Delaware,Wilmington,"1000 block of N Lombard St",male,N/A,"Adult 18+",N/A
+"March 8, 2017",Delaware,Wilmington,"900 block of Marshall St",male,"Tajuane Helton","Adult 18+",N/A
+"March 7, 2017",Delaware,Dover,"800 block of Bacon Ave",male,"Fatou Small","Adult 18+",N/A
+"March 6, 2017",Delaware,Newark,"1913 Sheldon Dr",male,N/A,"Adult 18+",N/A
+"March 2, 2017",Delaware,Harbeson,"22000 block of Hurdle Ditch Rd",male,"Maurice C Gordon Jr","Adult 18+",N/A
+"March 2, 2017",Delaware,Harbeson,"22000 block of Hurdle Ditch Rd",male,"Naquan T Williams","Adult 18+",N/A
+"March 1, 2017",Delaware,Dover,"South Queen Street and Bank Lane",male,"Randall Harris","Adult 18+",N/A
+"February 28, 2017",Delaware,Wilmington,"900 block of Vandever Avenue",male,N/A,"Adult 18+",N/A
+"February 28, 2017",Delaware,Dover,"820 Carvel Dr",male,"Rodney Miller","Adult 18+",N/A
+"February 23, 2017",Delaware,Wilmington,"600 block of E 23rd St",male,"Keevan Hale","Adult 18+",N/A
+"February 23, 2017",Delaware,Wilmington,"600 block of E 23rd St",male,"Kashiem Thomas","Adult 18+",N/A
+"February 22, 2017",Delaware,Newark,"1000 block of S College Rd",male,"Drew Chicklo","Adult 18+",N/A
+"February 21, 2017",Delaware,Wilmington,"2200 block of N Market St",male,"Ainsley Cumberbatch Jr.","Adult 18+",N/A
+"February 21, 2017",Delaware,Wilmington,"2200 block of N Market St",male,"Jamiel Congo","Adult 18+",N/A
+"February 21, 2017",Delaware,Wilmington,"2200 block of N Market St",male,"Thomas Hollingsworth","Adult 18+",N/A
+"February 20, 2017",Delaware,Wilmington,"800 block of Vandever Avenue",male,N/A,"Adult 18+",N/A
+"February 18, 2017",Delaware,Newark,"S College Ave and Christina Pkwy",male,"Donovan Don J Blake","Adult 18+",N/A
+"February 18, 2017",Delaware,"New Castle","1500 block of Surry Ct",male,"John Marcus Fryer","Adult 18+",N/A
+"February 18, 2017",Delaware,"New Castle","1500 block of Surry Ct",male,N/A,Unknown,N/A
+"February 17, 2017",Delaware,"New Castle","700 block of Grantham Ln",male,N/A,"Adult 18+",N/A
+"February 16, 2017",Delaware,Wilmington,"400 block of Delamore Pl",male,N/A,"Adult 18+",N/A
+"February 16, 2017",Delaware,Wilmington,"942 Bennett St",male,N/A,"Adult 18+",N/A
+"February 16, 2017",Delaware,Wilmington,"900 block of Lombard",male,"Nakeem Watson","Adult 18+",N/A
+"February 14, 2017",Delaware,Wilmington,"2000 block of Shallcross Avenue",male,"Shakur Parks","Adult 18+",N/A
+"February 13, 2017",Delaware,Wilmington,"2101 Prior Rd",male,N/A,"Adult 18+",N/A
+"February 12, 2017",Delaware,Wilmington,"400 block of W. 29th St",male,N/A,"Adult 18+",N/A
+"February 11, 2017",Delaware,Wilmington,"1100 block of B Street",male,N/A,"Adult 18+",N/A
+"February 10, 2017",Delaware,"New Castle","Fairhaven Court",male,"Jeremiah White","Adult 18+",N/A
+"February 10, 2017",Delaware,"New Castle","Fairhaven Court",male,N/A,"Teen 12-17",N/A
+"February 10, 2017",Delaware,Dover,"Stevenson Dr",male,"Benjamin Greene","Adult 18+",N/A
+"February 9, 2017",Delaware,Wilmington,"1000 block of W 3rd St",male,N/A,"Adult 18+",N/A
+"February 8, 2017",Delaware,"New Castle","100 block of Parma Ave",male,N/A,"Adult 18+",N/A
+"February 8, 2017",Delaware,Wilmington,"1700 block of Conrad Street",male,N/A,"Adult 18+",N/A
+"February 8, 2017",Delaware,Wilmington,"1700 block of Conrad Street",male,N/A,"Adult 18+",N/A
+"February 8, 2017",Delaware,Wilmington,"2400 block of N. Monroe St.",male,N/A,"Adult 18+",N/A
+"February 7, 2017",Delaware,Dover,"S New St",male,N/A,"Adult 18+",N/A
+"February 7, 2017",Delaware,Dover,"S New St",male,"Gregory Scott","Adult 18+",N/A
+"February 7, 2017",Delaware,"New Castle","Revelle and Deen streets",N/A,N/A,"Teen 12-17",N/A
+"February 7, 2017",Delaware,"New Castle","Revelle and Deen streets",N/A,N/A,"Teen 12-17",N/A
+"February 7, 2017",Delaware,"New Castle","Revelle and Deen streets",male,"Jeremiah White","Adult 18+",N/A
+"February 3, 2017",Delaware,Wilmington,"Lancaster Avenue and South Van Buren Street",male,"Z’kai Brooks","Adult 18+",N/A
+"February 3, 2017",Delaware,Greenwood,"Deep Grass Ln",male,"Robert T Reed","Adult 18+",N/A
+"February 3, 2017",Delaware,Wilmington,"S Van Buren St and Beech St",male,"Therion Reese","Adult 18+",N/A
+"February 3, 2017",Delaware,Wilmington,"S Van Buren St and Beech St",male,N/A,"Teen 12-17",N/A
+"January 31, 2017",Delaware,Milford,"N Rehoboth Rd",male,"Jesus G Serrano Torres","Adult 18+",N/A
+"January 31, 2017",Delaware,Selbyville,"31000 block of Lighthouse Rd",male,"Brad Fosque","Adult 18+",N/A
+"January 31, 2017",Delaware,Selbyville,"31000 block of Lighthouse Rd",male,"Phillip Smith II","Adult 18+",N/A
+"January 31, 2017",Delaware,Selbyville,"31000 block of Lighthouse Rd",male,"William Hudson","Adult 18+",N/A
+"January 30, 2017",Delaware,Wilmington,"1200 block of Oak St",male,N/A,"Adult 18+",N/A
+"January 30, 2017",Delaware,Wilmington,"3rd and Washington streets",male,N/A,"Adult 18+",N/A
+"January 29, 2017",Delaware,Wilmington,"2900 block of N. Claymont St.",male,N/A,"Adult 18+",N/A
+"January 29, 2017",Delaware,Wilmington,"300 block of East 5th Street",male,N/A,"Adult 18+",N/A
+"January 29, 2017",Delaware,Wilmington,"300 block of East 5th Street",male,N/A,"Teen 12-17",N/A
+"January 29, 2017",Delaware,Laurel,"56 Sunset Dr",male,"Mekell Horsey","Adult 18+",N/A
+"January 29, 2017",Delaware,Laurel,"56 Sunset Dr",male,"Stephon R Jackson","Adult 18+",N/A
+"January 29, 2017",Delaware,Wilmington,"13th St and French St",male,N/A,"Adult 18+",N/A
+"January 29, 2017",Delaware,Wilmington,"13th St and French St",male,N/A,"Teen 12-17",N/A
+"January 27, 2017",Delaware,Wilmington,"9th St and N Pine St",male,N/A,"Adult 18+",N/A
+"January 27, 2017",Delaware,Laurel,"Laurel Rd and Shiloh Church Rd",male,"Millard Bouchard","Adult 18+",N/A
+"January 27, 2017",Delaware,"New Castle","Booker Circle",female,N/A,"Adult 18+",N/A
+"January 26, 2017",Delaware,Newark,"700 block of Vinings Way",female,"Jaclyn “Jackie” Engman","Adult 18+",N/A
+"January 26, 2017",Delaware,Newark,"700 block of Vinings Way",male,"Jerry Blankenship","Adult 18+",N/A
+"January 25, 2017",Delaware,Dover,"300 block of Fulton Street",male,"Robert Jordan","Adult 18+",N/A
+"January 24, 2017",Delaware,Newark,"Prospect Ave",male,"Tyler Oppel","Adult 18+",N/A
+"January 24, 2017",Delaware,Newark,"Prospect Ave",male,"Elijah Stevens","Adult 18+",N/A
+"January 24, 2017",Delaware,Wilmington,"200 block of N Market St",female,N/A,"Adult 18+",N/A
+"January 24, 2017",Delaware,Wilmington,"200 block of N Market St",male,"Marc Champagne","Adult 18+",N/A
+"January 23, 2017",Delaware,Wilmington,"1700 block of W 13th St",male,"Bruce Altenburger","Adult 18+",N/A
+"January 22, 2017",Delaware,Newark,"700 Prides Crossing",male,"Jonathan Jackson","Adult 18+",N/A
+"January 22, 2017",Delaware,Wilmington,"2300 block of N. Pine St",male,N/A,"Adult 18+",N/A
+"January 22, 2017",Delaware,"New Castle","100 block of Wimbledon Court",male,"Gibriel Turay","Adult 18+",N/A
+"January 22, 2017",Delaware,"New Castle","100 block of Wimbledon Court",male,"Glenn Randolph","Adult 18+",N/A
+"January 20, 2017",Delaware,Wilmington,"200 block of S Harrison St",male,"Kaden Young","Adult 18+",N/A
+"January 20, 2017",Delaware,Wilmington,"200 block of S Harrison St",male,"Shyjuan Dickerson","Adult 18+",N/A
+"January 20, 2017",Delaware,Wilmington,"200 block of S Harrison St",male,"Isaiah Baird","Adult 18+",N/A
+"January 20, 2017",Delaware,Wilmington,"200 block of S Harrison St",male,"Therion Reese","Adult 18+",N/A
+"January 20, 2017",Delaware,Wilmington,"200 block of S Harrison St",male,"Dai'yann Wharton",Unknown,N/A
+"January 20, 2017",Delaware,Wilmington,"200 block of S Harrison St",male,"Benjamin Smith",Unknown,N/A
+"January 19, 2017",Delaware,Dover,"Loockerman and Queen Streets",male,"Victor Teasley","Adult 18+",N/A
+"January 19, 2017",Delaware,Dover,"Loockerman and Queen Streets",male,"Qadir Mosley","Adult 18+",N/A
+"January 19, 2017",Delaware,Dover,"Loockerman and Queen Streets",male,"Robert Cason","Adult 18+",N/A
+"January 19, 2017",Delaware,Dover,"Loockerman and Queen Streets",male,"Jakell Young","Adult 18+",N/A
+"January 18, 2017",Delaware,Wilmington,"S Market St",male,"Keith L Howell","Adult 18+",N/A
+"January 17, 2017",Delaware,Wilmington,"South Heald Street and A Street",male,N/A,"Adult 18+",N/A
+"January 17, 2017",Delaware,Wilmington,"7th and Market streets",male,"Jamiere Harris","Adult 18+",N/A
+"January 17, 2017",Delaware,Wilmington,"200 block of N Rodney St",male,N/A,"Adult 18+",N/A
+"January 17, 2017",Delaware,Wilmington,"200 block of N Rodney St",male,"Thomas Payne","Adult 18+",N/A
+"January 16, 2017",Delaware,Greenwood,"Unity Ln",male,N/A,"Adult 18+",N/A
+"January 16, 2017",Delaware,Wilmington,"E 22nd St and N Spruce St",male,N/A,"Adult 18+",N/A
+"January 15, 2017",Delaware,Wilmington,"2200 block of N Church St",male,N/A,"Adult 18+",N/A
+"January 15, 2017",Delaware,Wilmington,"1400 block of Northeast Blvd",male,N/A,"Adult 18+",N/A
+"January 14, 2017",Delaware,Wilmington,"2200 block of Lamotte St",male,"Charles Mays","Adult 18+",N/A
+"January 14, 2017",Delaware,Wilmington,"2200 block of Lamotte St",female,"Deneisha Wright","Adult 18+",N/A
+"January 13, 2017",Delaware,"Rehoboth Beach","1900 block of Duffy St",male,N/A,"Adult 18+",N/A
+"January 13, 2017",Delaware,"Rehoboth Beach","1900 block of Duffy St",male,N/A,"Adult 18+",N/A
+"January 11, 2017",Delaware,Wilmington,"100 block of E 14th St",male,"Jermaine Francois","Adult 18+",N/A
+"January 11, 2017",Delaware,Wilmington,"300 block of S. Jackson St.",male,N/A,"Adult 18+",N/A
+"January 11, 2017",Delaware,Wilmington,"300 block of S. Jackson St.",male,N/A,"Adult 18+",N/A
+"January 11, 2017",Delaware,Wilmington,"300 block of S. Jackson St.",male,N/A,"Adult 18+",N/A
+"January 10, 2017",Delaware,Dover,"120 Haman Dr",male,"Javan Cale","Adult 18+",N/A
+"January 10, 2017",Delaware,Dover,"120 Haman Dr",male,"Depaul Wilson","Adult 18+",N/A
+"January 10, 2017",Delaware,Dover,"120 Haman Dr",male,"Guy Jones Jr","Adult 18+",N/A
+"January 9, 2017",Delaware,Wilmington,"101 N Clayton St",male,"Santanu Muhuri","Adult 18+",N/A
+"January 9, 2017",Delaware,Wilmington,"101 N Clayton St",male,"Devonte Dorsett","Adult 18+",N/A
+"January 9, 2017",Delaware,Wilmington,"101 N Clayton St",male,"Jakevis Ellington","Teen 12-17",N/A
+"January 8, 2017",Delaware,Wilmington,"200 block of Porter St",male,"Dariberto Velazquez Mendez","Adult 18+",N/A
+"January 3, 2017",Delaware,Dover,"S. Queen St.",male,"Anthony Ridgeway","Adult 18+",N/A
+"January 3, 2017",Delaware,Wilmington,"7th Street and North Jackson Street",male,N/A,"Adult 18+",N/A
+"January 1, 2017",Delaware,Harrington,"301 Dorman St",male,N/A,"Teen 12-17",N/A
+"January 1, 2017",Delaware,Harrington,"301 Dorman St",male,"Trequon Seth","Adult 18+",N/A
+"January 1, 2017",Delaware,Harrington,"301 Dorman St",male,"David Brown","Adult 18+",N/A
+"December 30, 2016",Delaware,Magnolia,"Flint Dr",male,N/A,"Adult 18+",N/A
+"December 30, 2016",Delaware,Magnolia,"Flint Dr",female,N/A,"Adult 18+",N/A
+"December 30, 2016",Delaware,Magnolia,"Flint Dr",male,N/A,"Adult 18+",N/A
+"December 30, 2016",Delaware,Magnolia,"Flint Dr",male,N/A,"Adult 18+",N/A
+"December 29, 2016",Delaware,Dover,"W North Street and Saulsbury Rd",male,"Tyrese Tilghman-Benson","Adult 18+",N/A
+"December 29, 2016",Delaware,"Seaford (Blades)","West 2nd St",female,"Dina S Hawkins","Adult 18+",N/A
+"December 29, 2016",Delaware,"Seaford (Blades)","West 2nd St",male,"John D Phifer","Adult 18+",N/A
+"December 28, 2016",Delaware,Wilmington,"100 block of S Jackson St",female,N/A,"Adult 18+",N/A
+"December 28, 2016",Delaware,Wilmington,"100 block of S Jackson St",male,"Therion Reese","Adult 18+",N/A
+"December 27, 2016",Delaware,Wilmington,"300 block of 9th Street",male,N/A,"Adult 18+",N/A
+"December 27, 2016",Delaware,Laurel,"1000 block of Hollybrook Apartments",male,"Anthony L. Hood","Adult 18+",N/A
+"December 27, 2016",Delaware,Laurel,"1000 block of Hollybrook Apartments",female,"Denise Clark","Adult 18+",N/A
+"December 23, 2016",Delaware,Dover,"Collins Drive",male,N/A,Unknown,N/A
+"December 23, 2016",Delaware,Dover,"Collins Drive",male,N/A,Unknown,N/A
+"December 23, 2016",Delaware,Dover,"Collins Drive",male,"Eugene Riley","Adult 18+",N/A
+"December 23, 2016",Delaware,Dover,"Collins Drive",male,N/A,"Teen 12-17",N/A
+"December 23, 2016",Delaware,Dover,"Collins Drive",male,N/A,"Teen 12-17",N/A
+"December 20, 2016",Delaware,Wilmington,"1000 block of Linda Rd",male,"Jakeith Latham","Adult 18+",N/A
+"December 20, 2016",Delaware,Wilmington,"1000 block of Linda Rd",male,"Seth Kinderman","Adult 18+",N/A
+"December 13, 2016",Delaware,Wilmington,"200 block of W. 30th Street",N/A,N/A,Unknown,N/A
+"December 13, 2016",Delaware,Wilmington,"200 block of W. 30th Street",N/A,N/A,Unknown,N/A
+"December 13, 2016",Delaware,Dover,"400 block of New Castle Avenue",male,"Jamal Dunson","Adult 18+",N/A
+"December 13, 2016",Delaware,Dover,"400 block of New Castle Avenue",male,"Jonair Pollard","Adult 18+",N/A
+"December 13, 2016",Delaware,Dover,"400 block of New Castle Avenue",male,"Ryjhon Goode","Adult 18+",N/A
+"December 12, 2016",Delaware,Dover,"1400 block of South Farmview",male,N/A,"Teen 12-17",N/A
+"December 10, 2016",Delaware,Dover,"100 block of South New Street",male,N/A,"Adult 18+",N/A
+"December 10, 2016",Delaware,Dover,"100 block of South New Street",male,N/A,"Adult 18+",N/A
+"December 8, 2016",Delaware,Wilmington,"W. Fifth and N. Scott streets",male,N/A,"Adult 18+",N/A
+"December 6, 2016",Delaware,Dover,"400 block of Aspen Drive",male,"Tyler Parton","Adult 18+",N/A
+"December 5, 2016",Delaware,Wilmington,"22nd Street and Pine Street",male,N/A,"Adult 18+",N/A
+"December 4, 2016",Delaware,Bear,"100 block of Garwood Drive",male,N/A,"Adult 18+",N/A
+"December 1, 2016",Delaware,Wilmington,"2900 block of Baynard Blvd",male,N/A,"Adult 18+",N/A
+"November 30, 2016",Delaware,"New Castle","Howell Drive and Daniel Lane",male,N/A,"Adult 18+",N/A
+"November 30, 2016",Delaware,"New Castle","Deen and Pell Street",male,"Malachi Dendy","Adult 18+",N/A
+"November 28, 2016",Delaware,Millsboro,"25935 Plaza Drive",male,"Harvey Justice","Adult 18+",N/A
+"November 28, 2016",Delaware,Wilmington,"22nd and Jefferson streets",male,"Robert E ""Bobby Dimes"" Teat III","Adult 18+",N/A
+"November 28, 2016",Delaware,Wilmington,"West 27th and North Van Buren streets",male,N/A,"Teen 12-17",N/A
+"November 27, 2016",Delaware,"Dover (Leipsic)","Walnut Street",male,N/A,"Adult 18+",N/A
+"November 27, 2016",Delaware,"Dover (Leipsic)","Walnut Street",male,N/A,"Teen 12-17",N/A
+"November 27, 2016",Delaware,"Dover (Leipsic)","Walnut Street",male,N/A,"Teen 12-17",N/A
+"November 27, 2016",Delaware,"Dover (Leipsic)","Walnut Street",N/A,N/A,Unknown,N/A
+"November 25, 2016",Delaware,Wilmington,"Seventh and Washington",male,"Deiantsy Davis","Adult 18+",N/A
+"November 25, 2016",Delaware,Wilmington,"Seventh and Washington",male,"Dauwud Coles","Adult 18+",N/A
+"November 24, 2016",Delaware,Wilmington,"North Van Buren Street",male,N/A,"Adult 18+",N/A
+"November 23, 2016",Delaware,Newark,"100 block of South Patrice Drive",female,N/A,"Adult 18+",N/A
+"November 23, 2016",Delaware,Newark,"100 block of South Patrice Drive",male,N/A,"Adult 18+",N/A
+"November 23, 2016",Delaware,Newark,"100 block of South Patrice Drive",male,"Conor Wing","Adult 18+",N/A
+"November 23, 2016",Delaware,Dover,"30 South New Street",male,N/A,"Adult 18+",N/A
+"November 21, 2016",Delaware,Dover,"300 block of Martin St",male,"Dennell Harrison","Adult 18+",N/A
+"November 21, 2016",Delaware,Dover,"300 block of Martin St",male,"Taron Walker","Adult 18+",N/A
+"November 19, 2016",Delaware,Wilmington,"800 block of Morrow St.",male,"Dwan Bolden","Adult 18+",N/A
+"November 18, 2016",Delaware,Wilmington,"Cedar Ave and Maryland Avenue",male,N/A,"Adult 18+",N/A
+"November 18, 2016",Delaware,Wilmington,"Cedar Ave and Maryland Avenue",male,N/A,"Adult 18+",N/A
+"November 16, 2016",Delaware,Millsboro,"W Monroe St and Houston St",male,"Darrin T Gibbs","Adult 18+",N/A
+"November 16, 2016",Delaware,Millsboro,"W Monroe St and Houston St",male,"A.J. McMullen","Adult 18+",N/A
+"November 16, 2016",Delaware,Wilmington,"Linden and S. Van Buren",male,N/A,"Teen 12-17",N/A
+"November 16, 2016",Delaware,Wilmington,"Linden and S. Van Buren",N/A,N/A,Unknown,N/A
+"November 16, 2016",Delaware,Wilmington,"Linden and S. Van Buren",N/A,N/A,Unknown,N/A
+"November 14, 2016",Delaware,Wilmington,"8th and N. Madison streets",male,N/A,"Teen 12-17",N/A
+"November 14, 2016",Delaware,Wilmington,"8th and N. Madison streets",male,N/A,"Adult 18+",N/A
+"November 14, 2016",Delaware,Wilmington,"8th and N. Madison streets",male,N/A,"Adult 18+",N/A
+"November 11, 2016",Delaware,Dover,"1st block of S. New Street",male,N/A,"Adult 18+",N/A
+"November 9, 2016",Delaware,Bridgeville,"2000 block of Windy Lane",male,N/A,"Adult 18+",N/A
+"November 8, 2016",Delaware,Claymont,"200 block of Dewey Court",male,"Ismail Majid","Teen 12-17",N/A
+"November 8, 2016",Delaware,Dover,"South New and Reed streets",male,N/A,"Adult 18+",N/A
+"November 8, 2016",Delaware,Dover,"South New and Reed streets",male,"Maurice Wells","Adult 18+",N/A
+"November 7, 2016",Delaware,Wilmington,"2152 Melson Rd",male,"Shuron Lively","Adult 18+",N/A
+"November 7, 2016",Delaware,Wilmington,"2152 Melson Rd",male,"Antwyne Pugh","Adult 18+",N/A
+"November 6, 2016",Delaware,Bear,"US 40 and Brookmont Dr",male,"Daymien J. Roberts","Adult 18+",N/A
+"November 6, 2016",Delaware,Newark,"100 block of Flamingo Dr",female,N/A,"Adult 18+",N/A
+"November 5, 2016",Delaware,Seaford,"100 block of Woodland Mills",female,"Norquetta C. Heath","Adult 18+",N/A
+"November 5, 2016",Delaware,Seaford,"100 block of Woodland Mills",male,"Brandon A. Ways","Adult 18+",N/A
+"November 5, 2016",Delaware,Seaford,"100 block of Woodland Mills",male,"Torontay T. Mann","Adult 18+",N/A
+"November 5, 2016",Delaware,Seaford,"100 block of Woodland Mills",female,"Vanity N. Corea","Adult 18+",N/A
+"November 5, 2016",Delaware,Seaford,"100 block of Woodland Mills",female,"Angeline M. Metelus","Adult 18+",N/A
+"November 3, 2016",Delaware,Dover,"Kenton Road and College Road",male,"Kevin O Smith","Adult 18+",N/A
+"November 3, 2016",Delaware,Dover,"Cooper Road",male,"Efrain R Sudler","Adult 18+",N/A
+"November 3, 2016",Delaware,Wilmington,"409 W 25th St",male,N/A,"Adult 18+",N/A
+"November 3, 2016",Delaware,Wilmington,"409 W 25th St",male,N/A,"Adult 18+",N/A
+"November 3, 2016",Delaware,Wilmington,"409 W 25th St",male,N/A,"Adult 18+",N/A
+"November 3, 2016",Delaware,Wilmington,"409 W 25th St",male,"Thomas Brooks","Adult 18+",N/A
+"November 3, 2016",Delaware,Wilmington,"600 block of N. Madison St",male,"Theodore Smallwood","Adult 18+",N/A
+"November 2, 2016",Delaware,Wilmington,"1000 block of N. Church Street",male,"Nathan Henshaw","Adult 18+",N/A
+"November 2, 2016",Delaware,Wilmington,"1000 block of N. Church Street",female,"Audriana Healey","Adult 18+",N/A
+"November 2, 2016",Delaware,Wilmington,"1200 block of Lancaster Ave",male,N/A,"Adult 18+",N/A
+"November 2, 2016",Delaware,Wilmington,"1300 block of Chestnut St",male,N/A,"Adult 18+",N/A
+"November 2, 2016",Delaware,Wilmington,"1300 block of Chestnut St",male,N/A,"Adult 18+",N/A
+"November 1, 2016",Delaware,Wilmington,"200 block of E. 24th St.",male,"Cyrel Cannon","Adult 18+",N/A
+"October 31, 2016",Delaware,"New Castle","Revelle Street and Baylis Street",male,N/A,"Adult 18+",N/A
+"October 26, 2016",Delaware,Wilmington,"500 block of W. 25th St",male,N/A,"Adult 18+",N/A
+"October 26, 2016",Delaware,Wilmington,"500 block of W. 25th St",male,N/A,"Adult 18+",N/A
+"October 25, 2016",Delaware,Dover,"400 block of New Castle Ave",male,"Jamera Fisher","Adult 18+",N/A
+"October 25, 2016",Delaware,Middletown,"500 block of New Street",male,N/A,"Adult 18+",N/A
+"October 25, 2016",Delaware,Middletown,"500 block of New Street",male,"Dominique Ringgold","Adult 18+",N/A
+"October 24, 2016",Delaware,Dover,"500 block of River Road",male,"John T. William","Adult 18+",N/A
+"October 24, 2016",Delaware,Newark,"100 Christiana Mall Road",male,N/A,"Adult 18+",N/A
+"October 24, 2016",Delaware,Newark,"100 Christiana Mall Road",male,N/A,"Adult 18+",N/A
+"October 23, 2016",Delaware,"Wilmington (Newport)","500 block of Jackson Ave",male,N/A,"Adult 18+",N/A
+"October 20, 2016",Delaware,Wilmington,"Fourth and North Madison streets",female,N/A,"Adult 18+",N/A
+"October 20, 2016",Delaware,Wilmington,"Fourth and North Madison streets",male,"George Flores","Adult 18+",N/A
+"October 20, 2016",Delaware,"New Castle","50 block of Highland Blvd",male,N/A,"Adult 18+",N/A
+"October 20, 2016",Delaware,Wilmington,"1600 block of West 3rd Street",male,N/A,"Teen 12-17",N/A
+"October 20, 2016",Delaware,Milton,"West Springside Drive",male,N/A,"Adult 18+",N/A
+"October 19, 2016",Delaware,Wilmington,"2600 block of N. West St",female,N/A,"Adult 18+",N/A
+"October 18, 2016",Delaware,Wilmington,"499 Bethune Dr",male,N/A,"Adult 18+",N/A
+"October 18, 2016",Delaware,Wilmington,"499 Bethune Dr",N/A,N/A,Unknown,N/A
+"October 17, 2016",Delaware,Wilmington,"1000 block of Clayton Road",male,N/A,"Adult 18+",N/A
+"October 17, 2016",Delaware,Wilmington,"1000 block of Clayton Road",male,N/A,"Adult 18+",N/A
+"October 17, 2016",Delaware,Wilmington,"1000 block of Clayton Road",male,N/A,"Adult 18+",N/A
+"October 16, 2016",Delaware,Dover,"1400 block of Forrest Ave",male,N/A,"Adult 18+",N/A
+"October 16, 2016",Delaware,Wilmington,"1500 block of W. Fourth St",male,"Jewann Hopsin-El","Adult 18+",N/A
+"October 15, 2016",Delaware,"Rehoboth Beach","Wolfe Neck Road",male,N/A,"Adult 18+",N/A
+"October 14, 2016",Delaware,Wilmington,"W. Third St. and N. Clayton St.",male,N/A,"Adult 18+",N/A
+"October 11, 2016",Delaware,Wilmington,"3100 block of N. Harrison St.",male,N/A,"Adult 18+",N/A
+"October 10, 2016",Delaware,Wilmington,"W 9th St and N West St",male,N/A,"Adult 18+",N/A
+"October 10, 2016",Delaware,Wilmington,"W 9th St and N West St",male,N/A,"Adult 18+",N/A
+"October 10, 2016",Delaware,Dover,"100 block of W. Loockerman St",male,"Pierre Downs","Adult 18+",N/A
+"October 10, 2016",Delaware,Dover,"100 block of W. Loockerman St",N/A,N/A,Unknown,N/A
+"October 9, 2016",Delaware,Wilmington,"W 22nd St",male,N/A,"Adult 18+",N/A
+"October 9, 2016",Delaware,Wilmington,"W 22nd St",male,N/A,"Adult 18+",N/A
+"October 9, 2016",Delaware,Wilmington,"W 22nd St",male,N/A,"Adult 18+",N/A
+"October 8, 2016",Delaware,Felton,"Walnut Shade Rd and S DuPont Hwy",male,"Anthony J. Cadiz","Adult 18+",N/A
+"October 8, 2016",Delaware,"Wilmington (Stanton)","500 block of Sixth Ave",female,N/A,"Adult 18+",N/A
+"October 8, 2016",Delaware,"Wilmington (Stanton)","500 block of Sixth Ave",male,"Brian Kenney","Adult 18+",N/A
+"October 4, 2016",Delaware,Harbeson,"25000 block of Hollis Road",male,"David Ortlip","Adult 18+",N/A
+"October 4, 2016",Delaware,Harbeson,"25000 block of Hollis Road",male,"Marcos W. Ortlip","Adult 18+",N/A
+"October 4, 2016",Delaware,Harbeson,"25000 block of Hollis Road",male,"Guadalupe Marquez","Adult 18+",N/A
+"October 4, 2016",Delaware,Harbeson,"25000 block of Hollis Road",male,"Antonio Walters","Adult 18+",N/A
+"October 4, 2016",Delaware,Harbeson,"25000 block of Hollis Road",male,"Jaime A. Ramon","Adult 18+",N/A
+"October 3, 2016",Delaware,Newark,"20 block of Gogh Cir",male,N/A,"Adult 18+",N/A
+"October 3, 2016",Delaware,Newark,"20 block of Gogh Cir",N/A,N/A,Unknown,N/A
+"October 3, 2016",Delaware,Newark,"20 block of Gogh Cir",N/A,N/A,Unknown,N/A
+"October 3, 2016",Delaware,Wilmington,"700 block of E. 10th St",male,N/A,"Adult 18+",N/A
+"October 3, 2016",Delaware,Newark,"Gogh Circle and Ruebens Circle",male,N/A,"Adult 18+",N/A
+"October 3, 2016",Delaware,Newark,"Gogh Circle and Ruebens Circle",N/A,N/A,Unknown,N/A
+"October 3, 2016",Delaware,Newark,"Gogh Circle and Ruebens Circle",N/A,N/A,Unknown,N/A
+"October 2, 2016",Delaware,Wilmington,"1200 block of Elm Street",male,N/A,"Teen 12-17",N/A
+"October 2, 2016",Delaware,"New Castle","100 block of Jillian's Way",male,N/A,"Adult 18+",N/A
+"September 30, 2016",Delaware,Newark,"300 block of Auckland Drive",male,N/A,"Adult 18+",N/A
+"September 27, 2016",Delaware,Dover,"Leipsic Road",male,"Jamel Littlepage","Adult 18+",N/A
+"September 27, 2016",Delaware,Dover,"Leipsic Road",male,"Corey Harris","Adult 18+",N/A
+"September 27, 2016",Delaware,Dover,"Leipsic Road",male,"Hakeem Gibson","Adult 18+",N/A
+"September 24, 2016",Delaware,Bear,"U.S. 40",male,"Walike Parham","Teen 12-17",N/A
+"September 20, 2016",Delaware,Wilmington,"1500 block of West 3rd Street",female,N/A,Unknown,N/A
+"September 20, 2016",Delaware,Wilmington,"200 block of East 14th Street",male,N/A,"Adult 18+",N/A
+"September 18, 2016",Delaware,Wilmington,"200 block of W 20th St",male,"Abdullah Brown","Teen 12-17",N/A
+"September 18, 2016",Delaware,Wilmington,"200 block of W 20th St",male,"Deonta Carney","Teen 12-17",N/A
+"September 18, 2016",Delaware,Wilmington,"200 block of W 20th St",female,"Kenshall ""Keke"" Anderson","Adult 18+",N/A
+"September 18, 2016",Delaware,Wilmington,"200 block of W 20th St",male,N/A,"Adult 18+",N/A
+"September 16, 2016",Delaware,Wilmington,"2700 block of West St.",male,N/A,"Adult 18+",N/A
+"September 16, 2016",Delaware,Wilmington,"2700 block of West St.",male,N/A,"Adult 18+",N/A
+"September 16, 2016",Delaware,Wilmington,"900 block of N Pine St",male,"Deshawn Chase","Adult 18+",N/A
+"September 15, 2016",Delaware,Dover,"1700 N Dupont Hwy",male,"Antwan Freeman","Adult 18+",N/A
+"September 15, 2016",Delaware,Dover,"1700 N Dupont Hwy",female,"Keisha Nkop","Adult 18+",N/A
+"September 14, 2016",Delaware,Wilmington,"2600 block of North Market Street",male,N/A,"Teen 12-17",N/A
+"September 14, 2016",Delaware,Millsboro,"20000 block of Miller Drive",male,N/A,"Adult 18+",N/A
+"September 11, 2016",Delaware,"New Castle","500 block of S. DuPont Highway",male,N/A,"Adult 18+",N/A
+"September 10, 2016",Delaware,"New Castle","DE-273 and Airport Rd",male,N/A,"Teen 12-17",N/A
+"September 8, 2016",Delaware,"New Castle","50 block of Morris Rd",male,N/A,"Adult 18+",N/A
+"September 5, 2016",Delaware,"New Castle","300 block of Wildel Ave",male,N/A,"Adult 18+",N/A
+"September 5, 2016",Delaware,"New Castle","300 block of Wildel Ave",male,"Joseph Hughes","Adult 18+",N/A
+"September 5, 2016",Delaware,"New Castle","300 block of Wildel Ave",male,N/A,"Teen 12-17",N/A
+"September 3, 2016",Delaware,Wilmington,"200 block of N. Franklin St.",male,N/A,"Teen 12-17",N/A
+"September 3, 2016",Delaware,Wilmington,"50 block of W 27th St",male,N/A,"Adult 18+",N/A
+"September 3, 2016",Delaware,Wilmington,"50 block of W 27th St",male,N/A,"Adult 18+",N/A
+"September 3, 2016",Delaware,"New Castle",N/A,female,N/A,"Adult 18+",N/A
+"September 1, 2016",Delaware,Wilmington,"300 block of W. 24th Street",male,N/A,"Teen 12-17",N/A
+"September 1, 2016",Delaware,Wilmington,"West 27th Street",female,N/A,"Adult 18+",N/A
+"September 1, 2016",Delaware,Wilmington,"West 27th Street",female,N/A,"Adult 18+",N/A
+"September 1, 2016",Delaware,Wilmington,"West 27th Street",female,N/A,"Adult 18+",N/A
+"August 30, 2016",Delaware,Wilmington,"10th and Spruce streets",male,N/A,"Adult 18+",N/A
+"August 29, 2016",Delaware,Wilmington,"500 block of W Sixth St",male,N/A,"Adult 18+",N/A
+"August 26, 2016",Delaware,Wilmington,"Lea Blvd and N Market St",male,N/A,"Adult 18+",N/A
+"August 25, 2016",Delaware,Wilmington,"700  S. Vanburen Street",male,N/A,"Adult 18+",N/A
+"August 23, 2016",Delaware,Wilmington,"27th and N. Tatnall streets",female,N/A,"Adult 18+",N/A
+"August 22, 2016",Delaware,Wilmington,"500 block of W. 31st St",male,N/A,"Adult 18+",N/A
+"August 21, 2016",Delaware,Wilmington,"1200 block of Elm St.",male,N/A,"Adult 18+",N/A
+"August 18, 2016",Delaware,Dover,"100 block of South Queen Street",male,"Emmitt Brown","Adult 18+",N/A
+"August 18, 2016",Delaware,Dover,"100 block of South Queen Street",male,"Quashan Christy",Unknown,N/A
+"August 17, 2016",Delaware,Wilmington,"31st and North West streets",male,N/A,"Adult 18+",N/A
+"August 16, 2016",Delaware,Dover,"River Road and New Castle Avenue",male,"Alvin Williams","Adult 18+",N/A
+"August 15, 2016",Delaware,Wilmington,"3800 block of N. Market St.",male,N/A,"Adult 18+",N/A
+"August 15, 2016",Delaware,Wilmington,"3800 block of N. Market St.",male,N/A,"Adult 18+",N/A
+"August 15, 2016",Delaware,Wilmington,"3800 block of N. Market St.",male,N/A,"Adult 18+",N/A
+"August 15, 2016",Delaware,Wilmington,"600 block of W. Sixth St.",female,N/A,"Adult 18+",N/A
+"August 15, 2016",Delaware,Wilmington,"600 block of W. Sixth St.",male,N/A,"Adult 18+",N/A
+"August 15, 2016",Delaware,"New Castle","700 block of Center St",male,"Jesse Moreno","Adult 18+",N/A
+"August 14, 2016",Delaware,Wilmington,"500 block of W. 38th Street",male,N/A,"Adult 18+",N/A
+"August 13, 2016",Delaware,Dover,"200 block of Bradley Road",male,N/A,"Adult 18+",N/A
+"August 13, 2016",Delaware,Dover,"200 block of Bradley Road",male,N/A,"Adult 18+",N/A
+"August 13, 2016",Delaware,Dover,"200 block of Bradley Road",male,N/A,"Adult 18+",N/A
+"August 13, 2016",Delaware,Dover,"200 block of Bradley Road",male,N/A,"Adult 18+",N/A
+"August 13, 2016",Delaware,Wilmington,"1600 block of West Third Street",male,N/A,"Adult 18+",N/A
+"August 13, 2016",Delaware,"New Castle","44 Birkshire Rd",male,N/A,"Adult 18+",N/A
+"August 13, 2016",Delaware,Lincoln,"10000 block of Crescent Shores Drive",male,N/A,"Adult 18+",N/A
+"August 13, 2016",Delaware,Lincoln,"10000 block of Crescent Shores Drive",male,"James Satcher","Adult 18+",N/A
+"August 10, 2016",Delaware,"Wilmington (Elsmere)","131 Scarborough Park",male,N/A,"Adult 18+",N/A
+"August 6, 2016",Delaware,Dover,"100 block of Holmes Street",male,N/A,"Adult 18+",N/A
+"August 6, 2016",Delaware,Wilmington,"Burnside Blvd and Newport Gap Pk",male,N/A,"Adult 18+",N/A
+"August 4, 2016",Delaware,Wilmington,"300 block of  E. 23rd St.",male,"Jamal Jackson","Adult 18+",N/A
+"August 3, 2016",Delaware,Dover,"100 block of Madison Court",male,"Donovan Maldonado","Adult 18+",N/A
+"August 2, 2016",Delaware,Wilmington,"9th and Spruce streets",male,N/A,"Adult 18+",N/A
+"July 31, 2016",Delaware,Wilmington,"2600 block of N. Market Street",male,N/A,"Teen 12-17",N/A
+"July 31, 2016",Delaware,Wilmington,"400 block of Concord Ave",male,N/A,"Adult 18+",N/A
+"July 29, 2016",Delaware,Dover,"Stevenson Drive",male,"Chad Henderson","Adult 18+",N/A
+"July 27, 2016",Delaware,Wilmington,"100 block of E. 27th St",female,N/A,"Adult 18+",N/A
+"July 24, 2016",Delaware,Dover,"51 Webbs Lane",male,"Aaron T. Purnell","Adult 18+",N/A
+"July 23, 2016",Delaware,Wilmington,"1300 West 5th Street",female,N/A,"Adult 18+",N/A
+"July 23, 2016",Delaware,Wilmington,"3500 block of N. Church St.",male,N/A,"Teen 12-17",N/A
+"July 23, 2016",Delaware,Wilmington,"3500 block of N. Church St.",male,"Anfernee Evans","Adult 18+",N/A
+"July 23, 2016",Delaware,Wilmington,"3500 block of N. Church St.",male,"Gerald Wiggins","Adult 18+",N/A
+"July 23, 2016",Delaware,Wilmington,"3500 block of N. Church St.",male,"Maurice Hunter","Adult 18+",N/A
+"July 23, 2016",Delaware,Wilmington,"3500 block of N. Church St.",male,"Quan Tabron","Adult 18+",N/A
+"July 23, 2016",Delaware,Wilmington,"3500 block of N. Church St.",male,N/A,"Teen 12-17",N/A
+"July 18, 2016",Delaware,"New Castle","260 Christiana Road",female,"Ebony C. Smith","Adult 18+",N/A
+"July 18, 2016",Delaware,"New Castle","260 Christiana Road",male,"Braheem Queen","Adult 18+",N/A
+"July 18, 2016",Delaware,Wilmington,"Third Street",male,"Jermaine Smith","Adult 18+",N/A
+"July 18, 2016",Delaware,Milford,"Big Stone Beach Road",male,"Mightys E Gibbs","Adult 18+",N/A
+"July 18, 2016",Delaware,Milford,"Big Stone Beach Road",male,"Tavon G Johnson","Adult 18+",N/A
+"July 18, 2016",Delaware,Milford,"Big Stone Beach Road",male,"Jaydenn  D Clough","Adult 18+",N/A
+"July 18, 2016",Delaware,Milford,"Big Stone Beach Road",male,"Quadir Bryant","Adult 18+",N/A
+"July 18, 2016",Delaware,Milford,"Big Stone Beach Road",male,"Robert Mannings III","Adult 18+",N/A
+"July 18, 2016",Delaware,Wilmington,"700 block of E 11th St",male,"Dai’yann Wharton","Adult 18+",N/A
+"July 18, 2016",Delaware,Wilmington,"700 block of E 11th St",male,"Isaiah Baird","Adult 18+",N/A
+"July 18, 2016",Delaware,Wilmington,"700 block of E 11th St",male,"Tyreek Scott","Teen 12-17",N/A
+"July 18, 2016",Delaware,Wilmington,"700 block of E 11th St",male,"Elijah Crawford","Teen 12-17",N/A
+"July 15, 2016",Delaware,Harrington,"Milford Harrington Highway",male,"Jermaine Daniels","Adult 18+",N/A
+"July 13, 2016",Delaware,Newark,"1300 block of Greentree Rd",male,N/A,"Adult 18+",N/A
+"July 13, 2016",Delaware,Newark,"1300 block of Greentree Rd",male,N/A,"Adult 18+",N/A
+"July 12, 2016",Delaware,Wilmington,"200 block of W. 23rd St.",male,N/A,"Teen 12-17",N/A
+"July 12, 2016",Delaware,Wilmington,"200 block of W. 23rd St.",male,N/A,"Adult 18+",N/A
+"July 9, 2016",Delaware,Wilmington,"West Fourth and North Jefferson Streets",male,N/A,"Adult 18+",N/A
+"July 9, 2016",Delaware,"New Castle","600 block of Country Path Dr",male,"Malcolm Evans","Adult 18+",N/A
+"July 9, 2016",Delaware,"New Castle","600 block of Country Path Dr",female,"Cheryl Jennings","Adult 18+",N/A
+"July 8, 2016",Delaware,Wilmington,"600 block of W. Sixth St",male,N/A,"Teen 12-17",N/A
+"July 8, 2016",Delaware,Wilmington,"600 block of W. Sixth St",female,N/A,"Adult 18+",N/A
+"July 8, 2016",Delaware,Wilmington,N/A,male,N/A,"Teen 12-17",N/A
+"July 8, 2016",Delaware,Wilmington,N/A,female,N/A,"Adult 18+",N/A
+"July 8, 2016",Delaware,Wilmington,N/A,N/A,N/A,Unknown,N/A
+"July 8, 2016",Delaware,Wilmington,N/A,male,N/A,"Teen 12-17",N/A
+"July 6, 2016",Delaware,Bear,"700 block of Red Clay Drive",male,N/A,"Adult 18+",N/A
+"July 5, 2016",Delaware,Dover,"200 block of Stardust Drive",male,N/A,"Adult 18+",N/A
+"July 5, 2016",Delaware,Newark,"Raven Turn",male,N/A,"Adult 18+",N/A
+"July 4, 2016",Delaware,Wilmington,"Sherman Street and Clifford Brown Walk",male,N/A,"Teen 12-17",N/A
+"July 3, 2016",Delaware,Wilmington,"East 10th and Spruce streets",male,N/A,"Adult 18+",N/A
+"July 2, 2016",Delaware,Wilmington,"300 block of North Lincoln Street",male,N/A,"Adult 18+",N/A
+"July 2, 2016",Delaware,Wilmington,"221 Chestnut Avenue",female,"Nicole Shaw","Adult 18+",N/A
+"July 2, 2016",Delaware,Wilmington,"221 Chestnut Avenue",male,"Walter Shaw","Adult 18+",N/A
+"July 1, 2016",Delaware,Smyrna,"Providence Drive",male,"Steffen Forrest","Adult 18+",N/A
+"June 28, 2016",Delaware,Wilmington,"800 block of N. Adams St.",male,N/A,"Adult 18+",N/A
+"June 27, 2016",Delaware,Newark,"400 block of N Barrett Ln",male,N/A,"Adult 18+",N/A
+"June 27, 2016",Delaware,Newark,"400 block of N Barrett Ln",male,N/A,"Adult 18+",N/A
+"June 27, 2016",Delaware,Wilmington,"1300 block of N. Walnut St",male,N/A,"Adult 18+",N/A
+"June 27, 2016",Delaware,Frederica,"S DE-1",male,"Raymond A. Hutson","Adult 18+",N/A
+"June 26, 2016",Delaware,Wilmington,"27th and Moore streets",male,N/A,"Teen 12-17",N/A
+"June 26, 2016",Delaware,Wilmington,"900 block of N Spruce St",male,"Allen Cannon","Adult 18+",N/A
+"June 26, 2016",Delaware,Wilmington,"900 block of N Spruce St",male,"Eric Ray","Adult 18+",N/A
+"June 26, 2016",Delaware,Wilmington,"900 block of N Spruce St",male,"Brian Wilson","Adult 18+",N/A
+"June 24, 2016",Delaware,Newark,"2102 Ashkirk Drive",male,"Tyreek Larkins","Adult 18+",N/A
+"June 24, 2016",Delaware,Newark,"2102 Ashkirk Drive",male,N/A,Unknown,N/A
+"June 22, 2016",Delaware,Wilmington,"Northeast Boulevard and East 30th Street",male,N/A,"Adult 18+",N/A
+"June 18, 2016",Delaware,Wilmington,"900 block of North Pine Street",male,"Donald Tucker","Adult 18+",N/A
+"June 14, 2016",Delaware,Wilmington,"South Van Buren and Elm streets",female,N/A,"Teen 12-17",N/A
+"June 14, 2016",Delaware,Wilmington,"South Van Buren and Elm streets",male,N/A,"Teen 12-17",N/A
+"June 14, 2016",Delaware,Wilmington,"South Van Buren and Elm streets",male,N/A,"Teen 12-17",N/A
+"June 14, 2016",Delaware,Wilmington,"South Van Buren and Elm streets",male,N/A,"Teen 12-17",N/A
+"June 14, 2016",Delaware,Wilmington,"South Van Buren and Elm streets",N/A,N/A,Unknown,N/A
+"June 14, 2016",Delaware,Felton,"50 block of Weatherstone Ln",female,N/A,"Teen 12-17",N/A
+"June 14, 2016",Delaware,Felton,"50 block of Weatherstone Ln",male,N/A,"Adult 18+",N/A
+"June 13, 2016",Delaware,Wilmington,"200 block of South Harrison",male,N/A,"Adult 18+",N/A
+"June 12, 2016",Delaware,Newark,"700 block of Vining's Way",male,N/A,"Adult 18+",N/A
+"June 12, 2016",Delaware,Newark,"700 block of Vining's Way",male,N/A,"Adult 18+",N/A
+"June 11, 2016",Delaware,Wilmington,"1200 block of East 22nd Street",male,N/A,"Adult 18+",N/A
+"June 10, 2016",Delaware,Wilmington,"1200 block of Oak Street",male,N/A,"Teen 12-17",N/A
+"June 10, 2016",Delaware,Seaford,"Coverdale Road",male,"Dominique Hall","Adult 18+",N/A
+"June 7, 2016",Delaware,Wilmington,"50 block of Jensen Dr",male,"Charles White","Adult 18+",N/A
+"June 7, 2016",Delaware,Wilmington,"50 block of Jensen Dr",N/A,N/A,Unknown,N/A
+"June 6, 2016",Delaware,Wilmington,"800 block of Kirkwood Street",male,N/A,"Adult 18+",N/A
+"June 5, 2016",Delaware,Wilmington,"Concord Avenue and North Washington Street",male,N/A,"Adult 18+",N/A
+"June 3, 2016",Delaware,Wilmington,"900 block of Martin Luther King Boulevard",male,N/A,"Teen 12-17",N/A
+"June 2, 2016",Delaware,Wilmington,"Maryland Avenue and Robinson Lane",male,N/A,"Adult 18+",N/A
+"June 2, 2016",Delaware,Wilmington,"700 block of S. Van Buren St",male,N/A,"Teen 12-17",N/A
+"June 1, 2016",Delaware,Dover,"1000 block of S. Bradford St",female,N/A,"Adult 18+",N/A
+"June 1, 2016",Delaware,Dover,"1000 block of S. Bradford St",male,"Jason Scott","Adult 18+",N/A
+"May 31, 2016",Delaware,Dover,"1300 block of S. Farmview Drive",male,"Joseph Wilson","Adult 18+",N/A
+"May 31, 2016",Delaware,Dover,"1300 block of S. Farmview Drive",female,"Monica Lewis","Adult 18+",N/A
+"May 28, 2016",Delaware,Wilmington,"2600 block of Bowers St",male,N/A,"Adult 18+",N/A
+"May 26, 2016",Delaware,Dover,"100 block of Cherry Street",male,"Kevin Wayman Jr","Adult 18+",N/A
+"May 25, 2016",Delaware,Claymont,"2705 Philadelphia Pike",male,N/A,Unknown,N/A
+"May 25, 2016",Delaware,Dover,"First block of Webbs Lane",male,N/A,"Adult 18+",N/A
+"May 25, 2016",Delaware,Claymont,"2705 Philadelphia Pike",male,N/A,"Adult 18+",N/A
+"May 25, 2016",Delaware,Claymont,"2705 Philadelphia Pike",male,N/A,"Adult 18+",N/A
+"May 24, 2016",Delaware,Wilmington,"200 block of S. Harrison Street",male,N/A,"Adult 18+",N/A
+"May 24, 2016",Delaware,Wilmington,"200 block of S. Harrison Street",male,N/A,"Adult 18+",N/A
+"May 24, 2016",Delaware,"New Castle","50 block of W Balbach Ave",male,N/A,"Adult 18+",N/A
+"May 21, 2016",Delaware,Seaford,"22000 block of Coverdale Road",male,"Jeremy A. Cannon","Adult 18+",N/A
+"May 19, 2016",Delaware,Wilmington,"900 block of Clifford Brown Walk",male,"Brandon Wingo","Teen 12-17",N/A
+"May 19, 2016",Delaware,Wilmington,"900 block of Clifford Brown Walk",male,"Zaahir Smith","Adult 18+",N/A
+"May 19, 2016",Delaware,Wilmington,"900 block of Clifford Brown Walk",male,"Diamonte Taylor","Adult 18+",N/A
+"May 19, 2016",Delaware,Wilmington,"900 block of Clifford Brown Walk",male,"Kevon Harris-Dickerson","Adult 18+",N/A
+"May 19, 2016",Delaware,Wilmington,"900 block of Clifford Brown Walk",female,"Latasha Pierce","Adult 18+",N/A
+"May 18, 2016",Delaware,Wilmington,"1600 block of Thatcher St",male,N/A,"Adult 18+",N/A
+"May 18, 2016",Delaware,Wilmington,"1600 block of Thatcher St",male,"Zaahir Smith","Adult 18+",N/A
+"May 18, 2016",Delaware,Wilmington,"1600 block of Thatcher St",male,"Diamonte Taylor","Adult 18+",N/A
+"May 17, 2016",Delaware,Dover,"South Kirkwood and Division streets",male,"Dexter Brown","Adult 18+",N/A
+"May 17, 2016",Delaware,Wilmington,"Beech and South Van Buren Streets",male,N/A,"Adult 18+",N/A
+"May 16, 2016",Delaware,Wilmington,"1000 block of N. Lombard St.",male,N/A,"Teen 12-17",N/A
+"May 16, 2016",Delaware,Middletown,"Marl Pit Road",male,"Kyair Benson","Adult 18+",N/A
+"May 15, 2016",Delaware,Wilmington,"600 block of W. Sixth St.",female,N/A,"Adult 18+",N/A
+"May 15, 2016",Delaware,Dover,"Fulton Street",female,N/A,"Adult 18+",N/A
+"May 15, 2016",Delaware,Dover,"Fulton Street",male,N/A,"Adult 18+",N/A
+"May 14, 2016",Delaware,Dover,"East Water Street and New Castle Avenue",male,N/A,"Teen 12-17",N/A
+"May 14, 2016",Delaware,Dover,"East Water Street and New Castle Avenue",male,N/A,"Teen 12-17",N/A
+"May 11, 2016",Delaware,Milford,"300 Aurora Place",male,N/A,"Adult 18+",N/A
+"May 9, 2016",Delaware,Wilmington,"N Market St and 23rd St",male,N/A,"Teen 12-17",N/A
+"May 8, 2016",Delaware,Wilmington,"100 block of South Franklin Street",female,N/A,"Adult 18+",N/A
+"May 8, 2016",Delaware,Wilmington,"100 block of South Franklin Street",male,"Nykere Jackson","Adult 18+",N/A
+"May 7, 2016",Delaware,Dover,"900 block of Janeka Lane",male,N/A,"Adult 18+",N/A
+"May 7, 2016",Delaware,Dover,"900 block of Janeka Lane",male,"Caleb Mason","Adult 18+",N/A
+"May 7, 2016",Delaware,Wilmington,"North Market and 27th streets",male,N/A,"Adult 18+",N/A
+"May 7, 2016",Delaware,Wilmington,"North Market and 27th streets",female,N/A,"Adult 18+",N/A
+"May 7, 2016",Delaware,Wilmington,"W 3rd St and N Rodney St",male,"Terrance Kinard","Adult 18+",N/A
+"May 3, 2016",Delaware,Wilmington,"600 block of N. Madison St",male,N/A,"Teen 12-17",N/A
+"May 2, 2016",Delaware,"Wilmington (Edgemoor)","Rysing Dr and N Cannon Dr",N/A,N/A,"Adult 18+",N/A
+"May 2, 2016",Delaware,"Wilmington (Edgemoor)","Rysing Dr and N Cannon Dr",N/A,N/A,"Adult 18+",N/A
+"April 30, 2016",Delaware,Dover,"North DuPont Highway and Lake View Drive",male,"Allen Durham","Adult 18+",N/A
+"April 29, 2016",Delaware,Dover,"200 block of Acorn Lane",male,"Taylor Heesh","Adult 18+",N/A
+"April 26, 2016",Delaware,"New Castle","100 block of Freedom Trail",female,"Lauren Steed","Adult 18+",N/A
+"April 26, 2016",Delaware,"New Castle","100 block of Freedom Trail",male,"Brian Goodwin","Adult 18+",N/A
+"April 26, 2016",Delaware,Dover,"Queen and Reed streets",male,N/A,"Teen 12-17",N/A
+"April 26, 2016",Delaware,Dover,"Queen and Reed streets",N/A,N/A,Unknown,N/A
+"April 25, 2016",Delaware,Wilmington,"400 block of Anderson Dr",male,"Tymere Bailey","Adult 18+",N/A
+"April 22, 2016",Delaware,Townsend,"500 block of Dogtown Rd",male,"Joshua James","Adult 18+",N/A
+"April 22, 2016",Delaware,Townsend,"500 block of Dogtown Rd",male,"Jamar L Waters","Adult 18+",N/A
+"April 22, 2016",Delaware,Townsend,"500 block of Dogtown Rd",male,"Sylvester E Gould Jr","Adult 18+",N/A
+"April 21, 2016",Delaware,Wilmington,"400 block of W 3rd St",N/A,N/A,"Teen 12-17",N/A
+"April 16, 2016",Delaware,Wilmington,"10th and Bennett streets",male,"Shamir Rice","Adult 18+",N/A
+"April 15, 2016",Delaware,Bear,"800 block of Seymour Road",female,N/A,"Adult 18+",N/A
+"April 14, 2016",Delaware,Magnolia,"100 block of Terry Dr",male,"William J. Preston","Adult 18+",N/A
+"April 14, 2016",Delaware,Magnolia,"100 block of Terry Dr",male,"Keith J. Maye","Adult 18+",N/A
+"April 14, 2016",Delaware,Magnolia,"100 block of Terry Dr",male,"David Preston","Adult 18+",N/A
+"April 8, 2016",Delaware,"New Castle","Simmonds Drive",male,"Lamonte Butler","Adult 18+",N/A
+"April 4, 2016",Delaware,Wilmington,"400 block of Maryland Ave.",male,N/A,"Adult 18+",N/A
+"April 1, 2016",Delaware,Wilmington,"800 block of N. Pine St.",male,"Stanley Taylor","Adult 18+",N/A
+"April 1, 2016",Delaware,Wilmington,"800 block of N. Pine St.",male,"Shurkri Brown","Adult 18+",N/A
+"April 1, 2016",Delaware,Wilmington,"3806 Governor Printz Blvd",male,"Nathaniel Mangrum","Adult 18+",N/A
+"April 1, 2016",Delaware,Wilmington,"3806 Governor Printz Blvd",male,"Keivese Tolbert","Adult 18+",N/A
+"April 1, 2016",Delaware,Wilmington,"3806 Governor Printz Blvd",male,"Tyerin Griffin","Adult 18+",N/A
+"March 30, 2016",Delaware,"New Castle","Centerville Road",male,N/A,"Teen 12-17",N/A
+"March 30, 2016",Delaware,"New Castle","3000 block of New Castle Avenue",male,N/A,"Adult 18+",N/A
+"March 30, 2016",Delaware,Wilmington,"1100 block of Elm St",male,"Jason C Hicks","Adult 18+",N/A
+"March 30, 2016",Delaware,Wilmington,"1100 block of Elm St",male,"Joseph Hunt","Adult 18+",N/A
+"March 30, 2016",Delaware,Wilmington,"1100 block of Elm St",male,"Durrion Morrison","Adult 18+",N/A
+"March 30, 2016",Delaware,Dover,"2300 block of Port Mahon Rd",male,"Daiquan T. Bordley","Adult 18+",N/A
+"March 30, 2016",Delaware,Dover,"2300 block of Port Mahon Rd",male,"Zhyhee Y. Harmon","Adult 18+",N/A
+"March 30, 2016",Delaware,Dover,"2300 block of Port Mahon Rd",female,"Chelsea Braunskill","Adult 18+",N/A
+"March 30, 2016",Delaware,Dover,"2300 block of Port Mahon Rd",male,"Dontray Hendricks","Adult 18+",N/A
+"March 28, 2016",Delaware,Dover,"Reese and Lincoln streets",male,"Giovanni Echevarria","Adult 18+",N/A
+"March 28, 2016",Delaware,Wilmington,"12th Street and Northeast Boulevard",male,N/A,"Adult 18+",N/A
+"March 27, 2016",Delaware,Wilmington,"28th and Market streets",N/A,N/A,"Adult 18+",N/A
+"March 27, 2016",Delaware,Wilmington,"2700 block of N. Pine Street",N/A,N/A,Unknown,N/A
+"March 27, 2016",Delaware,Harrington,"300 block of Flat Iron Rd",male,N/A,"Adult 18+",N/A
+"March 23, 2016",Delaware,Dover,"Cecil and New Streets",male,N/A,"Adult 18+",N/A
+"March 22, 2016",Delaware,Wilmington,"600 block of North Jefferson Street",female,N/A,"Adult 18+",N/A
+"March 22, 2016",Delaware,Wilmington,"400 block of Porter St.",male,N/A,"Adult 18+",N/A
+"March 22, 2016",Delaware,Dover,"North Kirkwood Street",male,N/A,"Teen 12-17",N/A
+"March 22, 2016",Delaware,Dover,"North Kirkwood Street",male,N/A,"Adult 18+",N/A
+"March 20, 2016",Delaware,Newark,"268 Cornell Dr",female,N/A,"Adult 18+",N/A
+"March 19, 2016",Delaware,Wilmington,"300 block of New Castle Ave",male,N/A,"Teen 12-17",N/A
+"March 17, 2016",Delaware,Wilmington,"200 block of Franklin St",male,N/A,"Teen 12-17",N/A
+"March 17, 2016",Delaware,Wilmington,"200 block of N Connell St",male,"Christian Serrano","Adult 18+",N/A
+"March 17, 2016",Delaware,Wilmington,"200 block of N Connell St",N/A,"Jose Moreta","Adult 18+",N/A
+"March 17, 2016",Delaware,Wilmington,"200 block of N Connell St",male,"Joshua Gonzales","Adult 18+",N/A
+"March 16, 2016",Delaware,Wilmington,"1100 block of Lorewood Grove Road",male,"William Cooke","Adult 18+",N/A
+"March 16, 2016",Delaware,Wilmington,"800 block of Morrow St.",male,N/A,"Adult 18+",N/A
+"March 16, 2016",Delaware,Wilmington,"800 block of Morrow St.",male,N/A,"Adult 18+",N/A
+"March 15, 2016",Delaware,Wilmington,"Ninth and Spruce streets",male,N/A,"Adult 18+",N/A
+"March 15, 2016",Delaware,Wilmington,"1100 block of Lancaster Avenue",male,N/A,"Adult 18+",N/A
+"March 14, 2016",Delaware,Wilmington,"11th and Clifford Brown Walk",male,N/A,"Adult 18+",N/A
+"March 12, 2016",Delaware,Wilmington,"400 block of W. Seventh Street",male,N/A,"Adult 18+",N/A
+"March 11, 2016",Delaware,Wilmington,"600 block of Taylor St",male,"Ryan Schneese","Adult 18+",N/A
+"March 11, 2016",Delaware,Wilmington,"600 block of Taylor St",male,"Sha'Mir Sudler","Adult 18+",N/A
+"March 10, 2016",Delaware,Dover,"100 block of Westover Drive",male,N/A,"Teen 12-17",N/A
+"March 10, 2016",Delaware,Dover,"100 block of Westover Drive",male,N/A,"Teen 12-17",N/A
+"March 10, 2016",Delaware,Wilmington,"900 block of Bennett St",male,N/A,"Adult 18+",N/A
+"March 10, 2016",Delaware,Dover,"S. New and Division streets",male,"Kenneth DeShields","Adult 18+",N/A
+"March 9, 2016",Delaware,"New Castle","100 block of Covington Place",male,N/A,"Adult 18+",N/A
+"March 8, 2016",Delaware,Wilmington,"50 block of Gordon St",male,N/A,"Adult 18+",N/A
+"March 8, 2016",Delaware,Wilmington,"Taylor and Bennett streets",male,N/A,"Adult 18+",N/A
+"March 7, 2016",Delaware,Wilmington,"Seventh and Franklin streets",male,N/A,"Adult 18+",N/A
+"March 4, 2016",Delaware,Wilmington,"1200 block of West 7th Street",male,"Leroy Collins","Adult 18+",N/A
+"March 3, 2016",Delaware,Wilmington,"500 block of W. 6th St.",male,N/A,"Adult 18+",N/A
+"March 3, 2016",Delaware,Dover,"257 N Dupont Hwy",male,"Jason Westley","Adult 18+",N/A
+"March 3, 2016",Delaware,Wilmington,"500 block of West 6th Street",male,N/A,"Adult 18+",N/A
+"March 2, 2016",Delaware,Wilmington,"2100 block of Pine Street",male,"Jack Lassiter","Adult 18+",N/A
+"March 1, 2016",Delaware,Wilmington,"2900 block of Jessup Street",male,N/A,"Adult 18+",N/A
+"February 28, 2016",Delaware,"New Castle","50 block of Oakmont Dr",female,N/A,"Adult 18+",N/A
+"February 27, 2016",Delaware,Wilmington,"2100 block of North Pine Street",male,N/A,"Adult 18+",N/A
+"February 27, 2016",Delaware,Newark,"4140 Ogletown-Stanton Road",female,N/A,"Adult 18+",N/A
+"February 27, 2016",Delaware,Newark,"4140 Ogletown-Stanton Road",male,N/A,"Adult 18+",N/A
+"February 27, 2016",Delaware,Newark,"16 Chatham Ln",male,"Clifton Thompson","Adult 18+",N/A
+"February 27, 2016",Delaware,Newark,"16 Chatham Ln",male,"Reginald Waters","Adult 18+",N/A
+"February 26, 2016",Delaware,Wilmington,"1000 block of North Pine Street",male,"Sameir Handy","Adult 18+",N/A
+"February 26, 2016",Delaware,Wilmington,"1000 block of North Pine Street",male,"Adam Jablonski","Adult 18+",N/A
+"February 26, 2016",Delaware,Wilmington,"Shearman Street",male,N/A,"Adult 18+",N/A
+"February 26, 2016",Delaware,Wilmington,"800 block of North Pine Street",male,N/A,"Teen 12-17",N/A
+"February 25, 2016",Delaware,Dover,"200 block of S. Governors Boulevard",male,"Jason E. Mills","Adult 18+",N/A
+"February 23, 2016",Delaware,Wilmington,"200 block of North Madison Street",male,"Ronald Jackson","Adult 18+",N/A
+"February 21, 2016",Delaware,Dover,"West Reed Street",male,N/A,"Adult 18+",N/A
+"February 21, 2016",Delaware,Dover,"West Reed Street",male,N/A,"Adult 18+",N/A
+"February 21, 2016",Delaware,Dover,"West Reed Street",male,N/A,"Adult 18+",N/A
+"February 20, 2016",Delaware,Dover,"316 Fulton Street",male,N/A,"Adult 18+",N/A
+"February 20, 2016",Delaware,Dover,"316 Fulton Street",male,"Mahyoub Ali","Adult 18+",N/A
+"February 20, 2016",Delaware,Wilmington,"Madison Street",male,N/A,"Adult 18+",N/A
+"February 19, 2016",Delaware,Wilmington,"1900 block of Maryland Avenue",male,N/A,"Adult 18+",N/A
+"February 19, 2016",Delaware,Wilmington,"1900 block of Maryland Avenue",male,N/A,"Adult 18+",N/A
+"February 18, 2016",Delaware,Wilmington,"1300 block of Clifford Brown Walk",male,N/A,"Adult 18+",N/A
+"February 16, 2016",Delaware,Newark,"750 East Delaware Avenue",male,N/A,"Teen 12-17",N/A
+"February 13, 2016",Delaware,Wilmington,"1700 block of West Second Street",male,N/A,"Adult 18+",N/A
+"February 12, 2016",Delaware,Wilmington,"300 block of Clyde Street",male,"Stanley Evans","Adult 18+",N/A
+"February 12, 2016",Delaware,Wilmington,"300 block of Clyde Street",male,N/A,"Adult 18+",N/A
+"February 10, 2016",Delaware,Wilmington,"200 block of W. 30th St.",male,"Antoine Harris","Adult 18+",N/A
+"February 9, 2016",Delaware,Wilmington,"1100 block of Linden Street",male,"Kenneth Truitt","Adult 18+",N/A
+"February 9, 2016",Delaware,Wilmington,"1100 block of Linden Street",male,N/A,"Teen 12-17",N/A
+"February 9, 2016",Delaware,Wilmington,"200 block of West 29th Street",male,"Tymere Brown","Adult 18+",N/A
+"February 8, 2016",Delaware,Wilmington,"1100 block of W. Second St.",female,N/A,"Teen 12-17",N/A
+"February 8, 2016",Delaware,"New Castle","128 N Dupont Hwy",male,"Eric Pearson","Adult 18+",N/A
+"February 7, 2016",Delaware,Bridgeville,"Apple Tree Road",female,N/A,"Adult 18+",N/A
+"February 7, 2016",Delaware,Bridgeville,"Apple Tree Road",male,N/A,"Adult 18+",N/A
+"February 7, 2016",Delaware,Bridgeville,"Apple Tree Road",female,N/A,"Child 0-11",N/A
+"February 5, 2016",Delaware,Wilmington,"Hay Road",male,"Keith Covington","Adult 18+",N/A
+"February 5, 2016",Delaware,Wilmington,"Hay Road",male,"Andre Harding","Adult 18+",N/A
+"February 5, 2016",Delaware,Wilmington,"Hay Road",N/A,N/A,"Adult 18+",N/A
+"February 5, 2016",Delaware,Wilmington,"Hay Road",N/A,N/A,"Teen 12-17",N/A
+"February 3, 2016",Delaware,Dover,"Barrister Place",male,"Zhamir Cooper-Watson","Adult 18+",N/A
+"January 29, 2016",Delaware,Dover,"800 block of Lincoln Street",female,"Nechole Seymour","Adult 18+",N/A
+"January 29, 2016",Delaware,Dover,"800 block of Lincoln Street",male,"Robert Cole","Adult 18+",N/A
+"January 28, 2016",Delaware,Wilmington,"25th Street",male,"Timothy Czeiner","Adult 18+",N/A
+"January 28, 2016",Delaware,Wilmington,"2500 block of West Street",male,"Tarail McDuffie","Adult 18+",N/A
+"January 27, 2016",Delaware,"New Castle","Wilton Blvd",male,N/A,"Adult 18+",N/A
+"January 26, 2016",Delaware,Wilmington,"2200 block of Jessup Street",male,N/A,"Adult 18+",N/A
+"January 26, 2016",Delaware,Wilmington,"2200 block of Jessup Street",male,N/A,"Adult 18+",N/A
+"January 26, 2016",Delaware,Wilmington,"2200 block of Jessup Street",male,N/A,"Adult 18+",N/A
+"January 25, 2016",Delaware,Wilmington,"West 36th Street",male,"Malik Willingham","Adult 18+",N/A
+"January 21, 2016",Delaware,Dover,"Greenhill Avenue and White Oak Road",male,N/A,"Teen 12-17",N/A
+"January 21, 2016",Delaware,Dover,"Greenhill Avenue and White Oak Road",male,N/A,"Teen 12-17",N/A
+"January 21, 2016",Delaware,Dover,"Greenhill Avenue and White Oak Road",female,"Gabriella Rivera","Adult 18+",N/A
+"January 20, 2016",Delaware,Wilmington,"27th Street and Bowers Street",male,N/A,"Teen 12-17",N/A
+"January 13, 2016",Delaware,Wilmington,"1200 block of N. Locust St",male,"Therman Redden","Adult 18+",N/A
+"January 12, 2016",Delaware,Dover,"211 Delaware Avenue",male,"Aaron Carillo","Teen 12-17",N/A
+"January 12, 2016",Delaware,Dover,"211 Delaware Avenue",male,"Nasir Bush","Teen 12-17",N/A
+"January 11, 2016",Delaware,Wilmington,"900 block of Brown Street",male,"Ira Brown","Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"900 block of Brown Street",female,N/A,"Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"900 block of Brown Street",male,N/A,"Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"900 block of Brown Street",male,N/A,"Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"900 block of Brown Street",male,N/A,"Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"1800 block of West Second Street",male,N/A,"Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"1800 block of West Second Street",male,N/A,"Adult 18+",N/A
+"January 11, 2016",Delaware,Wilmington,"1800 block of West Second Street",male,N/A,"Adult 18+",N/A
+"January 8, 2016",Delaware,Dover,"2600 block of South State Street",male,N/A,"Adult 18+",N/A
+"January 8, 2016",Delaware,Dover,"2600 block of South State Street",male,N/A,"Adult 18+",N/A
+"January 7, 2016",Delaware,Bridgeville,"2000 block of Conrail Street",male,"James F. Dickerson","Adult 18+",N/A
+"January 7, 2016",Delaware,Dover,"Churchmans Road",male,"Lateef Dickerson","Adult 18+",N/A
+"January 7, 2016",Delaware,Dover,"Churchmans Road",male,"Taron Hampton","Adult 18+",N/A
+"January 7, 2016",Delaware,Dover,"Churchmans Road",male,"Von Smith","Adult 18+",N/A
+"January 3, 2016",Delaware,Wilmington,"600 block of West Fifth St.",male,N/A,"Adult 18+",N/A
+"January 3, 2016",Delaware,Newark,"50 block of Mercer Dr",male,N/A,"Adult 18+",N/A
+"January 3, 2016",Delaware,Newark,"50 block of Mercer Dr",N/A,N/A,"Adult 18+",N/A
+"January 3, 2016",Delaware,Newark,"50 block of Mercer Dr",N/A,N/A,"Adult 18+",N/A
+"December 30, 2015",Delaware,Middletown,"300 block of Jefferson Street",male,N/A,"Adult 18+",N/A
+"December 30, 2015",Delaware,Middletown,"300 block of Jefferson Street",male,N/A,"Adult 18+",N/A
+"December 30, 2015",Delaware,Middletown,"300 block of Jefferson Street",male,N/A,"Adult 18+",N/A
+"December 30, 2015",Delaware,Newark,"4126 Ogletown Stanton Road",male,N/A,"Adult 18+",N/A
+"December 30, 2015",Delaware,Newark,"4126 Ogletown Stanton Road",male,N/A,"Adult 18+",N/A
+"December 28, 2015",Delaware,Wilmington,"Concord Avenue and Jefferson Street",male,N/A,"Adult 18+",N/A
+"December 27, 2015",Delaware,Wilmington,"North Broom Street and West Third Street",male,N/A,"Teen 12-17",N/A
+"December 27, 2015",Delaware,Wilmington,"North Broom Street and West Third Street",male,N/A,"Adult 18+",N/A
+"December 27, 2015",Delaware,Dover,"801 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"December 27, 2015",Delaware,Dover,"801 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"December 27, 2015",Delaware,Newark,"Kirkwood Highway and Wollaston Avenue",male,"Khaliq D. Scott","Adult 18+",N/A
+"December 27, 2015",Delaware,Wilmington,"East 23rd and Lamotte Streets",male,"Andre Winn","Adult 18+",N/A
+"December 27, 2015",Delaware,Wilmington,"East 23rd and Lamotte Streets",male,N/A,"Adult 18+",N/A
+"December 26, 2015",Delaware,Lincoln,"21000 block of West Mayhew Drive",male,N/A,"Adult 18+",N/A
+"December 23, 2015",Delaware,Wilmington,"Gov. Printz Boulevard",male,"Shayne Litteral","Adult 18+",N/A
+"December 23, 2015",Delaware,Wilmington,"1100 block of Beech Street",male,N/A,"Adult 18+",N/A
+"December 21, 2015",Delaware,Claymont,"749 Montclair Drive",female,N/A,"Adult 18+",N/A
+"December 21, 2015",Delaware,Claymont,"749 Montclair Drive",male,"Scott Sullivan","Adult 18+",N/A
+"December 21, 2015",Delaware,Wilmington,"East 23rd Street",male,"Antoine Perkins","Adult 18+",N/A
+"December 21, 2015",Delaware,Dover,"1502 E Lebanon Rd",male,"Malik Nasir","Adult 18+",N/A
+"December 20, 2015",Delaware,Wilmington,"Locust and East 23rd Streets",male,N/A,"Adult 18+",N/A
+"December 20, 2015",Delaware,Wilmington,"Locust and East 23rd Streets",male,N/A,"Teen 12-17",N/A
+"December 20, 2015",Delaware,"Millsboro (Long Neck)","34000 block of Starboard Court",female,N/A,"Adult 18+",N/A
+"December 20, 2015",Delaware,"Millsboro (Long Neck)","34000 block of Starboard Court",male,"Cecil T. Hicks","Adult 18+",N/A
+"December 20, 2015",Delaware,Wilmington,"1000 block of West Fourth Street",male,N/A,"Adult 18+",N/A
+"December 20, 2015",Delaware,Wilmington,"1000 block of West Fourth Street",male,"Michael Newton","Adult 18+",N/A
+"December 18, 2015",Delaware,Bear,"100 block of Hawk Drive",male,N/A,"Adult 18+",N/A
+"December 17, 2015",Delaware,Laurel,"Sussex Highway",male,N/A,"Adult 18+",N/A
+"December 17, 2015",Delaware,Wilmington,"2300 block of N Monroe St",male,N/A,"Adult 18+",N/A
+"December 17, 2015",Delaware,Newark,"300 block of Salem Church Road",male,"Brian Richardson","Adult 18+",N/A
+"December 17, 2015",Delaware,Newark,"300 block of Salem Church Road",male,"James McCardell","Adult 18+",N/A
+"December 15, 2015",Delaware,Dover,"South Little Creek Road",male,N/A,"Adult 18+",N/A
+"December 15, 2015",Delaware,Dover,"South Little Creek Road",male,"Malik Washington","Adult 18+",N/A
+"December 15, 2015",Delaware,Dover,"South Little Creek Road",male,N/A,"Adult 18+",N/A
+"December 15, 2015",Delaware,"New Castle","100 block of Freedom Trail",male,N/A,"Adult 18+",N/A
+"December 15, 2015",Delaware,"New Castle","100 block of Freedom Trail",male,N/A,"Adult 18+",N/A
+"December 13, 2015",Delaware,Dover,"779 North DuPont Highway",male,N/A,"Adult 18+",N/A
+"December 11, 2015",Delaware,Wilmington,"1300 block of Read St.",male,N/A,"Teen 12-17",N/A
+"December 10, 2015",Delaware,Dover,"Village Drive",male,N/A,"Teen 12-17",N/A
+"December 10, 2015",Delaware,Dover,"Village Drive",male,"Deontray Watson","Teen 12-17",N/A
+"December 9, 2015",Delaware,Wilmington,"West Fourth Street",male,"Marquies Brown","Adult 18+",N/A
+"December 9, 2015",Delaware,Wilmington,"2200 block of North Market Street",male,N/A,"Adult 18+",N/A
+"December 8, 2015",Delaware,Georgetown,"Park Avenue",male,"Christopher Altoe","Adult 18+",N/A
+"December 5, 2015",Delaware,Wilmington,"2500 block of Bowers Street",male,N/A,"Teen 12-17",N/A
+"December 3, 2015",Delaware,Wilmington,"2702 Jacqueline Dr",male,"Jamai White","Adult 18+",N/A
+"December 3, 2015",Delaware,Dover,"Cecil and New",male,"Alex Durham","Adult 18+",N/A
+"December 1, 2015",Delaware,Wilmington,"700 block of E. 22nd St.",male,"Jabari Saunders","Adult 18+",N/A
+"November 29, 2015",Delaware,Frederica,"Johnny Cake Landing Road",N/A,N/A,"Adult 18+",N/A
+"November 29, 2015",Delaware,Frederica,"Johnny Cake Landing Road",N/A,N/A,"Adult 18+",N/A
+"November 28, 2015",Delaware,Wilmington,"2700 block of Northeast Boulevard",N/A,N/A,"Adult 18+",N/A
+"November 27, 2015",Delaware,Bear,"1921 Pulaski Hwy",male,"Aloysisus Taylor","Adult 18+",N/A
+"November 27, 2015",Delaware,Bear,"1921 Pulaski Hwy",male,"Bobby Taylor","Adult 18+",N/A
+"November 26, 2015",Delaware,"New Castle","3000 block of New Castle Ave",N/A,N/A,Unknown,N/A
+"November 26, 2015",Delaware,"New Castle","3000 block of New Castle Ave",N/A,N/A,Unknown,N/A
+"November 25, 2015",Delaware,Wilmington,"2500 block of Carter Street",male,N/A,Unknown,N/A
+"November 24, 2015",Delaware,Bear,"Brookmont Dr and Pulaski Hwy",male,N/A,"Adult 18+",N/A
+"November 23, 2015",Delaware,Dover,"200 block of South New Street",male,"Keith Stevens","Adult 18+",N/A
+"November 23, 2015",Delaware,Dover,"200 block of South New Street",female,"Cierra Brummell","Adult 18+",N/A
+"November 20, 2015",Delaware,Wilmington,"W 20th St and N West St",male,N/A,"Adult 18+",N/A
+"November 18, 2015",Delaware,Newark,"100 Mcintosh Plaza",male,"Thomas Mcilvain","Adult 18+",N/A
+"November 18, 2015",Delaware,Newark,"100 Mcintosh Plaza",male,"Frank Prentice","Adult 18+",N/A
+"November 18, 2015",Delaware,Newark,"100 Mcintosh Plaza",male,"Michael Carello","Adult 18+",N/A
+"November 17, 2015",Delaware,Dover,"Lincoln Street and Gibbs Drive",male,"Lawrence Bracy","Adult 18+",N/A
+"November 16, 2015",Delaware,Dover,"White Oak Road and Frear Drive",male,"Dahppy Brewah","Adult 18+",N/A
+"November 16, 2015",Delaware,Wilmington,"1031 S Market St",male,"William O. Brown","Adult 18+",N/A
+"November 16, 2015",Delaware,Wilmington,"1031 S Market St",male,"Lamott Matthews","Adult 18+",N/A
+"November 13, 2015",Delaware,Claymont,"Harvey Road and Garfield Avenue",male,"William F. McNulty","Adult 18+",N/A
+"November 13, 2015",Delaware,Harrington,"West Center Street",male,N/A,Unknown,N/A
+"November 13, 2015",Delaware,Harrington,"West Center Street",male,N/A,Unknown,N/A
+"November 10, 2015",Delaware,"Wilmington (Edgemoor)","Philadelphia Pk and Beeson Ave",female,N/A,"Adult 18+",N/A
+"November 10, 2015",Delaware,"Wilmington (Edgemoor)","Philadelphia Pk and Beeson Ave",male,"Norris Farlow","Adult 18+",N/A
+"November 10, 2015",Delaware,"Wilmington (Edgemoor)","Philadelphia Pk and Beeson Ave",male,"John Johnson","Adult 18+",N/A
+"November 3, 2015",Delaware,Wilmington,"900 block of Maryland Avenue",male,N/A,"Teen 12-17",N/A
+"November 2, 2015",Delaware,Wilmington,"3rd and North Harrison Street",female,N/A,"Teen 12-17",N/A
+"November 2, 2015",Delaware,Wilmington,"3rd and North Harrison Street",male,N/A,"Adult 18+",N/A
+"November 2, 2015",Delaware,Wilmington,"3rd and North Harrison Street",male,"Troy Gee","Adult 18+",N/A
+"November 2, 2015",Delaware,Wilmington,"3rd and North Harrison Street",male,"Elijah Warren","Adult 18+",N/A
+"November 2, 2015",Delaware,Dover,"Beechwood Avenue",male,N/A,"Adult 18+",N/A
+"November 2, 2015",Delaware,Wilmington,"South Heald and Lobdell street",male,N/A,"Adult 18+",N/A
+"November 2, 2015",Delaware,Wilmington,"Taylor and Kirkwood",male,N/A,"Adult 18+",N/A
+"November 1, 2015",Delaware,Wilmington,"10th and Bennett Streets",female,N/A,"Adult 18+",N/A
+"November 1, 2015",Delaware,Wilmington,"10th and Bennett Streets",male,N/A,"Adult 18+",N/A
+"October 31, 2015",Delaware,Dover,"1131 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"October 31, 2015",Delaware,Milford,"100 block of West St.",male,"Joseynazio ""Jose"" Colombo","Adult 18+",N/A
+"October 31, 2015",Delaware,Milford,"100 block of West St.",male,"Eric A. Harris","Adult 18+",N/A
+"October 29, 2015",Delaware,Wilmington,"1801 Milltown Road",male,N/A,"Adult 18+",N/A
+"October 29, 2015",Delaware,Wilmington,"1801 Milltown Road",N/A,N/A,"Teen 12-17",N/A
+"October 29, 2015",Delaware,Wilmington,"1801 Milltown Road",N/A,N/A,"Teen 12-17",N/A
+"October 28, 2015",Delaware,Felton,"Barney Jenkins Rd and S DuPont Hwy",male,N/A,"Adult 18+",N/A
+"October 27, 2015",Delaware,Wilmington,"1300 block of Lancaster Avenue",male,N/A,"Adult 18+",N/A
+"October 27, 2015",Delaware,Wilmington,"1300 block of Lancaster Avenue",male,N/A,"Adult 18+",N/A
+"October 27, 2015",Delaware,Wilmington,"1800 block of Prospect Rd",male,N/A,"Adult 18+",N/A
+"October 25, 2015",Delaware,Laurel,"County Seat Highway",female,N/A,"Adult 18+",N/A
+"October 22, 2015",Delaware,Wilmington,"800 block of Vanever Avenue",N/A,N/A,Unknown,N/A
+"October 22, 2015",Delaware,Wilmington,"800 block of Vanever Avenue",N/A,N/A,Unknown,N/A
+"October 22, 2015",Delaware,Wilmington,"800 block of Vanever Avenue",N/A,N/A,Unknown,N/A
+"October 21, 2015",Delaware,Dover,"South Du Pont Highway and Martin Luther King Jr. Boulevard",male,"Michael Neal","Adult 18+",N/A
+"October 21, 2015",Delaware,Wilmington,"800 block of Spruce St.",male,N/A,"Adult 18+",N/A
+"October 20, 2015",Delaware,Wilmington,"100 block of Lower Oak St.",male,"Quadrice Barksdale","Adult 18+",N/A
+"October 19, 2015",Delaware,"New Castle","1300 block of W. Fourth St.",male,"Taleem Bryant","Adult 18+",N/A
+"October 17, 2015",Delaware,Dover,"1400 John Clark Road",male,"Clifton M. Leager","Adult 18+",N/A
+"October 17, 2015",Delaware,Dover,"1400 John Clark Road",N/A,N/A,Unknown,N/A
+"October 17, 2015",Delaware,Dover,"1400 John Clark Road",male,N/A,Unknown,N/A
+"October 17, 2015",Delaware,Dover,"1400 John Clark Road",female,"Haley Henwood","Adult 18+",N/A
+"October 17, 2015",Delaware,Dover,"1400 John Clark Road",male,"Saleem Shabazz","Adult 18+",N/A
+"October 15, 2015",Delaware,Wilmington,"900 W. Eighth St",male,"Shavar Jackson","Adult 18+",N/A
+"October 15, 2015",Delaware,Wilmington,"900 W. Eighth St",male,"Stephon Williams","Adult 18+",N/A
+"October 15, 2015",Delaware,Wilmington,"900 W. Eighth St",male,"Donte Broomer","Adult 18+",N/A
+"October 15, 2015",Delaware,Wilmington,"West 27th and Tatnall Streets",male,N/A,"Adult 18+",N/A
+"October 14, 2015",Delaware,Wilmington,"Claymont Street",male,N/A,"Adult 18+",N/A
+"October 14, 2015",Delaware,Wilmington,"300 block of N Monroe St",male,"William Beltran","Adult 18+",N/A
+"October 14, 2015",Delaware,Wilmington,"West Third and North Lincoln Streets",male,N/A,"Adult 18+",N/A
+"October 14, 2015",Delaware,Wilmington,"West Third and North Lincoln Streets",male,"Nasir Manuel","Adult 18+",N/A
+"October 14, 2015",Delaware,Wilmington,"West Third and North Lincoln Streets",male,N/A,"Adult 18+",N/A
+"October 13, 2015",Delaware,Wilmington,"900 block of Buyer Street",male,"Gregory Dorsey","Adult 18+",N/A
+"October 11, 2015",Delaware,"New Castle","50 block of Oakmont Dr",male,N/A,"Adult 18+",N/A
+"October 11, 2015",Delaware,"New Castle","Oakmont Drive",male,N/A,"Adult 18+",N/A
+"October 11, 2015",Delaware,Middletown,"Greenlawn Boulevard",male,N/A,"Teen 12-17",N/A
+"October 11, 2015",Delaware,Middletown,"Greenlawn Boulevard",male,N/A,"Teen 12-17",N/A
+"October 11, 2015",Delaware,Middletown,"Greenlawn Boulevard",male,N/A,"Teen 12-17",N/A
+"October 6, 2015",Delaware,Dover,"West Division and North Queen Streets",male,"Lewis Harrell","Adult 18+",N/A
+"October 5, 2015",Delaware,Wilmington,"Bennett and East Eighth streets",female,"Armoni Fields","Child 0-11",N/A
+"October 5, 2015",Delaware,Wilmington,"Bennett and East Eighth streets",male,"Korie D. Henry","Adult 18+",N/A
+"October 5, 2015",Delaware,Wilmington,"100 block of W. 27th St.",male,N/A,"Adult 18+",N/A
+"October 5, 2015",Delaware,Wilmington,"300 block of E. 14th St.",male,N/A,"Adult 18+",N/A
+"October 4, 2015",Delaware,"New Castle","30 Highland Blvd",male,N/A,"Teen 12-17",N/A
+"October 2, 2015",Delaware,Dover,"400 Barrister Place",male,"Thomas Deputy","Adult 18+",N/A
+"October 2, 2015",Delaware,Newark,"1-29 E Cleveland Ave",male,N/A,"Adult 18+",N/A
+"October 2, 2015",Delaware,Newark,"1-29 E Cleveland Ave",male,N/A,Unknown,N/A
+"October 2, 2015",Delaware,Newark,"1-29 E Cleveland Ave",male,N/A,Unknown,N/A
+"October 2, 2015",Delaware,Newark,"1-29 E Cleveland Ave",male,N/A,Unknown,N/A
+"October 1, 2015",Delaware,Wilmington,"West 28th and North West",male,N/A,"Adult 18+",N/A
+"October 1, 2015",Delaware,Wilmington,"E. 23rd St.",male,N/A,"Adult 18+",N/A
+"September 29, 2015",Delaware,Dover,"Fulton Street",male,N/A,"Adult 18+",N/A
+"September 27, 2015",Delaware,Wilmington,"600 block of N. Jefferson St.",male,"Daywan Scott","Adult 18+",N/A
+"September 27, 2015",Delaware,Wilmington,"1000 block of S. Market St.",male,N/A,"Adult 18+",N/A
+"September 27, 2015",Delaware,Wilmington,"1000 block of S. Market St.",male,"Terrance Everett","Adult 18+",N/A
+"September 24, 2015",Delaware,"New Castle","Jensen Drive",male,N/A,Unknown,N/A
+"September 24, 2015",Delaware,Bear,"Pulaski Highway",N/A,N/A,Unknown,N/A
+"September 23, 2015",Delaware,Wilmington,"Tulip and South Scott streets",male,"Jeremy ""Bam"" McDole","Adult 18+",N/A
+"September 18, 2015",Delaware,Wilmington,"4th and N. Van Buren",male,"Robert Flippen","Adult 18+",N/A
+"September 16, 2015",Delaware,"New Castle","100 Wildfire Lane",male,"Markief Baynard","Adult 18+",N/A
+"September 16, 2015",Delaware,"New Castle","100 Wildfire Lane",male,"Cornelius Woodruff","Adult 18+",N/A
+"September 16, 2015",Delaware,Bear,"100 block of Wimbledon Court",male,N/A,"Adult 18+",N/A
+"September 10, 2015",Delaware,Wilmington,"4th and Lombard Streets",male,N/A,Unknown,N/A
+"September 9, 2015",Delaware,Wilmington,"500 block of E. Ninth Street",male,N/A,"Adult 18+",N/A
+"September 9, 2015",Delaware,Wilmington,"500 block of E. Ninth Street",male,"Michael Newton","Adult 18+",N/A
+"September 9, 2015",Delaware,Wilmington,"500 block of E. Ninth Street",male,N/A,Unknown,N/A
+"September 8, 2015",Delaware,Dover,"Kent Avenue and Water Street",male,"Tywon Peace","Teen 12-17",N/A
+"September 8, 2015",Delaware,Wilmington,"Pennsylvania Avenue and North Van Buren Street",male,"Driver Bryce Davis-Hutt","Adult 18+",N/A
+"September 7, 2015",Delaware,Claymont,"Ridge Road",male,N/A,"Adult 18+",N/A
+"September 7, 2015",Delaware,Wilmington,"600 block of W. Sixth St.",male,"Hassan Brown","Adult 18+",N/A
+"September 6, 2015",Delaware,Felton,"1000 block of Cabin Ridge Road",male,N/A,"Adult 18+",N/A
+"September 5, 2015",Delaware,Wilmington,"600 block of N. Monroe St.",female,N/A,"Adult 18+",N/A
+"September 4, 2015",Delaware,Dover,N/A,male,N/A,"Adult 18+",N/A
+"September 4, 2015",Delaware,Dover,N/A,male,"Alex Joseph","Adult 18+",N/A
+"September 4, 2015",Delaware,Dover,N/A,male,"Johnson Joseph","Adult 18+",N/A
+"September 4, 2015",Delaware,Wilmington,"800 block of W. Third St",N/A,N/A,Unknown,N/A
+"September 3, 2015",Delaware,Dover,"1019 Walker Road",male,N/A,Unknown,N/A
+"September 3, 2015",Delaware,Dover,"1019 Walker Road",male,N/A,Unknown,N/A
+"September 3, 2015",Delaware,Wilmington,"North Madison Street and West 24th Street",male,N/A,Unknown,N/A
+"September 3, 2015",Delaware,Wilmington,"West 25th Street and North Market Street",male,N/A,Unknown,N/A
+"September 1, 2015",Delaware,Wilmington,"Gordon and Lamotte streets",male,N/A,"Adult 18+",N/A
+"September 1, 2015",Delaware,Wilmington,"Gordon and Lamotte streets",N/A,N/A,Unknown,N/A
+"August 30, 2015",Delaware,"Ocean View","37000 block of Muddy Neck Road",female,N/A,"Child 0-11",N/A
+"August 30, 2015",Delaware,"Ocean View","37000 block of Muddy Neck Road",male,"Joseph M. Jenkins Jr.","Adult 18+",N/A
+"August 30, 2015",Delaware,"Ocean View (Oceanview)","37000 block of Muddy Neck Road",female,N/A,"Child 0-11",N/A
+"August 30, 2015",Delaware,"Ocean View (Oceanview)","37000 block of Muddy Neck Road",male,"Joseph M. Jenkins, Jr","Adult 18+",N/A
+"August 29, 2015",Delaware,Laurel,"West Eighth Street",male,"Lee Harper","Adult 18+",N/A
+"August 29, 2015",Delaware,Wilmington,"1200 block of Vandever Ave",male,N/A,"Adult 18+",N/A
+"August 29, 2015",Delaware,Wilmington,"West Sixth Street",male,N/A,"Adult 18+",N/A
+"August 28, 2015",Delaware,Dover,"Webbs Lane",male,N/A,"Adult 18+",N/A
+"August 28, 2015",Delaware,Wilmington,"Delamore Place",male,"Stephan DeShields","Adult 18+",N/A
+"August 28, 2015",Delaware,Wilmington,"Delamore Place",male,"Bilah Goldsborough","Adult 18+",N/A
+"August 28, 2015",Delaware,Dover,"100 block of New Street",male,"Terrance Fletcher","Adult 18+",N/A
+"August 24, 2015",Delaware,Hockessin,"Saint Clair Dr",male,"Shazim Uppal","Adult 18+",N/A
+"August 24, 2015",Delaware,Hockessin,"Saint Clair Dr",male,"Benjamin Rauf","Adult 18+",N/A
+"August 22, 2015",Delaware,Claymont,"Harvey Rd and Jackson Ave",male,N/A,"Adult 18+",N/A
+"August 21, 2015",Delaware,Wilmington,"200 block of North Monroe Street",male,N/A,"Adult 18+",N/A
+"August 21, 2015",Delaware,Wilmington,"200 block of North Monroe Street",male,N/A,"Teen 12-17",N/A
+"August 21, 2015",Delaware,Wilmington,"200 block of Delamore Place",male,N/A,"Adult 18+",N/A
+"August 18, 2015",Delaware,Wilmington,"500 block of Vandever Ave.",male,N/A,"Adult 18+",N/A
+"August 18, 2015",Delaware,Wilmington,"700 block of Townsend Place",male,N/A,"Child 0-11",N/A
+"August 18, 2015",Delaware,Wilmington,"700 block of Townsend Place",male,"Jaleel Goldsborough","Adult 18+",N/A
+"August 17, 2015",Delaware,Wilmington,"10th and Bennett Streets",male,N/A,"Adult 18+",N/A
+"August 16, 2015",Delaware,Wilmington,"West 6th and Madison Streets",male,N/A,"Adult 18+",N/A
+"August 15, 2015",Delaware,Wilmington,"North Locust Street",male,N/A,"Teen 12-17",N/A
+"August 15, 2015",Delaware,Wilmington,"800 block of Vandever Ave",male,"Markevis Clark","Adult 18+",N/A
+"August 15, 2015",Delaware,Wilmington,"800 block of Vandever Ave",male,"Hakiem Anderson","Adult 18+",N/A
+"August 13, 2015",Delaware,Wilmington,"West Second Street and North Madison Street",N/A,N/A,"Adult 18+",N/A
+"August 13, 2015",Delaware,Wilmington,"Pleasant Street and North Van Buren Street",male,N/A,"Adult 18+",N/A
+"August 12, 2015",Delaware,Wilmington,"17th and Thatcher Streets",male,"Amin Ackridge","Adult 18+",N/A
+"August 10, 2015",Delaware,Wilmington,"400 block of W. 7th Street",female,N/A,"Child 0-11",N/A
+"August 10, 2015",Delaware,Wilmington,"400 block of W. 7th Street",female,N/A,"Adult 18+",N/A
+"August 10, 2015",Delaware,Wilmington,"400 block of W. 7th Street",male,"Thomas Robles","Adult 18+",N/A
+"August 10, 2015",Delaware,Wilmington,"400 block of W. 7th Street",male,"Tyler Carter","Adult 18+",N/A
+"August 10, 2015",Delaware,Wilmington,"400 block of W. 7th Street",female,"Latrice Blackshear","Adult 18+",N/A
+"August 10, 2015",Delaware,Dover,"1210 White Oak Road",male,N/A,"Adult 18+",N/A
+"August 10, 2015",Delaware,Dover,"1210 White Oak Road",male,N/A,Unknown,N/A
+"August 10, 2015",Delaware,Dover,"Manchester Square and Stevenson Drive",N/A,N/A,Unknown,N/A
+"August 9, 2015",Delaware,Dover,"652 North DuPont Highway",male,"Royshawn Clark","Adult 18+",N/A
+"August 9, 2015",Delaware,Lincoln,"21000 block of W. Mayhew Dr.",male,N/A,"Child 0-11",N/A
+"August 9, 2015",Delaware,Lincoln,"21000 block of W. Mayhew Dr.",male,"Juan J. Shirey","Adult 18+",N/A
+"August 9, 2015",Delaware,Lincoln,"21000 block of W. Mayhew Dr.",male,N/A,"Adult 18+",N/A
+"August 9, 2015",Delaware,Wilmington,"2400 block of North Tatnall Street",male,N/A,"Adult 18+",N/A
+"August 9, 2015",Delaware,Wilmington,"2400 block of North Tatnall Street",male,"Marcel Dixon","Adult 18+",N/A
+"August 8, 2015",Delaware,Dover,"500 Persimmon Tree Ln",male,N/A,"Adult 18+",N/A
+"August 8, 2015",Delaware,Milford,"500 block of N Walnut St",male,"John Harmon","Adult 18+",N/A
+"August 8, 2015",Delaware,Milford,"500 block of N Walnut St",male,"Abdul T. White","Adult 18+",N/A
+"August 8, 2015",Delaware,Milford,"500 block of N Walnut St",male,N/A,Unknown,N/A
+"August 8, 2015",Delaware,Milford,"500 block of N Walnut St",male,N/A,Unknown,N/A
+"August 7, 2015",Delaware,Wilmington,"2400 block of Carter Street",male,N/A,"Adult 18+",N/A
+"August 6, 2015",Delaware,Dagsboro,"28000 block of East Diamond Dr",male,"William U. Drummond","Adult 18+",N/A
+"July 31, 2015",Delaware,Claymont,"Pennsylvania Avenue and Mansion Avenue",male,N/A,"Adult 18+",N/A
+"July 30, 2015",Delaware,"Rehoboth Beach","300 block of Rehoboth Ave",male,N/A,Unknown,N/A
+"July 30, 2015",Delaware,"Rehoboth Beach","300 block of Rehoboth Ave",male,N/A,Unknown,N/A
+"July 29, 2015",Delaware,"New Castle","300 block of Martin Drive",male,N/A,"Adult 18+",N/A
+"July 29, 2015",Delaware,"New Castle","300 block of Martin Drive",male,N/A,"Adult 18+",N/A
+"July 29, 2015",Delaware,Wilmington,"777 Delaware Park Blvd",male,N/A,"Adult 18+",N/A
+"July 29, 2015",Delaware,Wilmington,"777 Delaware Park Blvd",male,N/A,"Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",male,"Dameir Walker","Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",male,"Miguel Taylor","Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",male,"Marquivus Hardy","Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",female,"Zieisha Watters","Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",male,"Isaias Gonzalez","Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",male,"Timane Dollard","Adult 18+",N/A
+"July 28, 2015",Delaware,"New Castle","300 block of of Martin Dr",male,N/A,Unknown,N/A
+"July 24, 2015",Delaware,Wilmington,"800 block of of W. Ninth St.",male,"Howard Watkins","Adult 18+",N/A
+"July 24, 2015",Delaware,Wilmington,"2501 Newport Gap Pike",male,N/A,"Adult 18+",N/A
+"July 24, 2015",Delaware,Wilmington,"2501 Newport Gap Pike",male,N/A,Unknown,N/A
+"July 24, 2015",Delaware,Claymont,"4th Avenue",male,N/A,"Adult 18+",N/A
+"July 23, 2015",Delaware,Wilmington,"West Fourth and Washington Streets",male,"James Rogers","Adult 18+",N/A
+"July 23, 2015",Delaware,Wilmington,"West Fourth and Washington Streets",male,"Taushia Mitchell","Adult 18+",N/A
+"July 22, 2015",Delaware,Wilmington,"500 block of N. Madison St",male,N/A,"Adult 18+",N/A
+"July 22, 2015",Delaware,Wilmington,"900 block of Maryland Ave",male,N/A,"Adult 18+",N/A
+"July 22, 2015",Delaware,Wilmington,"900 block of Maryland Ave",male,N/A,"Adult 18+",N/A
+"July 22, 2015",Delaware,Wilmington,"500 block of North Madison St",male,N/A,"Adult 18+",N/A
+"July 22, 2015",Delaware,Dover,"400 block of Sussex Avenue",male,N/A,"Teen 12-17",N/A
+"July 21, 2015",Delaware,Wilmington,"Chestnut and South Franklin streets",male,N/A,"Adult 18+",N/A
+"July 21, 2015",Delaware,Wilmington,"2400 block of Carter St",male,N/A,"Adult 18+",N/A
+"July 21, 2015",Delaware,Bear,"20 block of Monferrato Ct",female,"Jennifer Fertig","Adult 18+",N/A
+"July 21, 2015",Delaware,Bear,"20 block of Monferrato Ct",male,"Michael Jackson","Adult 18+",N/A
+"July 20, 2015",Delaware,Wilmington,"800 block of Vandever Ave",male,"Bernard Bryant","Adult 18+",N/A
+"July 18, 2015",Delaware,Wilmington,"Concord Avenue and North Washington",male,N/A,"Adult 18+",N/A
+"July 18, 2015",Delaware,Wilmington,"Concord Avenue and North Washington",male,N/A,"Adult 18+",N/A
+"July 18, 2015",Delaware,Wilmington,"100 block of N. Clayton St",male,N/A,"Adult 18+",N/A
+"July 16, 2015",Delaware,Dover,"400 block of New Castle Avenue",male,"Anteaza Vann","Adult 18+",N/A
+"July 16, 2015",Delaware,Wilmington,"Lancaster Avenue and Du Pont Street",male,"Brandon Ryans","Adult 18+",N/A
+"July 15, 2015",Delaware,Wilmington,"1800 block of Foulk Rd",male,"Andrew E. Allen","Adult 18+",N/A
+"July 15, 2015",Delaware,Wilmington,"1800 block of Foulk Rd",male,"Jeremy W. Clark","Adult 18+",N/A
+"July 14, 2015",Delaware,Wilmington,"400 block of S. Madison St",male,N/A,"Adult 18+",N/A
+"July 13, 2015",Delaware,"Wilmington (Edgemoor)",N/A,male,N/A,"Adult 18+",N/A
+"July 13, 2015",Delaware,"Wilmington (Edgemoor)",N/A,male,N/A,"Teen 12-17",N/A
+"July 13, 2015",Delaware,Dover,"900 block of W. North St.",male,"Jamal Weeks","Adult 18+",N/A
+"July 11, 2015",Delaware,Wilmington,"2300 block of Baynard Blvd.",male,N/A,"Adult 18+",N/A
+"July 10, 2015",Delaware,Wilmington,"100 block of S. Franklin Street",male,N/A,"Teen 12-17",N/A
+"July 9, 2015",Delaware,Wilmington,"1300 block of West 6th Street",male,"William Fisher","Adult 18+",N/A
+"July 8, 2015",Delaware,Wilmington,"100 block of N. Van Buren St.",male,N/A,"Adult 18+",N/A
+"July 8, 2015",Delaware,Wilmington,"37012 Country Club Road",male,N/A,Unknown,N/A
+"July 8, 2015",Delaware,Newark,"Finch Way",male,"Cordeiro McClain","Adult 18+",N/A
+"July 7, 2015",Delaware,Wilmington,"10th and Spruce streets",male,N/A,"Adult 18+",N/A
+"July 7, 2015",Delaware,"Rehoboth Beach","37000 block of Country Club Road",male,"Chaise Darley","Adult 18+",N/A
+"July 6, 2015",Delaware,Wilmington,"Sixth and Madison Streets",male,N/A,"Adult 18+",N/A
+"July 6, 2015",Delaware,Dover,"N. New St.",male,N/A,"Adult 18+",N/A
+"July 6, 2015",Delaware,Dover,"N. New St.",male,N/A,"Adult 18+",N/A
+"July 6, 2015",Delaware,Seaford,"Tull Drive",male,N/A,"Adult 18+",N/A
+"July 6, 2015",Delaware,Seaford,"Tull Drive",female,N/A,"Adult 18+",N/A
+"July 6, 2015",Delaware,Wilmington,"1400 block of W. Second St.",male,"Jerome Jeter","Adult 18+",N/A
+"July 2, 2015",Delaware,Wilmington,"603 Philadelphia Pike",male,"Steven Kellam","Adult 18+",N/A
+"July 2, 2015",Delaware,Wilmington,"603 Philadelphia Pike",male,"Carlton Gibbs","Adult 18+",N/A
+"July 2, 2015",Delaware,Wilmington,"603 Philadelphia Pike",male,"Damon Bethea","Adult 18+",N/A
+"July 2, 2015",Delaware,Middletown,"100 block of St. Augustine Court",male,"Thomas Reamer","Adult 18+",N/A
+"July 1, 2015",Delaware,Wilmington,"900 block of N. Jefferson St.",male,"William Yancey","Adult 18+",N/A
+"June 30, 2015",Delaware,Wilmington,"600 block of N. Broom St",male,"Quiaire Nesmith","Adult 18+",N/A
+"June 29, 2015",Delaware,Wilmington,"2900 block of N. Washington St",male,"Otis Bridgeforth","Adult 18+",N/A
+"June 29, 2015",Delaware,Wilmington,"400 block of S. Heald St.",male,"Damont Emory","Adult 18+",N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",N/A,N/A,Unknown,N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",N/A,N/A,Unknown,N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",N/A,N/A,Unknown,N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",N/A,N/A,Unknown,N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",N/A,N/A,Unknown,N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",male,"Elijah Desir","Adult 18+",N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",male,N/A,"Teen 12-17",N/A
+"June 28, 2015",Delaware,Harrington,"100 block of East St",N/A,N/A,Unknown,N/A
+"June 26, 2015",Delaware,Newark,"Penman Seventy 6 Dr and Sandburg Pl",male,N/A,"Teen 12-17",N/A
+"June 23, 2015",Delaware,Wilmington,"600 block of N. Broom St",male,N/A,"Adult 18+",N/A
+"June 22, 2015",Delaware,Bear,"100 block of Wimbledon Court",male,N/A,"Adult 18+",N/A
+"June 22, 2015",Delaware,Bear,"100 block of Wimbledon Court",male,N/A,Unknown,N/A
+"June 22, 2015",Delaware,Bear,"100 block of Wimbledon Court",male,N/A,Unknown,N/A
+"June 15, 2015",Delaware,"New Castle","3 Memorial Dr",male,N/A,"Adult 18+",N/A
+"June 15, 2015",Delaware,"New Castle","3 Memorial Dr",male,N/A,"Adult 18+",N/A
+"June 14, 2015",Delaware,Wilmington,"600 block of North Jefferson Street",male,"Antonio Cropper","Adult 18+",N/A
+"June 14, 2015",Delaware,Milford,"100 block of NW Front St",male,"Robert G. Cook","Adult 18+",N/A
+"June 13, 2015",Delaware,Magnolia,"300 block of Marshview Terrace",male,N/A,"Adult 18+",N/A
+"June 13, 2015",Delaware,Magnolia,"300 block of Marshview Terrace",male,N/A,"Adult 18+",N/A
+"June 13, 2015",Delaware,Magnolia,"300 block of Marshview Terrace",male,N/A,"Adult 18+",N/A
+"June 13, 2015",Delaware,Dover,"500 block of South Dupont Highway",male,"Ricky S. Sanabria","Adult 18+",N/A
+"June 10, 2015",Delaware,Wilmington,"100 block of N. Connell St",male,N/A,"Adult 18+",N/A
+"June 10, 2015",Delaware,Wilmington,"100 block of N. Connell St",male,N/A,"Adult 18+",N/A
+"June 9, 2015",Delaware,Wilmington,"100 block of Delamore Place",male,N/A,"Adult 18+",N/A
+"June 9, 2015",Delaware,Wilmington,"100 block of Delamore Place",male,N/A,"Adult 18+",N/A
+"June 9, 2015",Delaware,Wilmington,"100 block of Delamore Place",male,N/A,"Adult 18+",N/A
+"June 7, 2015",Delaware,Dover,"100 block of S. New St.",male,"Rondree Campbell","Adult 18+",N/A
+"June 6, 2015",Delaware,Dover,"South Little Creek Road",male,N/A,"Adult 18+",N/A
+"June 6, 2015",Delaware,Dover,"South Little Creek Road",female,N/A,"Adult 18+",N/A
+"June 6, 2015",Delaware,Dover,"1131 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"June 2, 2015",Delaware,Wilmington,"West Fourth and Delamore Streets",female,N/A,"Adult 18+",N/A
+"June 2, 2015",Delaware,Wilmington,"West Fourth and Delamore Streets",male,N/A,"Adult 18+",N/A
+"June 2, 2015",Delaware,Dover,"200 block of Frear Drive",female,"Melissa Thompkins","Adult 18+",N/A
+"June 2, 2015",Delaware,Dover,"200 block of Frear Drive",male,"Frederick Tolson","Adult 18+",N/A
+"June 2, 2015",Delaware,"New Castle","Powhaten Road",male,N/A,"Adult 18+",N/A
+"June 2, 2015",Delaware,"New Castle","Powhaten Road",male,N/A,"Adult 18+",N/A
+"June 1, 2015",Delaware,Wilmington,"500 block of E. 10th St.",male,"Ernest Robinson","Adult 18+",N/A
+"June 1, 2015",Delaware,Wilmington,"100 block of North Broom Street",male,N/A,"Adult 18+",N/A
+"June 1, 2015",Delaware,Wilmington,"Bedford Drive",male,N/A,"Adult 18+",N/A
+"June 1, 2015",Delaware,Dover,"200 block of N. Kirkwood St.",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,"Isaiah Gonzalez","Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,"Nathaniel Gonzalez","Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,Wilmington,"3900 block of Lancaster Ave.",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,Dover,"100 block of Madison Court",male,N/A,"Adult 18+",N/A
+"May 31, 2015",Delaware,"Port Penn","W. Market St.",male,"Matthew W. Kennedy","Adult 18+",N/A
+"May 30, 2015",Delaware,Wilmington,"200 block of North Broom Street",male,N/A,"Teen 12-17",N/A

--- a/data/participants/2019-03-12 - 2021-10-27.csv
+++ b/data/participants/2019-03-12 - 2021-10-27.csv
@@ -1,0 +1,2001 @@
+"Incident Date",State,"City Or County",Address,"Participant Gender","Participant Name","Participant Age Group",Operations
+"October 27, 2021",Delaware,Smyrna,"700 Duck Creek Pkwy",male,N/A,"Teen 12-17",N/A
+"October 27, 2021",Delaware,"New Castle","I-95 and Airport Rd",N/A,N/A,Unknown,N/A
+"October 27, 2021",Delaware,Wilmington,"800 block of Towne Ct",male,N/A,"Teen 12-17",N/A
+"October 25, 2021",Delaware,Wilmington,"W 7th St and N West St",male,N/A,"Teen 12-17",N/A
+"October 24, 2021",Delaware,Seaford,"11000 block of Hastings Farm Rd",N/A,N/A,"Adult 18+",N/A
+"October 24, 2021",Delaware,Wilmington,"50 block of W 27th St",male,"Zion Davis Shelton","Adult 18+",N/A
+"October 23, 2021",Delaware,Wilmington,"200 block of W 30th St",male,"Synai Smith","Adult 18+",N/A
+"October 21, 2021",Delaware,Wilmington,"W 5th St and N Madison St",male,N/A,"Teen 12-17",N/A
+"October 21, 2021",Delaware,Wilmington,"W 5th St and N Madison St",male,N/A,"Teen 12-17",N/A
+"October 21, 2021",Delaware,"Ocean View","30000 block of Bethany Crest",female,"Cheryl Beckett-Brown","Adult 18+",N/A
+"October 21, 2021",Delaware,"Ocean View","30000 block of Bethany Crest",male,"Jason R. Meredith","Adult 18+",N/A
+"October 20, 2021",Delaware,Wilmington,"1300 block of Maryland Ave",male,N/A,"Adult 18+",N/A
+"October 19, 2021",Delaware,Dover,"1 Dover High Dr",N/A,N/A,"Teen 12-17",N/A
+"October 17, 2021",Delaware,Wilmington,"W 3rd St and N Clayton St",male,"Marquis Lopez Jr","Adult 18+",N/A
+"October 16, 2021",Delaware,Dover,"S Little Creek Rd and Barrister Place",male,N/A,"Adult 18+",N/A
+"October 15, 2021",Delaware,Wilmington,"300 block of W 6th St",female,N/A,"Adult 18+",N/A
+"October 12, 2021",Delaware,Wilmington,"1000 block of Kirkwood St",female,"Carla Aiken","Adult 18+",N/A
+"October 11, 2021",Delaware,Middletown,"600 block of Schoonover Ln",female,N/A,"Adult 18+",N/A
+"October 11, 2021",Delaware,Middletown,"600 block of Schoonover Ln",male,"Brandon Christian","Adult 18+",N/A
+"October 10, 2021",Delaware,Dover,"1500 block of Nathaniel Mitchell Rd",female,N/A,"Adult 18+",N/A
+"October 10, 2021",Delaware,Dover,"1500 block of Nathaniel Mitchell Rd",female,N/A,"Adult 18+",N/A
+"October 10, 2021",Delaware,Dover,"1500 block of Nathaniel Mitchell Rd",male,N/A,"Adult 18+",N/A
+"October 10, 2021",Delaware,Dover,"1500 block of Nathaniel Mitchell Rd",male,N/A,"Adult 18+",N/A
+"October 10, 2021",Delaware,Dover,"1500 block of Nathaniel Mitchell Rd",male,"Brenden Harmon","Adult 18+",N/A
+"October 9, 2021",Delaware,Newark,"100 block of Madison Dr",female,N/A,"Teen 12-17",N/A
+"October 9, 2021",Delaware,Newark,"100 block of Madison Dr",male,N/A,"Teen 12-17",N/A
+"October 9, 2021",Delaware,Newark,"100 block of Madison Dr",male,N/A,"Teen 12-17",N/A
+"October 2, 2021",Delaware,Wilmington,"3800 block of Governor Printz Blvd",male,N/A,"Adult 18+",N/A
+"October 1, 2021",Delaware,Clayton,"4700 block of Wheatleys Pond Rd",female,N/A,"Adult 18+",N/A
+"October 1, 2021",Delaware,Clayton,"4700 block of Wheatleys Pond Rd",male,"Richard Lawson III","Adult 18+",N/A
+"October 1, 2021",Delaware,Clayton,"3900 block of Wheatleys Pond Rd",female,N/A,"Adult 18+",N/A
+"October 1, 2021",Delaware,Clayton,"3900 block of Wheatleys Pond Rd",male,"Richard C. Lawson III","Adult 18+",N/A
+"September 26, 2021",Delaware,Wilmington,"2200 block of North Spruce St",male,"Tyrell Lewis","Adult 18+",N/A
+"September 26, 2021",Delaware,Wilmington,"700 block of N Washington St",male,N/A,"Adult 18+",N/A
+"September 25, 2021",Delaware,Wilmington,"400 block of N Monroe St",male,"Tyaire Anderson","Adult 18+",N/A
+"September 23, 2021",Delaware,Wilmington,"1300 block of E 29th St",male,"Jamar Warren","Adult 18+",N/A
+"September 22, 2021",Delaware,Wilmington,"E 28th and Jessup St",male,N/A,"Adult 18+",N/A
+"September 20, 2021",Delaware,Wilmington,"Taylor St and Bennett St",male,N/A,"Adult 18+",N/A
+"September 19, 2021",Delaware,Wilmington,"800 block of 7½ St",male,N/A,"Adult 18+",N/A
+"September 19, 2021",Delaware,Dover,"New Castle Ave and E Water St",male,N/A,"Adult 18+",N/A
+"September 19, 2021",Delaware,Dover,"New Castle Ave and E Water St",male,N/A,"Adult 18+",N/A
+"September 18, 2021",Delaware,Wilmington,"100 block of S Harrison St",male,N/A,"Adult 18+",N/A
+"September 17, 2021",Delaware,Wilmington,"4737 Concord Pike",male,N/A,"Adult 18+",N/A
+"September 14, 2021",Delaware,Wilmington,"Pleasant St and Van Buren St",male,N/A,"Adult 18+",N/A
+"September 12, 2021",Delaware,Wilmington,"Chestnut St and S Harrison St",male,N/A,"Adult 18+",N/A
+"September 12, 2021",Delaware,Wilmington,"Chestnut St and S Harrison St",male,N/A,"Adult 18+",N/A
+"September 11, 2021",Delaware,"New Castle","N Dupont Hwy and E Hazeldell Ave",male,N/A,"Adult 18+",N/A
+"September 11, 2021",Delaware,Newark,"104 Sandburg Pl",male,N/A,"Adult 18+",N/A
+"September 11, 2021",Delaware,Newark,"104 Sandburg Pl",male,"Jermaine Boardingham","Adult 18+",N/A
+"September 9, 2021",Delaware,Newark,"1901 S College Ave",male,"Mcdevitt P James","Adult 18+",N/A
+"September 9, 2021",Delaware,Wilmington,"200 block of N Van Buren St",male,N/A,"Adult 18+",N/A
+"September 7, 2021",Delaware,Wilmington,"A St and New Castle Ave",female,N/A,"Adult 18+",N/A
+"September 7, 2021",Delaware,Wilmington,"A St and New Castle Ave",male,N/A,"Adult 18+",N/A
+"September 7, 2021",Delaware,Wilmington,"A St and New Castle Ave",female,N/A,"Adult 18+",N/A
+"September 7, 2021",Delaware,Wilmington,"A St and New Castle Ave",female,N/A,"Adult 18+",N/A
+"September 7, 2021",Delaware,Wilmington,"3rd St and Harrison St",male,N/A,"Adult 18+",N/A
+"September 3, 2021",Delaware,Smyrna,"100 Block of Lincoln St",male,"Jehoshaphat Martinez","Adult 18+",N/A
+"August 31, 2021",Delaware,"New Castle","100 block of Freedom Trail",male,"Ernest Staples","Adult 18+",N/A
+"August 29, 2021",Delaware,Smyrna,"50 Block of N Howard St",female,N/A,"Adult 18+",N/A
+"August 29, 2021",Delaware,Wilmington,"2500 block of West St",female,N/A,"Adult 18+",N/A
+"August 27, 2021",Delaware,Seaford,"US-13 and Concord Rd",male,N/A,"Adult 18+",N/A
+"August 26, 2021",Delaware,Wilmington,"1950 Maryland Ave",male,N/A,"Adult 18+",N/A
+"August 26, 2021",Delaware,Wilmington,"1950 Maryland Ave",male,N/A,"Adult 18+",N/A
+"August 26, 2021",Delaware,Wilmington,"1950 Maryland Ave",male,N/A,"Adult 18+",N/A
+"August 22, 2021",Delaware,Dover,"1001 White Oak Rd",male,N/A,"Adult 18+",N/A
+"August 22, 2021",Delaware,Dover,"1001 White Oak Rd",male,"Hector Gonzalez","Adult 18+",N/A
+"August 21, 2021",Delaware,Wilmington,"1700 block of W 5th St",male,N/A,"Adult 18+",N/A
+"August 21, 2021",Delaware,Wilmington,"1700 block of W 5th St",male,"Jamar Smith","Adult 18+",N/A
+"August 21, 2021",Delaware,Dover,"2000 Block of Dyke Branch Rd",female,"Anna Hurst","Adult 18+",N/A
+"August 21, 2021",Delaware,Dover,"2000 Block of Dyke Branch Rd",male,"Ronald D. Suber Jr","Adult 18+",N/A
+"August 21, 2021",Delaware,Wilmington,"300 block of S Broom St",female,N/A,"Teen 12-17",N/A
+"August 16, 2021",Delaware,Wilmington,"200 block of S Broom St",male,N/A,"Adult 18+",N/A
+"August 15, 2021",Delaware,Middletown,"67 New St",N/A,N/A,Unknown,N/A
+"August 15, 2021",Delaware,Newark,"I-95 and Churchmans Rd",female,N/A,"Teen 12-17",N/A
+"August 15, 2021",Delaware,Wilmington,"500 block of E 9th St",male,N/A,"Teen 12-17",N/A
+"August 14, 2021",Delaware,Wilmington,"2700 block of Bowers St",male,"Marquise Holmes","Adult 18+",N/A
+"August 14, 2021",Delaware,Dover,"107 W Loockerman St",male,N/A,"Adult 18+",N/A
+"August 14, 2021",Delaware,Dover,"107 W Loockerman St",female,N/A,"Adult 18+",N/A
+"August 14, 2021",Delaware,Dover,"107 W Loockerman St",male,"Dashere Lewis","Adult 18+",N/A
+"August 14, 2021",Delaware,Dover,"107 W Loockerman St",male,"Stacey Henry","Adult 18+",N/A
+"August 12, 2021",Delaware,Wilmington,"1200 block of W 4th St",male,"Nyden Holmes","Adult 18+",N/A
+"August 9, 2021",Delaware,Dover,"995 Whatcoat Dr",male,"Carnell Hill","Teen 12-17",N/A
+"August 9, 2021",Delaware,Dover,"995 Whatcoat Dr",male,"Unique Trader","Teen 12-17",N/A
+"August 8, 2021",Delaware,Dover,"295 S DuPont Hwy",male,N/A,"Adult 18+",N/A
+"August 8, 2021",Delaware,Dover,"295 S DuPont Hwy",male,"Stevenson Benoit","Adult 18+",N/A
+"August 8, 2021",Delaware,Wilmington,"700 block of E 10th St",female,N/A,"Adult 18+",N/A
+"August 8, 2021",Delaware,Wilmington,"700 block of E 10th St",female,N/A,"Adult 18+",N/A
+"August 7, 2021",Delaware,Wilmington,"Conrad St and N Scott St",male,N/A,"Adult 18+",N/A
+"August 7, 2021",Delaware,Wilmington,"400 block of W 29th St",male,"Joshua Bailey","Adult 18+",N/A
+"August 6, 2021",Delaware,Wilmington,"800 block of N West St",male,N/A,"Adult 18+",N/A
+"August 4, 2021",Delaware,Wilmington,"100 block of N Harrison St",male,N/A,"Adult 18+",N/A
+"August 2, 2021",Delaware,"New Castle","Glen Ave and Dyer Ave",male,N/A,"Adult 18+",N/A
+"August 1, 2021",Delaware,Dover,"50 block of Stevenson Dr",male,N/A,"Adult 18+",N/A
+"August 1, 2021",Delaware,Dover,"50 block of Stevenson Dr",male,N/A,"Adult 18+",N/A
+"July 30, 2021",Delaware,Newark,"1000 Churchmans Rd",male,N/A,"Adult 18+",N/A
+"July 30, 2021",Delaware,Bear,"Korean War Veterans Memorial Hwy and Pulaski Hwy",male,N/A,"Adult 18+",N/A
+"July 30, 2021",Delaware,Bear,"Korean War Veterans Memorial Hwy and Pulaski Hwy",male,N/A,Unknown,N/A
+"July 30, 2021",Delaware,Bear,"Korean War Veterans Memorial Hwy and Pulaski Hwy",male,N/A,Unknown,N/A
+"July 30, 2021",Delaware,Wilmington,"1000 block of N Pine St",male,N/A,"Adult 18+",N/A
+"July 26, 2021",Delaware,Wilmington,"1100 block of W 2nd St",female,N/A,"Teen 12-17",N/A
+"July 26, 2021",Delaware,Wilmington,"1100 block of W 2nd St",female,"McKenzie Horn","Adult 18+",N/A
+"July 26, 2021",Delaware,Wilmington,"1100 block of W 2nd St",female,"Jayda Reed","Adult 18+",N/A
+"July 26, 2021",Delaware,Wilmington,"1100 block of W 2nd St",male,"Robert Horn","Adult 18+",N/A
+"July 26, 2021",Delaware,Wilmington,"2400 block of Jessup St",male,"Jawaun Shockley","Adult 18+",N/A
+"July 26, 2021",Delaware,Wilmington,"2400 block of Jessup St",male,N/A,"Adult 18+",N/A
+"July 26, 2021",Delaware,Wilmington,"600 block of N Monroe St",male,"Kevin Thompson","Adult 18+",N/A
+"July 26, 2021",Delaware,Wilmington,"600 block of N Monroe St",male,N/A,"Adult 18+",N/A
+"July 24, 2021",Delaware,Dover,"400 block of Barrister Pl",male,N/A,"Adult 18+",N/A
+"July 24, 2021",Delaware,Dover,"995 Whatcoat Dr",male,N/A,"Teen 12-17",N/A
+"July 24, 2021",Delaware,Dover,"995 Whatcoat Dr",male,"Duwanyae Smith","Adult 18+",N/A
+"July 22, 2021",Delaware,Wilmington,"200 block of N Clayton St",male,N/A,"Adult 18+",N/A
+"July 20, 2021",Delaware,Newark,"400 block of Wollaston Ave",male,N/A,"Adult 18+",N/A
+"July 20, 2021",Delaware,Seaford,"900 Woodland Mills Dr",N/A,N/A,Unknown,N/A
+"July 19, 2021",Delaware,Dover,"1156 S Bay Rd",female,N/A,"Adult 18+",N/A
+"July 19, 2021",Delaware,Dover,"1156 S Bay Rd",male,N/A,"Adult 18+",N/A
+"July 19, 2021",Delaware,Wilmington,"50 block of W 27th St",male,N/A,"Adult 18+",N/A
+"July 18, 2021",Delaware,Dover,"1200 block of Harrison Dr",male,N/A,"Teen 12-17",N/A
+"July 18, 2021",Delaware,Dover,"1200 block of Harrison Dr",male,"William Cooper","Adult 18+",N/A
+"July 15, 2021",Delaware,Milford,"East St and NE 4th St",male,N/A,"Adult 18+",N/A
+"July 14, 2021",Delaware,Claymont,"50 block of Balfour Ave",male,"Jasir Brown","Teen 12-17",N/A
+"July 14, 2021",Delaware,Claymont,"50 block of Balfour Ave",female,N/A,"Adult 18+",N/A
+"July 14, 2021",Delaware,Claymont,"50 block of Balfour Ave",male,N/A,"Adult 18+",N/A
+"July 14, 2021",Delaware,Claymont,"50 block of Balfour Ave",male,"Nathan Smith","Adult 18+",N/A
+"July 13, 2021",Delaware,Dover,"100 block of W Loockerman St",male,N/A,"Adult 18+",N/A
+"July 13, 2021",Delaware,Wilmington,"1300 block of W 6th St",male,N/A,"Adult 18+",N/A
+"July 13, 2021",Delaware,Wilmington,"1300 block of W 6th St",male,"Hakeem Allen","Adult 18+",N/A
+"July 9, 2021",Delaware,Dover,"200 block of Cecil St",male,N/A,"Adult 18+",N/A
+"July 9, 2021",Delaware,"New Castle","1600 block of Coleman St",male,"James Jackson","Adult 18+",N/A
+"July 9, 2021",Delaware,"New Castle","1600 block of Coleman St",male,"Sean Tyler","Adult 18+",N/A
+"July 6, 2021",Delaware,Wilmington,"1300 block of Read St",male,N/A,"Adult 18+",N/A
+"July 6, 2021",Delaware,"New Castle","600 block of Moores Ln",N/A,N/A,Unknown,N/A
+"July 5, 2021",Delaware,Wilmington,"700 block of Elbert Pl",male,"Matima Miller","Adult 18+",N/A
+"July 3, 2021",Delaware,Newark,"100 block of Madison Dr",male,N/A,"Adult 18+",N/A
+"July 3, 2021",Delaware,Newark,"100 block of Madison Dr",male,"Nih’ki Price","Adult 18+",N/A
+"July 2, 2021",Delaware,Wilmington,"2300 block of N West St",male,N/A,"Teen 12-17",N/A
+"July 2, 2021",Delaware,Wilmington,"2500 block of N Tatnall St",male,N/A,"Adult 18+",N/A
+"July 2, 2021",Delaware,Wilmington,"900 block of Lombard St",male,"Quinton Dorsey","Adult 18+",N/A
+"July 1, 2021",Delaware,Newark,"13 Salem Village Square",female,N/A,"Adult 18+",N/A
+"July 1, 2021",Delaware,Newark,"13 Salem Village Square",male,N/A,"Teen 12-17",N/A
+"July 1, 2021",Delaware,Newark,"13 Salem Village Square",male,N/A,"Adult 18+",N/A
+"July 1, 2021",Delaware,Wilmington,"7th St and N Jefferson St",male,N/A,"Adult 18+",N/A
+"June 30, 2021",Delaware,Wilmington,"600 block of N Madison St",male,N/A,"Adult 18+",N/A
+"June 30, 2021",Delaware,Dover,"100 block of S New St",male,"Tysean Nelson","Adult 18+",N/A
+"June 30, 2021",Delaware,Dover,"100 block of S New St",male,N/A,"Adult 18+",N/A
+"June 30, 2021",Delaware,Dover,"100 block of S New St",male,N/A,"Adult 18+",N/A
+"June 30, 2021",Delaware,Dover,"100 block of S New St",female,N/A,"Adult 18+",N/A
+"June 28, 2021",Delaware,Newark,"132 Christiana Mall",female,"Alexis Woods","Adult 18+",N/A
+"June 28, 2021",Delaware,Newark,"132 Christiana Mall",female,"Shaidiah McNeair","Adult 18+",N/A
+"June 27, 2021",Delaware,Wilmington,"700 block of N Jefferson St",male,N/A,"Adult 18+",N/A
+"June 27, 2021",Delaware,Wilmington,"700 block of N Jefferson St",male,N/A,"Adult 18+",N/A
+"June 27, 2021",Delaware,Wilmington,"700 block of N Jefferson St",male,N/A,"Adult 18+",N/A
+"June 27, 2021",Delaware,Newark,"1 Louis Ct",male,"Aaron Moore","Adult 18+",N/A
+"June 27, 2021",Delaware,Newark,"1 Louis Ct",male,N/A,"Adult 18+",N/A
+"June 27, 2021",Delaware,Newark,"1 Louis Ct",male,N/A,"Teen 12-17",N/A
+"June 27, 2021",Delaware,Wilmington,"200 block of N Harrison St",male,"Javier Velez-Torres","Adult 18+",N/A
+"June 25, 2021",Delaware,"Fenwick Island","W Atlantic St",male,"Andre J Blakeney","Adult 18+",N/A
+"June 25, 2021",Delaware,"Fenwick Island","W Atlantic St",male,"Finis A Miles","Adult 18+",N/A
+"June 25, 2021",Delaware,"Fenwick Island","50 block of W Atlantic St",male,"Andre J. Blakeney","Adult 18+",N/A
+"June 25, 2021",Delaware,"Fenwick Island","50 block of W Atlantic St",male,"Finis A. Miles","Adult 18+",N/A
+"June 24, 2021",Delaware,Wilmington,"200 block of N Rodney St",male,N/A,"Adult 18+",N/A
+"June 24, 2021",Delaware,Dover,"Bicentennial Blvd and Declaration Dr",male,"Kyle Robinson","Adult 18+",N/A
+"June 23, 2021",Delaware,Dover,"400 block of River Rd",male,N/A,"Adult 18+",N/A
+"June 23, 2021",Delaware,Wilmington,"Pleasant St and Franklin St",male,N/A,"Adult 18+",N/A
+"June 23, 2021",Delaware,Wilmington,"2300 block of Bowers St",male,N/A,"Adult 18+",N/A
+"June 22, 2021",Delaware,Wilmington,"500 block of W 35th St",male,"Christopher Smith","Teen 12-17",N/A
+"June 22, 2021",Delaware,Middletown,"Greenlawn Blvd and Janvier Dr",N/A,"Devon Custis","Adult 18+",N/A
+"June 22, 2021",Delaware,Dover,"Garfield Dr and Frear Dr",male,N/A,"Adult 18+",N/A
+"June 22, 2021",Delaware,Dover,"Garfield Dr and Frear Dr",male,"Kyle Robinson","Adult 18+",N/A
+"June 22, 2021",Delaware,Dover,"Garfield Dr and Frear Dr",male,"Emeka Dimkpa","Adult 18+",N/A
+"June 20, 2021",Delaware,"Seaford (Blades)","E 4th St",male,N/A,"Adult 18+",N/A
+"June 20, 2021",Delaware,Wilmington,"2300 block of Lamotte St",male,N/A,"Adult 18+",N/A
+"June 20, 2021",Delaware,Dover,"1426 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"June 20, 2021",Delaware,Dover,"1426 N Dupont Hwy",male,"Caleb Collins","Adult 18+",N/A
+"June 20, 2021",Delaware,Dover,"1426 N Dupont Hwy",male,"Joshua Collins","Adult 18+",N/A
+"June 19, 2021",Delaware,Wilmington,"700 block of W 5th St",female,N/A,"Teen 12-17",N/A
+"June 19, 2021",Delaware,Wilmington,"2400 block of N Market St",male,N/A,"Teen 12-17",N/A
+"June 17, 2021",Delaware,Wilmington,"200 block of N Connell St",male,N/A,"Adult 18+",N/A
+"June 16, 2021",Delaware,Dover,"Fairway Lakes Dr",male,N/A,"Adult 18+",N/A
+"June 16, 2021",Delaware,Dover,"Fairway Lakes Dr",male,"Shakur Peck","Adult 18+",N/A
+"June 14, 2021",Delaware,Felton,"Indian Runner Rd",male,"Eugene K. Sykes","Adult 18+",N/A
+"June 9, 2021",Delaware,Dover,"W North St and Simon Cir",male,N/A,"Adult 18+",N/A
+"June 9, 2021",Delaware,Dover,"W North St and Simon Cir",female,"Nyasia Smith","Adult 18+",N/A
+"June 9, 2021",Delaware,Wilmington,"2900 block of N Madison St",male,N/A,"Teen 12-17",N/A
+"June 9, 2021",Delaware,Wilmington,"2900 block of N Madison St",female,N/A,"Teen 12-17",N/A
+"June 9, 2021",Delaware,Wilmington,"200 block of Garden Ct",male,N/A,"Adult 18+",N/A
+"June 9, 2021",Delaware,Wilmington,"200 block of Garden Ct",male,"Nazer Hayman-Cooper","Adult 18+",N/A
+"June 9, 2021",Delaware,Wilmington,"200 block of Garden Ct",male,N/A,"Teen 12-17",N/A
+"June 8, 2021",Delaware,Wilmington,"1300 block of Wilson St",male,N/A,"Adult 18+",N/A
+"June 8, 2021",Delaware,Wilmington,"2200 block of N Washington St",male,N/A,"Adult 18+",N/A
+"June 8, 2021",Delaware,Wilmington,"2200 block of N Washington St",male,N/A,"Adult 18+",N/A
+"June 8, 2021",Delaware,Newark,"50 block of Ethan Allen Ct",male,"James Harland","Adult 18+",N/A
+"June 8, 2021",Delaware,Newark,"50 block of Ethan Allen Ct",male,"Desmond Elliott","Adult 18+",N/A
+"June 7, 2021",Delaware,Dover,"Lingo Dr",female,"Shelva Smith","Adult 18+",N/A
+"June 6, 2021",Delaware,Wilmington,"300 block of W 9th St",male,N/A,"Adult 18+",N/A
+"June 6, 2021",Delaware,Wilmington,"1200 block of W Third St",male,"Ronald Wright","Adult 18+",N/A
+"June 3, 2021",Delaware,Wilmington,"2400 block of N Market St",N/A,N/A,"Adult 18+",N/A
+"June 3, 2021",Delaware,Wilmington,"2400 block of N Market St",N/A,N/A,"Adult 18+",N/A
+"June 3, 2021",Delaware,Wilmington,"2400 block of N Market St",N/A,N/A,"Adult 18+",N/A
+"June 3, 2021",Delaware,Wilmington,"2400 block of N Market St",male,"Bernard Goodwyn","Adult 18+",N/A
+"June 3, 2021",Delaware,Dover,"900 block of Woodcrest Dr",male,N/A,"Adult 18+",N/A
+"June 3, 2021",Delaware,Dover,"900 block of Woodcrest Dr",male,N/A,"Adult 18+",N/A
+"June 2, 2021",Delaware,Belvedere,"300 block of Cedar Ave",male,"Rajohn Hardaway","Adult 18+",N/A
+"June 1, 2021",Delaware,Seaford,"500 block of Clearbrooke Blvd",male,N/A,"Adult 18+",N/A
+"June 1, 2021",Delaware,Wilmington,"600 block of E 10th St",male,N/A,"Adult 18+",N/A
+"June 1, 2021",Delaware,Wilmington,"1100 block of B St",male,N/A,"Adult 18+",N/A
+"May 28, 2021",Delaware,"Wilmington (Edgemoor)","Gordan Ave and Beeson Ave",male,N/A,"Adult 18+",N/A
+"May 26, 2021",Delaware,Hartly,"700 block of Proctors Purchase Rd",male,"John H. Carter III","Adult 18+",N/A
+"May 26, 2021",Delaware,Hartly,"700 block of Proctors Purchase Rd",male,N/A,"Adult 18+",N/A
+"May 25, 2021",Delaware,"New Castle","50 block of Meehan Ave",female,N/A,"Adult 18+",N/A
+"May 24, 2021",Delaware,Wilmington,"201 S Heald St",male,N/A,"Adult 18+",N/A
+"May 24, 2021",Delaware,Wilmington,"201 S Heald St",male,N/A,"Adult 18+",N/A
+"May 22, 2021",Delaware,"New Castle","3900 N DuPont Hwy",male,N/A,"Adult 18+",N/A
+"May 22, 2021",Delaware,"New Castle","3900 N DuPont Hwy",male,N/A,"Adult 18+",N/A
+"May 22, 2021",Delaware,Wilmington,"800 block of N Pine St",female,N/A,"Adult 18+",N/A
+"May 22, 2021",Delaware,Wilmington,"800 block of N Pine St",male,N/A,"Adult 18+",N/A
+"May 22, 2021",Delaware,Wilmington,"800 block of N Pine St",male,N/A,"Adult 18+",N/A
+"May 22, 2021",Delaware,Wilmington,"800 block of N Pine St",female,N/A,"Adult 18+",N/A
+"May 22, 2021",Delaware,Milton,"W Springside Dr",male,"Jerome L. Weathersby","Adult 18+",N/A
+"May 22, 2021",Delaware,Laurel,"30739 Sussex Hwy",male,"Aaron M. Givens","Adult 18+",N/A
+"May 22, 2021",Delaware,Dover,"1014 S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"May 22, 2021",Delaware,Dover,"1014 S Little Creek Rd",male,N/A,"Teen 12-17",N/A
+"May 19, 2021",Delaware,"Wilmington (Edgemoor)","50 block of Le Parc Dr",male,N/A,"Adult 18+",N/A
+"May 18, 2021",Delaware,Frankford,"50 block of Honolulu Rd",male,N/A,"Adult 18+",N/A
+"May 16, 2021",Delaware,Milford,"500 block of Truitt Ave",male,N/A,"Adult 18+",N/A
+"May 16, 2021",Delaware,Milford,"500 block of Truitt Ave",male,N/A,"Adult 18+",N/A
+"May 15, 2021",Delaware,"Wilmington (Elsmere)","900 block of Kirkwood Hwy",female,"Leslie Ruiz-Basilio","Adult 18+",N/A
+"May 15, 2021",Delaware,"Wilmington (Elsmere)","900 block of Kirkwood Hwy",male,"Keith Gibson","Adult 18+",N/A
+"May 14, 2021",Delaware,Bear,"700 Mill Creek Ct",female,N/A,"Adult 18+",N/A
+"May 14, 2021",Delaware,Bear,"700 Mill Creek Ct",male,N/A,"Adult 18+",N/A
+"May 14, 2021",Delaware,Dover,"1534 S Governors Ave",male,N/A,"Adult 18+",N/A
+"May 12, 2021",Delaware,Wilmington,"400 block of W 28th St",male,N/A,"Adult 18+",N/A
+"May 9, 2021",Delaware,Dover,"100 block of S New St",female,N/A,"Adult 18+",N/A
+"May 9, 2021",Delaware,Dover,"100 block of S New St",male,N/A,"Adult 18+",N/A
+"May 6, 2021",Delaware,Dover,N/A,male,"Rahiem Jackson","Adult 18+",N/A
+"May 6, 2021",Delaware,Dover,N/A,female,"Maya Hairston","Adult 18+",N/A
+"May 3, 2021",Delaware,Harrington,"Mill St",male,"Jordan Young","Adult 18+",N/A
+"May 3, 2021",Delaware,Harrington,"Mill St",male,"Jaquan Burton","Adult 18+",N/A
+"May 3, 2021",Delaware,Harrington,"Mill St",male,N/A,"Teen 12-17",N/A
+"May 2, 2021",Delaware,Wilmington,"W 26th St and N Madison St",male,N/A,"Adult 18+",N/A
+"May 1, 2021",Delaware,Wilmington,"800 block of N Pine St",male,N/A,"Adult 18+",N/A
+"May 1, 2021",Delaware,Wilmington,"800 block of N Pine St",female,N/A,"Adult 18+",N/A
+"May 1, 2021",Delaware,Wilmington,"800 block of N Pine St",female,N/A,"Adult 18+",N/A
+"May 1, 2021",Delaware,Wilmington,"800 block of N Pine St",male,N/A,"Adult 18+",N/A
+"April 27, 2021",Delaware,Wilmington,"50 block of W 27th St",male,N/A,"Adult 18+",N/A
+"April 27, 2021",Delaware,Dover,"Kenton Rd and Walker Rd",male,"Rayquian Horsey","Adult 18+",N/A
+"April 27, 2021",Delaware,Dover,"Kenton Rd and Walker Rd",male,"Sadique Ingram","Adult 18+",N/A
+"April 27, 2021",Delaware,Dover,"Kenton Rd and Walker Rd",male,"Lamar Howard","Adult 18+",N/A
+"April 27, 2021",Delaware,Smyrna,"700 Duck Creek Pkwy",female,"Stephanie Gill","Adult 18+",N/A
+"April 27, 2021",Delaware,Smyrna,"700 Duck Creek Pkwy",female,"Deanna Dominick-Dalton","Adult 18+",N/A
+"April 27, 2021",Delaware,Smyrna,"700 Duck Creek Pkwy",male,"Llewellyn Gill","Adult 18+",N/A
+"April 26, 2021",Delaware,Milford,"6000 block of Slaughter Beach Rd",male,N/A,"Adult 18+",N/A
+"April 26, 2021",Delaware,Knollwood,"50 block of Denham Ave",male,"Enfiniti Webb","Adult 18+",N/A
+"April 26, 2021",Delaware,Knollwood,"50 block of Denham Ave",female,N/A,"Adult 18+",N/A
+"April 26, 2021",Delaware,"New Castle","133 S DuPont Hwy",male,N/A,"Adult 18+",N/A
+"April 26, 2021",Delaware,Wilmington,"2200 block of N Pine St",male,N/A,"Adult 18+",N/A
+"April 25, 2021",Delaware,Clayton,"392 Hopewell Dr",female,"Heather L. Truitt","Adult 18+",N/A
+"April 25, 2021",Delaware,Clayton,"392 Hopewell Dr",male,"Raymond C. Bell","Adult 18+",N/A
+"April 25, 2021",Delaware,Clayton,"392 Hopewell Dr",male,"Russell N. Bell","Adult 18+",N/A
+"April 25, 2021",Delaware,Wilmington,"600 block of E 10th St",male,N/A,"Adult 18+",N/A
+"April 24, 2021",Delaware,Bear,"Saint Georges Terrace",male,N/A,"Adult 18+",N/A
+"April 24, 2021",Delaware,Wilmington,"300 block of W 26th St",male,"Ji Air Wing","Adult 18+",N/A
+"April 23, 2021",Delaware,Wilmington,"300 block of Concord Ave",male,"Jermaine Black","Adult 18+",N/A
+"April 23, 2021",Delaware,Wilmington,"300 block of Concord Ave",male,"James McKnight","Adult 18+",N/A
+"April 20, 2021",Delaware,Wilmington,"50 block of Saint John Dr",N/A,N/A,Unknown,N/A
+"April 17, 2021",Delaware,Wilmington,"I-95 and Martin Luther King Jr Blvd",female,N/A,"Adult 18+",N/A
+"April 15, 2021",Delaware,Millsboro,"34000 block of Sports Dr",male,N/A,"Adult 18+",N/A
+"April 15, 2021",Delaware,Millsboro,"34000 block of Sports Dr",male,"Christopher Fedder","Adult 18+",N/A
+"April 15, 2021",Delaware,Wilmington,"400 block of Buttonwood St",male,N/A,"Adult 18+",N/A
+"April 15, 2021",Delaware,Wilmington,"400 block of Buttonwood St",female,N/A,"Teen 12-17",N/A
+"April 14, 2021",Delaware,Dover,"S Little Creek Rd",female,N/A,"Adult 18+",N/A
+"April 14, 2021",Delaware,Dover,"S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"April 14, 2021",Delaware,Wilmington,"2300 block of Carter St",female,N/A,"Adult 18+",N/A
+"April 14, 2021",Delaware,Wilmington,"2300 block of Carter St",male,N/A,"Adult 18+",N/A
+"April 13, 2021",Delaware,Wilmington,"940 N Pine St",female,"Latahesia Hill","Adult 18+",N/A
+"April 13, 2021",Delaware,Wilmington,"940 N Pine St",female,N/A,"Adult 18+",N/A
+"April 13, 2021",Delaware,Wilmington,"940 N Pine St",female,N/A,"Adult 18+",N/A
+"April 12, 2021",Delaware,Wilmington,"600 block of Concord Ave",male,"Amir Collins","Adult 18+",N/A
+"April 12, 2021",Delaware,Dover,"400 block of Sussex Ave",male,"Dazhmier Brooks","Adult 18+",N/A
+"April 12, 2021",Delaware,Dover,"400 block of Sussex Ave",male,"Riley Braswell","Adult 18+",N/A
+"April 7, 2021",Delaware,Laurel,"Daniel St and Wilson St",male,N/A,"Adult 18+",N/A
+"April 7, 2021",Delaware,Laurel,"Daniel St and Wilson St",male,"Antoine Deshields","Adult 18+",N/A
+"April 7, 2021",Delaware,Laurel,"Daniel St and Wilson St",female,"Savanna Fosque","Adult 18+",N/A
+"April 4, 2021",Delaware,Harrington,"100 block of Fox Hunters Rd",male,"Donald C. Spiering","Adult 18+",N/A
+"April 2, 2021",Delaware,Wilmington,"200 block of W 19th St",male,"Larry Porter","Adult 18+",N/A
+"April 2, 2021",Delaware,Wilmington,"200 block of W 19th St",male,"Dean Sutton","Adult 18+",N/A
+"March 31, 2021",Delaware,Milford,"300 Aurora Pl",male,N/A,"Adult 18+",N/A
+"March 31, 2021",Delaware,Milford,"Sandbox Rd and Milford Harrington Hwy",female,"Maricruz Sanchez","Adult 18+",N/A
+"March 30, 2021",Delaware,Wilmington,"200 block of Maryland Ave",male,N/A,"Adult 18+",N/A
+"March 30, 2021",Delaware,Wilmington,"200 block of Maryland Ave",male,"Brennan Velez","Adult 18+",N/A
+"March 29, 2021",Delaware,Wilmington,"Lancaster Ave and Clayton St",female,N/A,"Adult 18+",N/A
+"March 29, 2021",Delaware,Newark,"190 Salem Church Rd",male,N/A,"Teen 12-17",N/A
+"March 29, 2021",Delaware,Wilmington,"400 block of Bradford St",male,N/A,"Adult 18+",N/A
+"March 26, 2021",Delaware,Dover,"200 block of Greenwich Dr",male,N/A,"Adult 18+",N/A
+"March 26, 2021",Delaware,Dover,"200 block of Greenwich Dr",male,"Diondre Williams","Adult 18+",N/A
+"March 25, 2021",Delaware,Seaford,"Danny Dr",female,"Kelly E Rooks","Adult 18+",N/A
+"March 16, 2021",Delaware,Wilmington,"700 block of N Washington St",male,"Demier Chambers","Adult 18+",N/A
+"March 16, 2021",Delaware,Wilmington,"700 block of N Washington St",male,"Treasure Parsons","Adult 18+",N/A
+"March 15, 2021",Delaware,Wilmington,"W 4th St and N Adams St",male,N/A,"Adult 18+",N/A
+"March 15, 2021",Delaware,Wilmington,"W 4th St and N Adams St",male,"Benjamin Cole","Adult 18+",N/A
+"March 13, 2021",Delaware,Newark,"Prospect Ave",male,"Trevor Long","Adult 18+",N/A
+"March 10, 2021",Delaware,Dover,"100 block of Duet Ct",male,N/A,"Adult 18+",N/A
+"March 10, 2021",Delaware,Dover,"100 block of Duet Ct",male,"Antar Gales","Adult 18+",N/A
+"March 10, 2021",Delaware,Dover,"100 block of Duet Ct",male,N/A,"Adult 18+",N/A
+"March 8, 2021",Delaware,Wilmington,"1300 block of E 27th St",male,N/A,"Adult 18+",N/A
+"March 7, 2021",Delaware,Wilmington,"200 block of Cherry St",male,"Franklin Lloyd","Adult 18+",N/A
+"March 1, 2021",Delaware,Wilmington,"W 26th St and Northeast Blvd",male,N/A,"Adult 18+",N/A
+"February 28, 2021",Delaware,Dover,"4115 N DuPont Hwy",male,N/A,"Adult 18+",N/A
+"February 28, 2021",Delaware,Dover,"4115 N DuPont Hwy",male,N/A,"Adult 18+",N/A
+"February 28, 2021",Delaware,Dover,"4115 N DuPont Hwy",male,N/A,"Adult 18+",N/A
+"February 28, 2021",Delaware,Dover,"4115 N DuPont Hwy",male,N/A,"Adult 18+",N/A
+"February 28, 2021",Delaware,Dover,"4115 N DuPont Hwy",male,N/A,"Adult 18+",N/A
+"February 28, 2021",Delaware,Dover,"21 S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"February 28, 2021",Delaware,Dover,"21 S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"February 28, 2021",Delaware,Dover,"21 S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"February 28, 2021",Delaware,Dover,"21 S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"February 28, 2021",Delaware,Dover,"21 S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"February 28, 2021",Delaware,Dover,"21 S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"February 26, 2021",Delaware,Wilmington,"101 Clifton Park Cir",male,N/A,Unknown,N/A
+"February 26, 2021",Delaware,Wilmington,"600 block of E 22nd St",female,"Levonne Kellam","Adult 18+",N/A
+"February 26, 2021",Delaware,Wilmington,"600 block of E 22nd St",female,N/A,"Adult 18+",N/A
+"February 23, 2021",Delaware,Dover,"100 block of Mifflin Rd",male,"Zackary Hobbs","Adult 18+",N/A
+"February 23, 2021",Delaware,Georgetown,"Tranquility Ln",male,"Ryan Crater","Adult 18+",N/A
+"February 23, 2021",Delaware,Georgetown,"Tranquility Ln",male,"Samuel Senecharles","Adult 18+",N/A
+"February 23, 2021",Delaware,Georgetown,"Tranquility Ln",male,"Jahiem Godwin","Adult 18+",N/A
+"February 23, 2021",Delaware,Georgetown,"Tranquility Ln",male,"Brandon Gibbs","Adult 18+",N/A
+"February 21, 2021",Delaware,Wilmington,"500 block of E 6th St",female,N/A,"Adult 18+",N/A
+"February 21, 2021",Delaware,Wilmington,"2900 block of Bowers St",male,N/A,"Adult 18+",N/A
+"February 19, 2021",Delaware,Middletown,"Naughty Ln and Vincent Cir",male,"James Ashley","Adult 18+",N/A
+"February 18, 2021",Delaware,Milford,"400 block of North St",male,N/A,"Adult 18+",N/A
+"February 18, 2021",Delaware,Seaford,"Woodland Dr",female,"Melanie P. Passwaters","Adult 18+",N/A
+"February 16, 2021",Delaware,"Newark (Christiana)","1200 block of Flanders Way",male,N/A,"Adult 18+",N/A
+"February 15, 2021",Delaware,Wilmington,"W 10th St and N Madison St",male,N/A,"Adult 18+",N/A
+"February 15, 2021",Delaware,Wilmington,"W 10th St and N Madison St",male,N/A,"Adult 18+",N/A
+"February 13, 2021",Delaware,Dover,"400 block of River Rd",male,N/A,"Adult 18+",N/A
+"February 13, 2021",Delaware,Dover,"400 block of River Rd",male,"Allen Durham","Adult 18+",N/A
+"February 12, 2021",Delaware,Newark,"50 block of Carlisle Rd",male,"Zyitae Britt","Adult 18+",N/A
+"February 12, 2021",Delaware,Newark,"50 block of Carlisle Rd",male,"Elijah Covington","Adult 18+",N/A
+"February 8, 2021",Delaware,Wilmington,"800 block of W 4th St",male,N/A,"Adult 18+",N/A
+"February 7, 2021",Delaware,Wilmington,"C St and Townsend St",male,N/A,"Adult 18+",N/A
+"February 6, 2021",Delaware,Newark,"1119 S College Ave",male,"Carlos Vasquez","Adult 18+",N/A
+"February 6, 2021",Delaware,Newark,"1119 S College Ave",male,"Abian Plenty","Adult 18+",N/A
+"February 6, 2021",Delaware,Newark,"1119 S College Ave",male,N/A,"Adult 18+",N/A
+"February 4, 2021",Delaware,Wilmington,"600 block of W 27th St",male,N/A,"Teen 12-17",N/A
+"February 4, 2021",Delaware,Wilmington,"2800 block of N Claymont St",male,N/A,"Adult 18+",N/A
+"February 2, 2021",Delaware,"New Castle","50 block of Birkshire Rd",male,N/A,"Adult 18+",N/A
+"January 30, 2021",Delaware,Claymont,"50 block of 3rd Ave",female,"Tanasia Rollins-Townsend","Adult 18+",N/A
+"January 29, 2021",Delaware,Wilmington,"900 block of N Spruce St",male,"Damond Emory","Adult 18+",N/A
+"January 27, 2021",Delaware,Felton,"3100 block of Abec Ln",male,"Alonzo Morris Sr.","Adult 18+",N/A
+"January 25, 2021",Delaware,Wilmington,"Concord Plaza and Silverside Rd",male,N/A,"Adult 18+",N/A
+"January 24, 2021",Delaware,"New Castle","50 block of Highland Blvd",male,N/A,"Adult 18+",N/A
+"January 24, 2021",Delaware,"New Castle","50 block of Highland Blvd",male,N/A,"Adult 18+",N/A
+"January 24, 2021",Delaware,"New Castle","50 block of Highland Blvd",male,N/A,"Adult 18+",N/A
+"January 24, 2021",Delaware,Wilmington,"100 block of E 24th St",male,N/A,"Adult 18+",N/A
+"January 23, 2021",Delaware,Newark,"41 Winterhaven Dr",male,N/A,"Adult 18+",N/A
+"January 23, 2021",Delaware,Newark,"41 Winterhaven Dr",male,N/A,"Adult 18+",N/A
+"January 23, 2021",Delaware,Seaford,"Park Cir",male,"Kwantae Hovington","Adult 18+",N/A
+"January 20, 2021",Delaware,Wilmington,"E 8th St and N Pine St",male,N/A,"Teen 12-17",N/A
+"January 20, 2021",Delaware,Wilmington,"E 8th St and N Pine St",male,N/A,"Adult 18+",N/A
+"January 20, 2021",Delaware,Wilmington,"E 8th St and N Pine St",male,N/A,"Adult 18+",N/A
+"January 18, 2021",Delaware,"New Castle","1213 West Ave",male,"Malik Gordon","Adult 18+",N/A
+"January 16, 2021",Delaware,Wilmington,"1100 block of W 5th St",male,N/A,"Adult 18+",N/A
+"January 16, 2021",Delaware,Wilmington,"1100 block of W 5th St",male,"Luis Torres","Adult 18+",N/A
+"January 14, 2021",Delaware,Wilmington,"800 block of W 8th St",male,N/A,"Adult 18+",N/A
+"January 13, 2021",Delaware,Wilmington,"800 block of N Monroe St",male,"Nahshon Archie-Eatmon","Adult 18+",N/A
+"January 13, 2021",Delaware,Wilmington,"800 block of N Monroe St",male,N/A,"Adult 18+",N/A
+"January 13, 2021",Delaware,Wilmington,"Rosemont Ave and E 24th St",male,"Lymond Moses","Adult 18+",N/A
+"January 12, 2021",Delaware,Newark,"132 Christiana Mall",male,N/A,"Adult 18+",N/A
+"January 12, 2021",Delaware,Newark,"132 Christiana Mall",male,"Raesheed Deshields","Adult 18+",N/A
+"January 11, 2021",Delaware,Wilmington,"2800 block of N Claymont St",male,"Ismail Drummond","Adult 18+",N/A
+"January 10, 2021",Delaware,Wilmington,"1050 S Market St",male,"Nigel Thomas","Adult 18+",N/A
+"January 7, 2021",Delaware,Newark,"402 Ogletown Rd",male,N/A,"Adult 18+",N/A
+"January 7, 2021",Delaware,Newark,"402 Ogletown Rd",female,N/A,"Adult 18+",N/A
+"January 7, 2021",Delaware,Felton,"Sandtown Rd",male,"Robert H. Field III","Adult 18+",N/A
+"January 4, 2021",Delaware,Wilmington,"W 7th St and Washington St",male,N/A,"Adult 18+",N/A
+"January 4, 2021",Delaware,Dover,"2600 block of Stevenson Dr",male,N/A,"Adult 18+",N/A
+"January 4, 2021",Delaware,Dover,"2600 block of Stevenson Dr",male,N/A,"Teen 12-17",N/A
+"January 3, 2021",Delaware,Dover,"1426 N DuPont Hwy",female,N/A,"Adult 18+",N/A
+"January 3, 2021",Delaware,Dover,"1426 N DuPont Hwy",male,"Tyrone Allison","Adult 18+",N/A
+"January 2, 2021",Delaware,Wilmington,"2900 block of Northeast Blvd",male,N/A,"Adult 18+",N/A
+"January 1, 2021",Delaware,Newark,"415 Stanton Christiana Rd",male,N/A,"Adult 18+",N/A
+"December 31, 2020",Delaware,Wilmington,"E 8th St and N Pine St",male,N/A,"Adult 18+",N/A
+"December 31, 2020",Delaware,Milton,"506 Union St",male,"Mark A. Gratton","Adult 18+",N/A
+"December 31, 2020",Delaware,Milton,"506 Union St",female,N/A,"Adult 18+",N/A
+"December 31, 2020",Delaware,Dover,"100 block of Spruance Rd",male,N/A,"Adult 18+",N/A
+"December 31, 2020",Delaware,Dover,"100 block of Spruance Rd",male,N/A,"Adult 18+",N/A
+"December 30, 2020",Delaware,Viola,"201 E Evens Dr",male,"Ronald Cochran","Adult 18+",N/A
+"December 30, 2020",Delaware,Wilmington,"500 block of E 8th St",male,N/A,"Teen 12-17",N/A
+"December 27, 2020",Delaware,Dover,"100 block of S New St",male,N/A,"Adult 18+",N/A
+"December 26, 2020",Delaware,Wilmington,"E 35th St and N Locust St",male,"Ryjee Pinkney","Adult 18+",N/A
+"December 25, 2020",Delaware,Houston,"Williamsville Rd",male,"Dustin Edge","Adult 18+",N/A
+"December 25, 2020",Delaware,Dover,"820 Carvel Dr",male,"Jermaine Scott","Adult 18+",N/A
+"December 24, 2020",Delaware,"Rehoboth Beach","100 block of Beachfield Dr",N/A,N/A,Unknown,N/A
+"December 21, 2020",Delaware,"New Castle","3000 block of New Castle Ave",male,N/A,"Adult 18+",N/A
+"December 21, 2020",Delaware,"New Castle","3000 block of New Castle Ave",male,N/A,"Adult 18+",N/A
+"December 21, 2020",Delaware,Wilmington,"200 block of N Dupont St",male,"Michael Parker","Adult 18+",N/A
+"December 19, 2020",Delaware,Dover,"S Queen St and Reed St",male,N/A,"Adult 18+",N/A
+"December 19, 2020",Delaware,Dover,"461 N DuPont Hwy",male,"Joshua Brown","Adult 18+",N/A
+"December 18, 2020",Delaware,Townsend,"Union Church Rd",male,"Andrew Parsons","Adult 18+",N/A
+"December 18, 2020",Delaware,"New Castle","1 Delaware St",male,"William Booker","Adult 18+",N/A
+"December 17, 2020",Delaware,Newark,"200 block of E Main St",male,N/A,"Adult 18+",N/A
+"December 17, 2020",Delaware,Newark,"200 block of E Main St",male,N/A,"Adult 18+",N/A
+"December 14, 2020",Delaware,"New Castle","50 block of Bristol Way",male,"Robert Wright","Adult 18+",N/A
+"December 13, 2020",Delaware,Newark,"50 block of Todd Ln",female,N/A,"Adult 18+",N/A
+"December 13, 2020",Delaware,Middletown,"E Lake St and Jefferson St",male,"Quentin Rutherford","Adult 18+",N/A
+"December 12, 2020",Delaware,"Wilmington (Edgemoor)","Polk Rd and S Rodney Dr",female,N/A,"Adult 18+",N/A
+"December 12, 2020",Delaware,Claymont,"I-95 and Harvey Rd",male,N/A,"Teen 12-17",N/A
+"December 12, 2020",Delaware,Claymont,"I-95 and Harvey Rd",male,N/A,"Teen 12-17",N/A
+"December 12, 2020",Delaware,Newark,"39 Fairway Rd",male,"Allen Huff","Adult 18+",N/A
+"December 12, 2020",Delaware,Newark,"39 Fairway Rd",female,"Iris Longakit","Adult 18+",N/A
+"December 11, 2020",Delaware,"New Castle","117 Wilton Blvd",female,N/A,"Adult 18+",N/A
+"December 10, 2020",Delaware,"Rehoboth Beach","19540 Coastal Hwy",male,"Senior Cpl. Timothy “TJ” Webb","Adult 18+",N/A
+"December 10, 2020",Delaware,"Rehoboth Beach","19540 Coastal Hwy",male,"Evelio Rivera","Adult 18+",N/A
+"December 10, 2020",Delaware,"New Castle","Boulden Blvd and Boulden Cir",male,N/A,"Adult 18+",N/A
+"December 10, 2020",Delaware,"New Castle","Boulden Blvd and Boulden Cir",male,N/A,"Adult 18+",N/A
+"December 10, 2020",Delaware,"New Castle","Boulden Blvd and Boulden Cir",male,N/A,"Adult 18+",N/A
+"December 10, 2020",Delaware,Wilmington,"300 block of E 23rd St",male,"Michael Reams","Adult 18+",N/A
+"December 10, 2020",Delaware,Wilmington,"300 block of E 23rd St",male,"Dashan Perrigan","Adult 18+",N/A
+"December 10, 2020",Delaware,"New Castle","100 block of Rose Ln",male,"Dakevis Reed","Adult 18+",N/A
+"December 10, 2020",Delaware,"New Castle","100 block of Rose Ln",male,N/A,"Teen 12-17",N/A
+"December 9, 2020",Delaware,Newark,"I-95 and Churchmans Rd",male,N/A,"Adult 18+",N/A
+"December 9, 2020",Delaware,Wilmington,"100 block of Stroud St",male,N/A,"Adult 18+",N/A
+"December 9, 2020",Delaware,Wilmington,"100 block of Stroud St",male,N/A,"Teen 12-17",N/A
+"December 9, 2020",Delaware,Wilmington,"100 block of Stroud St",male,N/A,"Teen 12-17",N/A
+"December 7, 2020",Delaware,Newark,"800 block of Library Ave",female,N/A,"Adult 18+",N/A
+"December 6, 2020",Delaware,Newark,"Church St",male,N/A,"Adult 18+",N/A
+"December 6, 2020",Delaware,Newark,"Church St",male,N/A,"Adult 18+",N/A
+"December 5, 2020",Delaware,Seaford,"400 block of North St",male,N/A,"Adult 18+",N/A
+"December 4, 2020",Delaware,Bridgeville,"21000 block of Mill Park Dr",male,N/A,"Adult 18+",N/A
+"December 4, 2020",Delaware,Bridgeville,"21000 block of Mill Park Dr",male,"Kasandan Clanton","Adult 18+",N/A
+"December 3, 2020",Delaware,Seaford,"400 block of North St",male,N/A,"Adult 18+",N/A
+"December 3, 2020",Delaware,Seaford,"400 block of North St",male,N/A,"Adult 18+",N/A
+"December 2, 2020",Delaware,Wilmington,"W 6th St and Willing St",male,"Kyree Harris","Adult 18+",N/A
+"November 30, 2020",Delaware,Wilmington,"1700 block of Conrad St",male,N/A,"Adult 18+",N/A
+"November 29, 2020",Delaware,"New Castle","Arbor Ave and Chesterfield Dr",female,N/A,"Adult 18+",N/A
+"November 29, 2020",Delaware,"New Castle","Arbor Ave and Chesterfield Dr",male,"Eddie Johnson","Adult 18+",N/A
+"November 29, 2020",Delaware,"New Castle","Arbor Ave and Chesterfield Dr",male,"Vincent Young","Adult 18+",N/A
+"November 29, 2020",Delaware,Wilmington,"2700 block of Northeast Blvd",male,N/A,"Teen 12-17",N/A
+"November 28, 2020",Delaware,Dagsboro,"31000 block of Country Gardens",male,N/A,"Adult 18+",N/A
+"November 28, 2020",Delaware,Wilmington,"600 block of New Castle Ave",male,N/A,"Adult 18+",N/A
+"November 27, 2020",Delaware,Georgetown,"14000 block of Old Furnace Rd",male,N/A,"Adult 18+",N/A
+"November 26, 2020",Delaware,"New Castle","1500 block of Stonebridge Blvd",male,N/A,"Adult 18+",N/A
+"November 26, 2020",Delaware,Wilmington,"500 block of E 9th St",male,N/A,"Adult 18+",N/A
+"November 25, 2020",Delaware,Wilmington,"600 block of N Jefferson St",male,"Gregory Wing","Adult 18+",N/A
+"November 22, 2020",Delaware,Dover,"800 block of S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"November 21, 2020",Delaware,Middletown,"New St and Cole Blvd",male,"Hakeem Evans","Adult 18+",N/A
+"November 20, 2020",Delaware,Wilmington,"9th St and Kirkwood St",male,N/A,"Adult 18+",N/A
+"November 18, 2020",Delaware,Wilmington,"2400 block of N Market St",male,N/A,"Teen 12-17",N/A
+"November 15, 2020",Delaware,"New Castle","Ashley Dr",male,N/A,"Adult 18+",N/A
+"November 15, 2020",Delaware,"New Castle","Ashley Dr",male,N/A,"Teen 12-17",N/A
+"November 15, 2020",Delaware,"New Castle","Ashley Dr",male,N/A,"Teen 12-17",N/A
+"November 14, 2020",Delaware,"New Castle","Estates Dr and Conlin Ct",male,"Qasim Felder","Adult 18+",N/A
+"November 13, 2020",Delaware,Dover,"Stevenson Dr",male,N/A,"Adult 18+",N/A
+"November 12, 2020",Delaware,Bear,"3601 Wrangle Hill Rd",male,"Jordan Smith","Adult 18+",N/A
+"November 11, 2020",Delaware,Wilmington,"100 block of W 23rd St",male,N/A,"Adult 18+",N/A
+"November 6, 2020",Delaware,Bear,"Buckley Blvd and Pulaski Hwy",male,N/A,"Adult 18+",N/A
+"November 4, 2020",Delaware,"New Castle","50 block of Rose Ln",male,N/A,"Adult 18+",N/A
+"November 4, 2020",Delaware,"New Castle","50 block of Rose Ln",male,N/A,"Child 0-11",N/A
+"November 4, 2020",Delaware,Wilmington,"800 block of N Pine St",male,N/A,"Teen 12-17",N/A
+"October 31, 2020",Delaware,Georgetown,"22518 Lewes-Georgetown Hwy",male,"Jacob Sprout","Adult 18+",N/A
+"October 31, 2020",Delaware,Dover,"100 block of Cherry St",male,"Charles Blackstock-Stansbury","Adult 18+",N/A
+"October 29, 2020",Delaware,Wilmington,"1300 block of E 24th St",male,N/A,"Adult 18+",N/A
+"October 28, 2020",Delaware,Selbyville,"Lincoln St",male,"Demetrius Jenkins","Adult 18+",N/A
+"October 28, 2020",Delaware,Dover,"W Division St and S West St",male,"Christin Brown","Adult 18+",N/A
+"October 27, 2020",Delaware,Wilmington,"300 block of W 7th St",male,N/A,"Adult 18+",N/A
+"October 25, 2020",Delaware,Wilmington,"1100 block of N Heald St",male,"Eddie Green","Adult 18+",N/A
+"October 25, 2020",Delaware,Wilmington,"2300 block of N Pine St",male,"Raquan Davis","Adult 18+",N/A
+"October 24, 2020",Delaware,Wilmington,"900 block of N Pine St",male,N/A,"Adult 18+",N/A
+"October 24, 2020",Delaware,Wilmington,"900 block of N Pine St",female,"Yazmyn Stewart","Adult 18+",N/A
+"October 24, 2020",Delaware,Wilmington,"700 block of N Madison St",male,N/A,"Teen 12-17",N/A
+"October 24, 2020",Delaware,Newark,"22 Marrows Rd",male,"Melvin Collins","Adult 18+",N/A
+"October 24, 2020",Delaware,Newark,"22 Marrows Rd",male,N/A,"Adult 18+",N/A
+"October 22, 2020",Delaware,Wilmington,"1400 block of N Harrison St",male,"Alexander Grier","Adult 18+",N/A
+"October 20, 2020",Delaware,Bear,"1100 Pulaski Hwy",male,"Daniel Haye","Adult 18+",N/A
+"October 20, 2020",Delaware,Bear,"1100 Pulaski Hwy",male,"Troy E. Waller Jr","Adult 18+",N/A
+"October 20, 2020",Delaware,"Wilmington (Edgemoor)","1000 block of Westlawn Ct",male,"Theodore Milner","Adult 18+",N/A
+"October 20, 2020",Delaware,"Wilmington (Edgemoor)","1000 block of Westlawn Ct",male,"Keshon Phipps","Adult 18+",N/A
+"October 20, 2020",Delaware,"Wilmington (Edgemoor)","1000 block of Westlawn Ct",male,"Dajuan Samuel","Adult 18+",N/A
+"October 20, 2020",Delaware,Laurel,"701 Little Creek Dr",female,N/A,"Adult 18+",N/A
+"October 20, 2020",Delaware,Laurel,"701 Little Creek Dr",male,"Otis E. Williams","Adult 18+",N/A
+"October 16, 2020",Delaware,Milford,"200 block of SE 2nd St",male,"Brandt Craft","Adult 18+",N/A
+"October 15, 2020",Delaware,Dover,"Steel Rd",male,"Dustin Ellsworth","Adult 18+",N/A
+"October 14, 2020",Delaware,Wilmington,"N 22nd St and E Church St",male,N/A,"Adult 18+",N/A
+"October 11, 2020",Delaware,Wilmington,"700 block of E 10th St",male,"Tommier Dendy","Adult 18+",N/A
+"October 10, 2020",Delaware,Townsend,"Harvey Straughn Rd",male,"Nicholas Turcol","Adult 18+",N/A
+"October 9, 2020",Delaware,"Wilmington (Edgemoor)","Haines Ave",male,N/A,"Adult 18+",N/A
+"October 9, 2020",Delaware,Smyrna,"Wheatleys Pond Rd",N/A,N/A,"Adult 18+",N/A
+"October 9, 2020",Delaware,Smyrna,"Wheatleys Pond Rd",male,N/A,Unknown,N/A
+"October 9, 2020",Delaware,Wilmington,"1300 block of E 29th St",male,N/A,"Adult 18+",N/A
+"October 9, 2020",Delaware,Wilmington,"1300 block of E 29th St",male,N/A,"Adult 18+",N/A
+"October 9, 2020",Delaware,Wilmington,"1300 block of E 29th St",male,N/A,"Adult 18+",N/A
+"October 9, 2020",Delaware,Millsboro,"Screenhouse Ln",male,"Linwood Shields","Adult 18+",N/A
+"October 9, 2020",Delaware,Milton,"20800 block of W Springside Dr",male,"Djuan Sheppard","Adult 18+",N/A
+"October 8, 2020",Delaware,Milford,"902 N Dupont Blvd",male,"Kareem V Williams","Adult 18+",N/A
+"October 7, 2020",Delaware,Wilmington,"E 24th St and Lamotte St",male,N/A,"Adult 18+",N/A
+"October 7, 2020",Delaware,Wilmington,"E 24th St and Lamotte St",male,N/A,"Adult 18+",N/A
+"October 6, 2020",Delaware,Wilmington,"2300 block of Jessup St",male,N/A,"Adult 18+",N/A
+"October 4, 2020",Delaware,Wilmington,"1300 block of W 5th St",male,N/A,"Adult 18+",N/A
+"October 2, 2020",Delaware,"New Castle","4010 N Dupont Hwy",male,"Tymir Mason","Adult 18+",N/A
+"October 2, 2020",Delaware,"New Castle","4010 N Dupont Hwy",male,"Malik X. Miller","Adult 18+",N/A
+"October 2, 2020",Delaware,Newark,"140 Pencader Plaza",male,"Daniel W Mopkins","Adult 18+",N/A
+"October 2, 2020",Delaware,Dover,"200 block of David Hall Rd",male,"Shakur A. Burrage","Adult 18+",N/A
+"October 2, 2020",Delaware,Dover,"200 block of David Hall Rd",male,"Deon’te Reaves","Adult 18+",N/A
+"September 30, 2020",Delaware,Wilmington,"400 block of Morehouse Dr",male,N/A,"Adult 18+",N/A
+"September 30, 2020",Delaware,"Newark (Christiana)","410 Eagle Run Rd",male,N/A,"Adult 18+",N/A
+"September 28, 2020",Delaware,Wilmington,"1200 block of Pleasant St",male,N/A,"Adult 18+",N/A
+"September 27, 2020",Delaware,Dover,"100 block of Willis Rd",male,"Samuel Orton","Adult 18+",N/A
+"September 27, 2020",Delaware,Dover,"100 block of Willis Rd",male,"Daeron May","Adult 18+",N/A
+"September 27, 2020",Delaware,Dover,"100 Electric Ave",male,"Devin Wright","Adult 18+",N/A
+"September 27, 2020",Delaware,Dover,"100 Electric Ave",male,N/A,"Adult 18+",N/A
+"September 26, 2020",Delaware,Dover,"700 block of Forest St",male,N/A,"Adult 18+",N/A
+"September 26, 2020",Delaware,Wilmington,"50 block of 9th Ave",male,"Mayveon McGriff","Adult 18+",N/A
+"September 24, 2020",Delaware,Wilmington,"3408 Lancaster Pike",male,"Michael Hastings","Adult 18+",N/A
+"September 24, 2020",Delaware,Wilmington,"1100 block of Maryland Ave",male,N/A,"Adult 18+",N/A
+"September 23, 2020",Delaware,Wilmington,"1022 Delaware Ave",male,"Shareef Hamilton","Adult 18+",N/A
+"September 23, 2020",Delaware,Wilmington,"800 block of W 7th St",male,N/A,"Adult 18+",N/A
+"September 23, 2020",Delaware,Wilmington,"4817 Governor Printz Blvd",male,N/A,"Teen 12-17",N/A
+"September 23, 2020",Delaware,Wilmington,"4817 Governor Printz Blvd",male,N/A,"Adult 18+",N/A
+"September 23, 2020",Delaware,Wilmington,"4817 Governor Printz Blvd",male,N/A,"Adult 18+",N/A
+"September 22, 2020",Delaware,Wilmington,"2400 block of N Tatnall St",male,N/A,"Adult 18+",N/A
+"September 22, 2020",Delaware,Wilmington,"2400 block of N Tatnall St",male,N/A,"Adult 18+",N/A
+"September 20, 2020",Delaware,"Wilmington (Elsmere)","50 block of Tamarack Ave",male,N/A,"Adult 18+",N/A
+"September 20, 2020",Delaware,"Wilmington (Elsmere)","50 block of Tamarack Ave",male,N/A,"Adult 18+",N/A
+"September 19, 2020",Delaware,Smyrna,"Woodland Beach Rd",male,"Elliott Glover","Adult 18+",N/A
+"September 19, 2020",Delaware,Newark,"N Thistle Way",male,"Khairon Edwards","Adult 18+",N/A
+"September 18, 2020",Delaware,Newark,"900 Churchmans Rd",male,"Jesus Martinez","Adult 18+",N/A
+"September 16, 2020",Delaware,Milford,"300 Aurora Pl",male,"Mario Satirin","Adult 18+",N/A
+"September 15, 2020",Delaware,Wilmington,"600 block of N Lincoln St",male,N/A,"Adult 18+",N/A
+"September 15, 2020",Delaware,Wilmington,"600 block of N Lincoln St",male,N/A,"Adult 18+",N/A
+"September 14, 2020",Delaware,Wilmington,"Vandever Ave and N Locust St",male,"Damar Smith","Adult 18+",N/A
+"September 13, 2020",Delaware,Wilmington,"1700 block of Tulip St",male,"Calvin Peterson","Adult 18+",N/A
+"September 12, 2020",Delaware,Wilmington,"Pine St and Taylor St",male,N/A,"Adult 18+",N/A
+"September 12, 2020",Delaware,Wilmington,"200 block of S Harrison St",male,"Taquan Davis","Adult 18+",N/A
+"September 12, 2020",Delaware,Wilmington,"500 block of S Locust St",male,N/A,"Adult 18+",N/A
+"September 12, 2020",Delaware,Wilmington,"E 23rd St and Pine St",male,N/A,"Adult 18+",N/A
+"September 12, 2020",Delaware,Smyrna,"100 block of Lincoln St",female,N/A,"Adult 18+",N/A
+"September 12, 2020",Delaware,Smyrna,"100 block of Lincoln St",male,N/A,"Adult 18+",N/A
+"September 10, 2020",Delaware,Dover,"100 block of Willis Rd",N/A,N/A,Unknown,N/A
+"September 10, 2020",Delaware,Dover,"100 block of Willis Rd",male,"Alexander Singletary","Teen 12-17",N/A
+"September 9, 2020",Delaware,Wilmington,"4800 block of Governor Printz Blvd",male,N/A,"Adult 18+",N/A
+"September 9, 2020",Delaware,Wilmington,"3400 block of Church St",male,"Namir Brown-Sullivan","Adult 18+",N/A
+"September 9, 2020",Delaware,Wilmington,"3400 block of Church St",male,"Khiry Clark","Adult 18+",N/A
+"September 8, 2020",Delaware,Wilmington,"1000 block of W 7th St",male,N/A,"Adult 18+",N/A
+"September 8, 2020",Delaware,Wilmington,"500 block of Pine St",male,"Olleir Henry","Teen 12-17",N/A
+"September 6, 2020",Delaware,Dover,"1210 White Oak Rd",male,N/A,"Adult 18+",N/A
+"September 6, 2020",Delaware,Dover,"1210 White Oak Rd",male,"Devone Humphrey","Adult 18+",N/A
+"September 5, 2020",Delaware,Wilmington,"600 block of W 5th St",male,N/A,"Adult 18+",N/A
+"September 3, 2020",Delaware,Wilmington,"100 block of W 40th St",male,N/A,"Adult 18+",N/A
+"September 3, 2020",Delaware,Wilmington,"100 block of W 40th St",male,N/A,"Adult 18+",N/A
+"September 2, 2020",Delaware,Wilmington,"200 block of N Madison St",male,N/A,"Adult 18+",N/A
+"September 2, 2020",Delaware,Bear,"711 Pulaski Hwy",male,"Corey Washington","Adult 18+",N/A
+"September 2, 2020",Delaware,Bear,"711 Pulaski Hwy",male,"Zavriel Watters","Adult 18+",N/A
+"September 1, 2020",Delaware,Wilmington,"1500 block of W 7th St",male,"Ronald Rathel","Adult 18+",N/A
+"September 1, 2020",Delaware,Dover,"300 Isabelle Isle",male,N/A,"Adult 18+",N/A
+"August 31, 2020",Delaware,Wilmington,"700 block of Jefferson St",female,N/A,"Child 0-11",N/A
+"August 30, 2020",Delaware,Wilmington,"1500 block of W 3rd St",female,N/A,"Adult 18+",N/A
+"August 30, 2020",Delaware,Wilmington,"1500 block of W 3rd St",male,N/A,"Adult 18+",N/A
+"August 30, 2020",Delaware,Claymont,"50 block of N Avon Dr",male,N/A,"Adult 18+",N/A
+"August 30, 2020",Delaware,Wilmington,"800 block of N Monroe St",male,N/A,"Adult 18+",N/A
+"August 28, 2020",Delaware,Wilmington,"1100 block of W 2nd St",male,N/A,"Adult 18+",N/A
+"August 28, 2020",Delaware,Wilmington,"1000 block of Shallcross Ave",male,"Oreese Young","Adult 18+",N/A
+"August 28, 2020",Delaware,Wilmington,"1000 block of Shallcross Ave",female,"Malinda Purnell","Adult 18+",N/A
+"August 28, 2020",Delaware,Wilmington,"1000 block of Shallcross Ave",male,"Donyel Starkey","Adult 18+",N/A
+"August 28, 2020",Delaware,Wilmington,"1000 block of Shallcross Ave",male,"Richard Mathis","Adult 18+",N/A
+"August 27, 2020",Delaware,Ellendale,"12000 block of N Old State Rd",male,"Qualeel Westcott","Adult 18+",N/A
+"August 27, 2020",Delaware,Wilmington,"800 block of Tatnall St",male,N/A,"Adult 18+",N/A
+"August 27, 2020",Delaware,Wilmington,"3209 Miller Rd",female,N/A,"Adult 18+",N/A
+"August 27, 2020",Delaware,Wilmington,"3209 Miller Rd",male,N/A,"Adult 18+",N/A
+"August 26, 2020",Delaware,Dover,"642 S Queen St",male,"Eric Sartin","Adult 18+",N/A
+"August 24, 2020",Delaware,Wilmington,"Edgemoor Rd and Marsh Rd",male,N/A,"Teen 12-17",N/A
+"August 24, 2020",Delaware,Wilmington,"Edgemoor Rd and Marsh Rd",male,N/A,"Adult 18+",N/A
+"August 23, 2020",Delaware,Wilmington,"50 block of E 24th St",male,N/A,"Adult 18+",N/A
+"August 23, 2020",Delaware,Wilmington,"50 block of E 24th St",male,"Jimvonte Chrisden","Adult 18+",N/A
+"August 23, 2020",Delaware,Wilmington,"50 block of E 24th St",male,N/A,"Adult 18+",N/A
+"August 23, 2020",Delaware,Wilmington,"700 block of E 10th St",male,N/A,"Adult 18+",N/A
+"August 23, 2020",Delaware,Wilmington,"700 block of E 10th St",male,"Jimvonte Chrisden","Adult 18+",N/A
+"August 23, 2020",Delaware,Wilmington,"W 7th St and West St",male,"Maurice Brown","Adult 18+",N/A
+"August 23, 2020",Delaware,Wilmington,"W 7th St and West St",female,"Mona Matthews","Adult 18+",N/A
+"August 22, 2020",Delaware,Newark,"240 Chapman Rd",male,N/A,"Adult 18+",N/A
+"August 21, 2020",Delaware,Seaford,"700 block of Collins Ave",N/A,N/A,Unknown,N/A
+"August 21, 2020",Delaware,Seaford,"700 block of Collins Ave",N/A,N/A,Unknown,N/A
+"August 21, 2020",Delaware,Dover,"805 S Governors Ave",male,"Jerome Aniska","Adult 18+",N/A
+"August 21, 2020",Delaware,Wilmington,"700 block of N Washington St",male,N/A,"Adult 18+",N/A
+"August 19, 2020",Delaware,"Wilmington (Edgemoor)","Rysing Dr and Polk Rd",female,"Alexis Delcoco","Adult 18+",N/A
+"August 19, 2020",Delaware,"Wilmington (Edgemoor)","Rysing Dr and Polk Rd",male,N/A,"Adult 18+",N/A
+"August 15, 2020",Delaware,Dover,"411 S Queen St",female,"Tiffany Burkett","Adult 18+",N/A
+"August 15, 2020",Delaware,Wilmington,"1300 block of E 29th St",male,"James Brown","Adult 18+",N/A
+"August 15, 2020",Delaware,Wilmington,"2500 block of N Tatnall St",male,N/A,"Adult 18+",N/A
+"August 11, 2020",Delaware,Wilmington,"2400 block of Washington St",male,N/A,"Adult 18+",N/A
+"August 11, 2020",Delaware,Magnolia,"50 block of Cherry Dr W",male,N/A,"Adult 18+",N/A
+"August 10, 2020",Delaware,Wilmington,"800 block of N Pine St",male,"Taron Whaley","Teen 12-17",N/A
+"August 10, 2020",Delaware,Wilmington,"800 block of N Pine St",male,N/A,"Adult 18+",N/A
+"August 10, 2020",Delaware,Newark,"100 block of W Main St",male,N/A,"Adult 18+",N/A
+"August 10, 2020",Delaware,Newark,"100 block of W Main St",male,N/A,"Adult 18+",N/A
+"August 8, 2020",Delaware,Seaford,"22588 Bridgeville Hwy",male,"Jeffrey L. Akins Jr","Adult 18+",N/A
+"August 8, 2020",Delaware,Seaford,"22588 Bridgeville Hwy",male,"Unique Smith","Adult 18+",N/A
+"August 7, 2020",Delaware,Wilmington,"E 24th St and Carter St",male,N/A,"Adult 18+",N/A
+"August 7, 2020",Delaware,Wilmington,"W 29th St and Washington St",male,N/A,"Adult 18+",N/A
+"August 6, 2020",Delaware,Wilmington,"2300 block of Carter St",male,N/A,"Adult 18+",N/A
+"August 6, 2020",Delaware,Wilmington,"2300 block of Carter St",male,N/A,"Adult 18+",N/A
+"August 5, 2020",Delaware,Wilmington,"2700 block of N Market St",male,N/A,"Adult 18+",N/A
+"August 5, 2020",Delaware,Wilmington,"2700 block of N Market St",male,N/A,"Adult 18+",N/A
+"August 4, 2020",Delaware,Wilmington,"2300 block of Carter St",male,N/A,"Adult 18+",N/A
+"July 29, 2020",Delaware,Wilmington,"900 block of N Lombard St",male,"Khalil Ameer-Bey","Adult 18+",N/A
+"July 29, 2020",Delaware,Wilmington,"5209 Concord Pike",male,N/A,"Adult 18+",N/A
+"July 29, 2020",Delaware,Wilmington,"5209 Concord Pike",N/A,N/A,"Adult 18+",N/A
+"July 29, 2020",Delaware,Wilmington,"5209 Concord Pike",N/A,N/A,"Adult 18+",N/A
+"July 29, 2020",Delaware,Wilmington,"5209 Concord Pike",N/A,N/A,"Adult 18+",N/A
+"July 28, 2020",Delaware,Wilmington,"1100 block of Beech St",male,N/A,"Adult 18+",N/A
+"July 28, 2020",Delaware,Wilmington,"1100 block of Beech St",male,"Nyzere Seth","Teen 12-17",N/A
+"July 28, 2020",Delaware,Wilmington,"1100 block of Beech St",female,"Alexus Cumberbatch","Adult 18+",N/A
+"July 28, 2020",Delaware,Wilmington,"1100 block of Beech St",male,N/A,"Adult 18+",N/A
+"July 28, 2020",Delaware,Milford,"9 Pennsylvania Ave",male,"David W. Parcher","Adult 18+",N/A
+"July 27, 2020",Delaware,Wilmington,"E 12th St and N Walnut St",male,N/A,"Teen 12-17",N/A
+"July 26, 2020",Delaware,Millsboro,"Golden Arrow Ct",female,"Christina Pilley","Adult 18+",N/A
+"July 26, 2020",Delaware,Wilmington,"100 block of N Franklin St",male,N/A,"Teen 12-17",N/A
+"July 25, 2020",Delaware,Dover,"N Governors Blvd",male,"Markas Custis","Adult 18+",N/A
+"July 24, 2020",Delaware,Wilmington,"50 block of Jensen Dr",male,N/A,"Teen 12-17",N/A
+"July 24, 2020",Delaware,Wilmington,"50 block of Jensen Dr",male,N/A,"Teen 12-17",N/A
+"July 24, 2020",Delaware,Wilmington,"50 block of Jensen Dr",male,N/A,"Teen 12-17",N/A
+"July 24, 2020",Delaware,Wilmington,"50 block of Jensen Dr",male,N/A,"Teen 12-17",N/A
+"July 24, 2020",Delaware,Dover,"1440 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"July 23, 2020",Delaware,Wilmington,"E 25th St and Jessup St",male,N/A,"Adult 18+",N/A
+"July 19, 2020",Delaware,Lincoln,"22000 block of Pine Haven Rd",male,"Michael Rosetta","Adult 18+",N/A
+"July 19, 2020",Delaware,Lincoln,"22000 block of Pine Haven Rd",male,"Russell Rosetta","Adult 18+",N/A
+"July 18, 2020",Delaware,Wilmington,"50 block of E 13th St",male,N/A,"Teen 12-17",N/A
+"July 18, 2020",Delaware,Milford,"Betsy Ross Cir",male,N/A,"Adult 18+",N/A
+"July 18, 2020",Delaware,Wilmington,"70 Court Dr",male,N/A,"Adult 18+",N/A
+"July 18, 2020",Delaware,Wilmington,"70 Court Dr",male,"Desidel Juarez","Adult 18+",N/A
+"July 16, 2020",Delaware,Dover,"100 N DuPont Hwy",male,N/A,"Adult 18+",N/A
+"July 16, 2020",Delaware,Wilmington,"2800 block of Northeast Blvd",male,N/A,"Adult 18+",N/A
+"July 15, 2020",Delaware,Wilmington,"500 block of Homestead Rd",male,N/A,"Adult 18+",N/A
+"July 15, 2020",Delaware,Milford,"Betsy Ross Cir",male,N/A,"Adult 18+",N/A
+"July 15, 2020",Delaware,Milford,"Betsy Ross Cir",male,"James A. Satcher","Adult 18+",N/A
+"July 14, 2020",Delaware,Wilmington,"400 block of N Madison St",male,N/A,"Teen 12-17",N/A
+"July 14, 2020",Delaware,Wilmington,"S Clifton Ave and Sylvan Ave",male,N/A,"Adult 18+",N/A
+"July 14, 2020",Delaware,Wilmington,"S Clifton Ave and Sylvan Ave",male,"Rashid Roane","Adult 18+",N/A
+"July 14, 2020",Delaware,Wilmington,"S Clifton Ave and Sylvan Ave",male,"Makye Fields","Adult 18+",N/A
+"July 14, 2020",Delaware,Smyrna,"Locust St and E Commerce St",female,N/A,"Adult 18+",N/A
+"July 14, 2020",Delaware,Smyrna,"Locust St and E Commerce St",male,"Gary Lewis","Adult 18+",N/A
+"July 13, 2020",Delaware,Wilmington,"700 block of W 4th St",male,N/A,"Adult 18+",N/A
+"July 13, 2020",Delaware,Wilmington,"700 block of W 4th St",male,"Dwan Jenkins","Adult 18+",N/A
+"July 13, 2020",Delaware,Milton,"28000 block of Fisher Rd",male,"Terron Brown","Adult 18+",N/A
+"July 12, 2020",Delaware,Wilmington,"800 block of W 23rd St",male,N/A,"Teen 12-17",N/A
+"July 12, 2020",Delaware,Wilmington,"800 block of W 23rd St",male,N/A,"Teen 12-17",N/A
+"July 11, 2020",Delaware,Wilmington,"600 block of N Pine St",male,N/A,"Teen 12-17",N/A
+"July 11, 2020",Delaware,Wilmington,"600 block of N Pine St",male,N/A,"Teen 12-17",N/A
+"July 11, 2020",Delaware,Wilmington,"600 block of N Pine St",female,N/A,"Teen 12-17",N/A
+"July 11, 2020",Delaware,Wilmington,"600 block of N Pine St",female,N/A,"Teen 12-17",N/A
+"July 11, 2020",Delaware,Wilmington,"600 block of N Pine St",male,N/A,"Child 0-11",N/A
+"July 9, 2020",Delaware,Wilmington,"600 block of N Madison St",male,N/A,"Adult 18+",N/A
+"July 9, 2020",Delaware,Bridgeville,"21000 block of Mill Park Dr",male,"Damaj T. Showell","Adult 18+",N/A
+"July 8, 2020",Delaware,Dover,"S DuPont Hwy and Loockerman St",female,"Uniqua Caldwell","Adult 18+",N/A
+"July 8, 2020",Delaware,Dover,"S DuPont Hwy and Loockerman St",female,N/A,"Teen 12-17",N/A
+"July 8, 2020",Delaware,Dover,"100 block of Mast Cir",male,N/A,"Adult 18+",N/A
+"July 8, 2020",Delaware,Dover,"100 block of Mast Cir",male,"Joshua Rodriguez","Adult 18+",N/A
+"July 7, 2020",Delaware,Dover,"N New St and Fulton St",male,"Anthony Clark","Adult 18+",N/A
+"July 7, 2020",Delaware,Wilmington,"100 block of N Franklin St",male,N/A,"Adult 18+",N/A
+"July 7, 2020",Delaware,Wilmington,"100 block of N Franklin St",male,N/A,"Adult 18+",N/A
+"July 6, 2020",Delaware,Dover,"100 block of S New St",male,"Thomas Gilbert","Adult 18+",N/A
+"July 6, 2020",Delaware,Dover,"100 block of S New St",male,"Tysheen Maxwell","Adult 18+",N/A
+"July 6, 2020",Delaware,Wilmington,"800 block of N Pine St",female,"Nakysha Richardson","Adult 18+",N/A
+"July 6, 2020",Delaware,Wilmington,"800 block of E 13th St",male,"Andre Hickson","Adult 18+",N/A
+"July 5, 2020",Delaware,Wilmington,"300 block of N Clayton St",male,"Abel Rivera-Mojica","Adult 18+",N/A
+"July 5, 2020",Delaware,Wilmington,"300 block of N Clayton St",male,N/A,"Teen 12-17",N/A
+"July 5, 2020",Delaware,Middletown,"400 block of Flower Hall Dr",male,N/A,"Adult 18+",N/A
+"July 5, 2020",Delaware,Middletown,"400 block of Flower Hall Dr",female,N/A,"Adult 18+",N/A
+"July 4, 2020",Delaware,"New Castle","50 block of Thorn Ct",male,"Kirk Flowers","Adult 18+",N/A
+"July 4, 2020",Delaware,"New Castle","50 block of Thorn Ct",male,N/A,"Adult 18+",N/A
+"July 4, 2020",Delaware,"New Castle","50 block of Thorn Ct",male,N/A,"Adult 18+",N/A
+"July 4, 2020",Delaware,Wilmington,"W 29th St and Washington St",male,N/A,"Adult 18+",N/A
+"July 3, 2020",Delaware,Wilmington,"200 block of N Rodney St",male,N/A,"Teen 12-17",N/A
+"July 2, 2020",Delaware,Millsboro,"Main St and Daisey Rd",male,"Layne Parker","Adult 18+",N/A
+"June 29, 2020",Delaware,Newark,"50 block of Madison Dr",male,"Jermaine Washington","Adult 18+",N/A
+"June 29, 2020",Delaware,Newark,"50 block of Madison Dr",male,"Jermaine Washington-Loper","Adult 18+",N/A
+"June 28, 2020",Delaware,Wilmington,"200 block of E 25th St",male,N/A,"Adult 18+",N/A
+"June 27, 2020",Delaware,Wilmington,"1000 block of W 8th St",male,N/A,"Adult 18+",N/A
+"June 26, 2020",Delaware,Wilmington,"E 7th St and N Spruce St",male,N/A,"Adult 18+",N/A
+"June 25, 2020",Delaware,Wilmington,"300 block of E 13th St",female,N/A,"Adult 18+",N/A
+"June 25, 2020",Delaware,Wilmington,"300 block of E 13th St",male,"Vincent Flowers","Adult 18+",N/A
+"June 25, 2020",Delaware,Wilmington,"300 block of E 13th St",male,"Dashan Freeman","Adult 18+",N/A
+"June 23, 2020",Delaware,Wilmington,"100 block of N Rodney St",male,N/A,"Adult 18+",N/A
+"June 23, 2020",Delaware,Magnolia,"Lambert Dr",male,N/A,"Adult 18+",N/A
+"June 21, 2020",Delaware,Wilmington,"100 block of S Dupont St",female,N/A,"Adult 18+",N/A
+"June 21, 2020",Delaware,Wilmington,"100 block of S Dupont St",male,N/A,"Adult 18+",N/A
+"June 20, 2020",Delaware,Greenwood,"10000 block of Memory Rd",male,N/A,"Adult 18+",N/A
+"June 20, 2020",Delaware,Greenwood,"10000 block of Memory Rd",male,"Edward Palmer","Adult 18+",N/A
+"June 19, 2020",Delaware,Dover,"5485 S Dupont Hwy",male,"Jaquan Lewis","Adult 18+",N/A
+"June 19, 2020",Delaware,Wilmington,"900 block of Vandever Ave",female,N/A,"Adult 18+",N/A
+"June 19, 2020",Delaware,Wilmington,"900 block of Vandever Ave",male,N/A,"Adult 18+",N/A
+"June 19, 2020",Delaware,Wilmington,"900 block of Vandever Ave",male,N/A,"Adult 18+",N/A
+"June 18, 2020",Delaware,Wilmington,"100 block of E 24th St",male,N/A,"Adult 18+",N/A
+"June 18, 2020",Delaware,Wilmington,"2300 block of N Washington St",male,N/A,"Adult 18+",N/A
+"June 16, 2020",Delaware,Wilmington,"1700 block of Locust St",male,"Francis Miller","Adult 18+",N/A
+"June 16, 2020",Delaware,Wilmington,"W 3rd St and N Clayton St",male,N/A,"Adult 18+",N/A
+"June 16, 2020",Delaware,Wilmington,"W 3rd St and N Clayton St",male,N/A,"Teen 12-17",N/A
+"June 16, 2020",Delaware,Harrington,"50 block of Clark St",male,"Edward Crum","Adult 18+",N/A
+"June 15, 2020",Delaware,Millsboro,"34000 block of Lynch Rd",male,"Marvel E. Shockley Jr.","Adult 18+",N/A
+"June 14, 2020",Delaware,Harrington,"700 block of Messicks Rd",female,"Jeanne D. Zebley","Adult 18+",N/A
+"June 14, 2020",Delaware,Seaford,"400 block of Pine St",male,N/A,"Adult 18+",N/A
+"June 14, 2020",Delaware,Seaford,"400 block of Pine St",male,"Duckens Lima","Adult 18+",N/A
+"June 14, 2020",Delaware,Seaford,"400 block of Pine St",male,"Devon Reynolds","Adult 18+",N/A
+"June 11, 2020",Delaware,Milton,"Springside Dr",male,"Devante J. Williams","Adult 18+",N/A
+"June 9, 2020",Delaware,Dover,"50 block of S New St",male,N/A,"Adult 18+",N/A
+"June 9, 2020",Delaware,Dover,"50 block of S New St",male,N/A,"Adult 18+",N/A
+"June 8, 2020",Delaware,Dover,"Becky Ln",male,"Shykeem Johnson","Adult 18+",N/A
+"June 8, 2020",Delaware,Dover,"Becky Ln",male,"Ray Horsey","Adult 18+",N/A
+"June 8, 2020",Delaware,Harrington,"1259 Corn Crib Rd",male,"Stacey L. Coleman","Adult 18+",N/A
+"June 6, 2020",Delaware,Lewes,"33000 block of Sandy Bay Dr",male,N/A,"Adult 18+",N/A
+"June 6, 2020",Delaware,Lewes,"33000 block of Sandy Bay Dr",male,"Kevin T. Brownlee","Adult 18+",N/A
+"June 6, 2020",Delaware,Wilmington,"2900 block of N Washington St",male,N/A,"Adult 18+",N/A
+"June 5, 2020",Delaware,Dover,"400 block of Barrister Pl",male,N/A,"Adult 18+",N/A
+"June 5, 2020",Delaware,Dover,"400 block of Barrister Pl",male,N/A,"Adult 18+",N/A
+"June 5, 2020",Delaware,Wilmington,"900 block of Bennett St",male,"Keith Evans","Adult 18+",N/A
+"June 4, 2020",Delaware,Wilmington,"500 block of E 3rd St",male,N/A,"Adult 18+",N/A
+"June 3, 2020",Delaware,Dover,"100 block of Hampton Dr",male,N/A,"Adult 18+",N/A
+"June 3, 2020",Delaware,Dover,"100 block of Hampton Dr",male,N/A,"Adult 18+",N/A
+"June 2, 2020",Delaware,Wilmington,"B St and Townsend St",male,N/A,"Adult 18+",N/A
+"June 2, 2020",Delaware,Wilmington,"B St and Townsend St",male,"Rodon Townsend","Adult 18+",N/A
+"June 2, 2020",Delaware,Dover,N/A,male,N/A,"Adult 18+",N/A
+"June 1, 2020",Delaware,Dover,"300 block of Kesselring Ave",male,"Mykal Dempster","Adult 18+",N/A
+"June 1, 2020",Delaware,Dover,"300 block of Kesselring Ave",male,"Raiquan Fisher","Adult 18+",N/A
+"June 1, 2020",Delaware,Dover,"300 block of Kesselring Ave",male,"Harry Charles","Teen 12-17",N/A
+"May 31, 2020",Delaware,Newark,"2644 Capitol Trail",male,"Nahsiem McIntosh","Adult 18+",N/A
+"May 31, 2020",Delaware,Newark,"2644 Capitol Trail",male,"Derris Lloyd","Adult 18+",N/A
+"May 31, 2020",Delaware,Newark,"2644 Capitol Trail",male,N/A,"Adult 18+",N/A
+"May 31, 2020",Delaware,Newark,"2644 Capitol Trail",male,N/A,"Adult 18+",N/A
+"May 31, 2020",Delaware,Newark,"2644 Capitol Trail",male,N/A,"Adult 18+",N/A
+"May 31, 2020",Delaware,Newark,"500 block of Capitol Trail",male,N/A,"Adult 18+",N/A
+"May 31, 2020",Delaware,Newark,"500 block of Capitol Trail",male,"Cody Johns","Adult 18+",N/A
+"May 31, 2020",Delaware,Newark,"500 block of Capitol Trail",male,"Christopher Troutman","Adult 18+",N/A
+"May 31, 2020",Delaware,Newark,"500 block of Capitol Trail",female,"Camryn Thomas","Adult 18+",N/A
+"May 31, 2020",Delaware,Dover,"Cecil St and N Governors Ave",male,N/A,"Adult 18+",N/A
+"May 31, 2020",Delaware,Dover,"Cecil St and N Governors Ave",male,N/A,"Adult 18+",N/A
+"May 31, 2020",Delaware,Dover,"Cecil St and N Governors Ave",male,N/A,"Adult 18+",N/A
+"May 30, 2020",Delaware,Wilmington,"600 block of W 5th St",male,N/A,"Adult 18+",N/A
+"May 30, 2020",Delaware,Wilmington,"600 block of W 7th St",male,N/A,"Adult 18+",N/A
+"May 30, 2020",Delaware,Wilmington,"600 block of W 7th St",male,N/A,"Teen 12-17",N/A
+"May 30, 2020",Delaware,Wilmington,"400 block of W 31st St",male,N/A,"Adult 18+",N/A
+"May 30, 2020",Delaware,Seaford,"9000 block of Middleford Rd",male,"Christopher D. Mann","Adult 18+",N/A
+"May 30, 2020",Delaware,Dover,"Simon Cir",male,N/A,"Adult 18+",N/A
+"May 30, 2020",Delaware,Dover,"Simon Cir",male,N/A,"Adult 18+",N/A
+"May 30, 2020",Delaware,Dover,"Simon Cir",male,N/A,"Adult 18+",N/A
+"May 29, 2020",Delaware,Wilmington,"800 block of Tatnall St",male,N/A,"Adult 18+",N/A
+"May 27, 2020",Delaware,Newark,"520 JFK Memorial Hwy",female,N/A,"Teen 12-17",N/A
+"May 26, 2020",Delaware,Milford,"100 block of Pritchett Rd",male,"David A. Tyler","Adult 18+",N/A
+"May 26, 2020",Delaware,Milton,"400 block of S Lake Dr",male,"Adam Fonseca","Adult 18+",N/A
+"May 26, 2020",Delaware,Wilmington,"2200 block of Washington St",male,N/A,"Adult 18+",N/A
+"May 25, 2020",Delaware,Newark,"300 block of Kemper Dr",male,N/A,"Adult 18+",N/A
+"May 24, 2020",Delaware,Dover,"1300 S Farmview Dr",male,N/A,"Adult 18+",N/A
+"May 24, 2020",Delaware,Dover,"1300 S Farmview Dr",male,N/A,"Adult 18+",N/A
+"May 24, 2020",Delaware,Dover,"1300 S Farmview Dr",male,N/A,"Adult 18+",N/A
+"May 21, 2020",Delaware,Dover,"200 block of N Queen St",male,N/A,"Adult 18+",N/A
+"May 21, 2020",Delaware,Dover,"200 block of N Queen St",female,N/A,"Adult 18+",N/A
+"May 21, 2020",Delaware,Wilmington,"E 9th St and N Church St",male,N/A,"Adult 18+",N/A
+"May 17, 2020",Delaware,Wilmington,"50 block of S Clayton St",male,N/A,"Teen 12-17",N/A
+"May 17, 2020",Delaware,Wilmington,"1800 block of W 3rd St",male,N/A,"Adult 18+",N/A
+"May 17, 2020",Delaware,Wilmington,"2300 block of Carter St",male,N/A,"Adult 18+",N/A
+"May 17, 2020",Delaware,Wilmington,"2300 block of Carter St",male,N/A,"Adult 18+",N/A
+"May 16, 2020",Delaware,Wilmington,"200 block of W 22nd St",male,"Stanley Lambert","Adult 18+",N/A
+"May 16, 2020",Delaware,Claymont,"4th Ave",male,N/A,"Adult 18+",N/A
+"May 16, 2020",Delaware,Claymont,"4th Ave",male,"Quishyne Jackson","Adult 18+",N/A
+"May 16, 2020",Delaware,Lincoln,"21000 block of Mayhew Dr",male,N/A,"Adult 18+",N/A
+"May 16, 2020",Delaware,Lincoln,"21000 block of Mayhew Dr",male,N/A,"Adult 18+",N/A
+"May 14, 2020",Delaware,Wilmington,"2400 block of Jefferson St",male,N/A,"Teen 12-17",N/A
+"May 14, 2020",Delaware,Ellendale,"18000 block of S Old State Rd",male,"John T. Shorts","Adult 18+",N/A
+"May 10, 2020",Delaware,Dover,"4000 block of Vermont Dr",male,"Anthony Stanzak","Adult 18+",N/A
+"May 10, 2020",Delaware,Dover,"100 Block of Willis Rd",female,N/A,"Adult 18+",N/A
+"May 10, 2020",Delaware,Dover,"100 Block of Willis Rd",male,N/A,"Adult 18+",N/A
+"May 10, 2020",Delaware,Dover,"100 Block of Willis Rd",male,N/A,"Adult 18+",N/A
+"May 9, 2020",Delaware,Dover,"150 N DuPont Hwy",male,"David Perrera","Adult 18+",N/A
+"May 8, 2020",Delaware,Bear,"2465 Chesapeake City Rd",male,"Paul C. Marino","Adult 18+",N/A
+"May 8, 2020",Delaware,Bear,"2465 Chesapeake City Rd",female,"Lidia Marino","Adult 18+",N/A
+"May 8, 2020",Delaware,Bear,"2465 Chesapeake City Rd",male,"Sheldon C. Francis","Adult 18+",N/A
+"May 7, 2020",Delaware,Wilmington,"600 block of Maryland Ave",female,N/A,"Teen 12-17",N/A
+"May 2, 2020",Delaware,Wilmington,"3602 Miller Rd",male,N/A,"Adult 18+",N/A
+"May 1, 2020",Delaware,Wilmington,"117 Washington Ave",male,"Richard Sitek","Adult 18+",N/A
+"April 28, 2020",Delaware,Wilmington,"100 block of Ashton St",male,N/A,"Teen 12-17",N/A
+"April 28, 2020",Delaware,Wilmington,"100 block of Ashton St",male,"Jeremiah Redding","Teen 12-17",N/A
+"April 28, 2020",Delaware,Wilmington,"1700 block of Lancaster Ave",male,"Keith Jarmon","Adult 18+",N/A
+"April 28, 2020",Delaware,"Wilmington (Edgemoor)","S Rodney Dr and Bedford Dr",female,N/A,"Teen 12-17",N/A
+"April 28, 2020",Delaware,"Wilmington (Edgemoor)","S Rodney Dr and Bedford Dr",male,N/A,"Teen 12-17",N/A
+"April 28, 2020",Delaware,Bear,"900 block of Red Lion Rd",male,"Joseph Thomas","Adult 18+",N/A
+"April 27, 2020",Delaware,Ellendale,"Beaver Dam Rd",male,"Joel Weche","Adult 18+",N/A
+"April 26, 2020",Delaware,Georgetown,"Briarwood Rd",male,"Jeff T. Cotonon-Ramos","Adult 18+",N/A
+"April 25, 2020",Delaware,Wilmington,"800 block of W 5th St",male,N/A,"Adult 18+",N/A
+"April 20, 2020",Delaware,Magnolia,"300 block of Millchop Ln",male,"Tyriekus D.Collick","Adult 18+",N/A
+"April 20, 2020",Delaware,Magnolia,"300 block of Millchop Ln",male,"Desmond Robinson","Adult 18+",N/A
+"April 20, 2020",Delaware,Magnolia,"300 block of Millchop Ln",male,"Desmond Johnson","Adult 18+",N/A
+"April 19, 2020",Delaware,Wilmington,"7th St and Washington St",female,N/A,"Adult 18+",N/A
+"April 19, 2020",Delaware,Wilmington,"7th St and Washington St",male,N/A,"Adult 18+",N/A
+"April 18, 2020",Delaware,Wilmington,"50 block of S Rodney Dr",male,N/A,"Teen 12-17",N/A
+"April 18, 2020",Delaware,Wilmington,"50 block of S Rodney Dr",female,N/A,"Teen 12-17",N/A
+"April 18, 2020",Delaware,Milton,"2000 block of Pickwick Dr",male,N/A,"Child 0-11",N/A
+"April 17, 2020",Delaware,Claymont,"3000 block of Green St",male,N/A,"Adult 18+",N/A
+"April 17, 2020",Delaware,Claymont,"3000 block of Green St",female,N/A,"Adult 18+",N/A
+"April 17, 2020",Delaware,Claymont,"3000 block of Green St",male,"Marqus Grooms","Adult 18+",N/A
+"April 17, 2020",Delaware,Felton,"8953 S Dupont Hwy",male,"Trey M Bowden","Adult 18+",N/A
+"April 14, 2020",Delaware,Wilmington,"400 block of Vandever Ave",male,N/A,"Teen 12-17",N/A
+"April 13, 2020",Delaware,Newark,"50 block of New London Ave",male,"Aaron Locke","Adult 18+",N/A
+"April 13, 2020",Delaware,Newark,"50 block of New London Ave",male,"Cameron Gordon","Adult 18+",N/A
+"April 13, 2020",Delaware,Newark,"50 block of New London Ave",male,"Nicholas Lane","Adult 18+",N/A
+"April 13, 2020",Delaware,Newark,"50 block of New London Ave",male,"Maurice Wilson","Adult 18+",N/A
+"April 12, 2020",Delaware,Wilmington,"E 11th St and N Walnut St",male,"Jabri Hunter","Adult 18+",N/A
+"April 11, 2020",Delaware,Dover,"Presidents Dr and N Governors Blvd",male,N/A,"Adult 18+",N/A
+"April 11, 2020",Delaware,Dover,"Presidents Dr and N Governors Blvd",male,N/A,"Adult 18+",N/A
+"April 11, 2020",Delaware,Dover,"Presidents Dr and N Governors Blvd",male,N/A,"Adult 18+",N/A
+"April 10, 2020",Delaware,Wilmington,"600 block of N Franklin St",male,N/A,"Teen 12-17",N/A
+"April 7, 2020",Delaware,Wilmington,"200 block of N Madison St",female,"Janaija Johnson","Teen 12-17",N/A
+"April 7, 2020",Delaware,Wilmington,"400 block of W 30th St",male,N/A,"Adult 18+",N/A
+"April 7, 2020",Delaware,Wilmington,"400 block of W 30th St",male,N/A,"Teen 12-17",N/A
+"April 7, 2020",Delaware,Wilmington,"W 7th St and N Monroe St",male,N/A,"Adult 18+",N/A
+"April 6, 2020",Delaware,Newark,"2000 block of Sunset Lake Rd",male,N/A,"Adult 18+",N/A
+"April 6, 2020",Delaware,Newark,"2000 block of Sunset Lake Rd",male,N/A,"Adult 18+",N/A
+"April 6, 2020",Delaware,Newark,"2000 block of Sunset Lake Rd",male,N/A,"Adult 18+",N/A
+"April 6, 2020",Delaware,Millsboro,"Rd 413 and Daisey Rd",male,"Tycere S. Bryant","Adult 18+",N/A
+"April 6, 2020",Delaware,Millsboro,"Rd 413 and Daisey Rd",male,"Brandon Jones","Adult 18+",N/A
+"April 6, 2020",Delaware,Millsboro,"Rd 413 and Daisey Rd",female,N/A,"Adult 18+",N/A
+"April 4, 2020",Delaware,Wilmington,"50 block of W 27th St",male,N/A,"Adult 18+",N/A
+"April 4, 2020",Delaware,Wilmington,"50 block of W 27th St",male,"Andre Davis","Adult 18+",N/A
+"March 31, 2020",Delaware,Wilmington,"300 block of W 26th St",male,N/A,"Adult 18+",N/A
+"March 30, 2020",Delaware,Newark,"69 Greenridge Dr",male,N/A,"Teen 12-17",N/A
+"March 26, 2020",Delaware,Wilmington,"3000 block of N Monroe St",male,N/A,"Teen 12-17",N/A
+"March 25, 2020",Delaware,Millsboro,"28000 block of Delaware Ave",male,N/A,"Adult 18+",N/A
+"March 25, 2020",Delaware,Millsboro,"28000 block of Delaware Ave",male,"Robert S. Hill","Adult 18+",N/A
+"March 24, 2020",Delaware,"New Castle (Minquadale)","Hazeldell Ave and Milford St",male,N/A,"Adult 18+",N/A
+"March 21, 2020",Delaware,Bear,"700 block of N Huckleberry Ave",male,N/A,"Adult 18+",N/A
+"March 21, 2020",Delaware,Bear,"700 block of N Huckleberry Ave",N/A,N/A,Unknown,N/A
+"March 17, 2020",Delaware,Wilmington,"2500 block of N West St",male,"Francis Reams","Adult 18+",N/A
+"March 17, 2020",Delaware,Wilmington,"300 block of W 37th St",male,N/A,"Adult 18+",N/A
+"March 16, 2020",Delaware,Smyrna,"100 block of Blackbird Greenspring Rd",male,"Richard P. Money","Adult 18+",N/A
+"March 10, 2020",Delaware,Milford,"Bennetts Pier Rd",male,N/A,"Adult 18+",N/A
+"March 7, 2020",Delaware,Wilmington,"500 block of W 7th St",male,"Andre Crisden","Adult 18+",N/A
+"March 6, 2020",Delaware,Seaford,"22588 Bridgeville Hwy",male,N/A,"Adult 18+",N/A
+"March 6, 2020",Delaware,Seaford,"22588 Bridgeville Hwy",male,"Rafael A Pena-Suarez","Adult 18+",N/A
+"March 5, 2020",Delaware,Wilmington,"3200 block of W 2nd St",male,"Orrin Daniels","Adult 18+",N/A
+"March 4, 2020",Delaware,Wilmington,"2501 Ebright Rd",male,"Ahmeer Ryle","Teen 12-17",N/A
+"March 2, 2020",Delaware,Dover,"400 block of Ann Moore St",male,"Brandon Scott","Adult 18+",N/A
+"March 2, 2020",Delaware,Dover,"400 block of Ann Moore St",male,"Tyler Scott","Adult 18+",N/A
+"February 28, 2020",Delaware,Lincoln,"8000 block of Virginia Pine Rd",male,"Richard L. White","Adult 18+",N/A
+"February 28, 2020",Delaware,Lincoln,"8000 block of Virginia Pine Rd",male,"Lee Lewis Sr.","Adult 18+",N/A
+"February 27, 2020",Delaware,Lincoln,"Virginia Pine Ln and Johnson Rd",male,"Qualeel T. Wescott","Adult 18+",N/A
+"February 25, 2020",Delaware,Dover,"Pine Cabin Rd and Lemay Ln",male,"Shiheem Durham","Adult 18+",N/A
+"February 25, 2020",Delaware,Dover,"Pine Cabin Rd and Lemay Ln",male,"Jason D Calhum","Adult 18+",N/A
+"February 25, 2020",Delaware,Dover,"Pine Cabin Rd and Lemay Ln",male,"Tyrie Burton","Adult 18+",N/A
+"February 23, 2020",Delaware,"Rehoboth Beach","19178 Coastal Highway",male,"Khail S. Reid","Adult 18+",N/A
+"February 23, 2020",Delaware,"Rehoboth Beach","19178 Coastal Highway",male,"Isaiah Reid","Adult 18+",N/A
+"February 23, 2020",Delaware,"Rehoboth Beach","19178 Coastal Highway",male,"Saa’diq A. Holmes","Adult 18+",N/A
+"February 22, 2020",Delaware,Frederica,"102 S Flack Ave",female,"Lysandra Bowers","Adult 18+",N/A
+"February 22, 2020",Delaware,Frederica,"102 S Flack Ave",male,"Kenneth Bowers","Adult 18+",N/A
+"February 22, 2020",Delaware,Wilmington,"2200 block of Washington St",male,N/A,"Teen 12-17",N/A
+"February 22, 2020",Delaware,Wilmington,"2700 block of W 5th St",male,"Robert Littlejohn","Adult 18+",N/A
+"February 22, 2020",Delaware,Wilmington,"2700 block of W 5th St",male,"Khalil Rodriguez-Fitzgerald","Adult 18+",N/A
+"February 21, 2020",Delaware,Dover,"1400 block of Garfield Dr",male,"Zachary Rhinehardt","Adult 18+",N/A
+"February 20, 2020",Delaware,Harrington,"100 block of Central Park Dr",male,"Samuel L. Thorpe","Adult 18+",N/A
+"February 20, 2020",Delaware,Wilmington,"1601 N Spruce St",male,N/A,"Adult 18+",N/A
+"February 19, 2020",Delaware,Wilmington,"E 7th St and N Pine St",male,N/A,"Adult 18+",N/A
+"February 19, 2020",Delaware,Wilmington,"E 7th St and N Pine St",male,N/A,"Teen 12-17",N/A
+"February 19, 2020",Delaware,Wilmington,"E 7th St and N Pine St",male,N/A,"Adult 18+",N/A
+"February 19, 2020",Delaware,Wilmington,"300 block of Concord Ave",male,"Sebastion Howell","Adult 18+",N/A
+"February 19, 2020",Delaware,Wilmington,"300 block of Concord Ave",male,"Jerry Bland","Adult 18+",N/A
+"February 19, 2020",Delaware,Wilmington,"300 block of Concord Ave",male,"Roosevelt Clark","Adult 18+",N/A
+"February 19, 2020",Delaware,Wilmington,"300 block of Concord Ave",male,"Theodore Parks","Adult 18+",N/A
+"February 19, 2020",Delaware,Wilmington,"300 block of Concord Ave",male,"Christian Lawrence","Adult 18+",N/A
+"February 19, 2020",Delaware,Wilmington,"300 block of Concord Ave",male,"Dion Boulden","Adult 18+",N/A
+"February 19, 2020",Delaware,Wilmington,"300 block of Concord Ave",male,"Archie Summer","Adult 18+",N/A
+"February 18, 2020",Delaware,Wilmington,"1800 block of W 6th St",male,N/A,"Adult 18+",N/A
+"February 18, 2020",Delaware,Wilmington,"1100 block of Chestnut St",male,N/A,"Teen 12-17",N/A
+"February 18, 2020",Delaware,Dover,"W North St and Simon Cir",male,N/A,"Teen 12-17",N/A
+"February 18, 2020",Delaware,Dover,"W North St and Simon Cir",male,"Darius Jean-Baptiste","Adult 18+",N/A
+"February 18, 2020",Delaware,Dover,"W North St and Simon Cir",male,"Brandon Scott","Adult 18+",N/A
+"February 16, 2020",Delaware,Milford,"8000 block of Slaughter Beach Rd",male,"Eric F. Edge","Adult 18+",N/A
+"February 16, 2020",Delaware,Wilmington,"800 block of N Adams St",male,"Lamont Davis","Adult 18+",N/A
+"February 16, 2020",Delaware,Wilmington,"800 block of N Adams St",male,"Wade Hammond","Adult 18+",N/A
+"February 16, 2020",Delaware,Wilmington,"800 block of N Adams St",male,"Marquis Crews-Foster","Adult 18+",N/A
+"February 15, 2020",Delaware,"Wilmington (Newport)","100 Bennett Ct",female,"Emoni Rivers-Boyd","Teen 12-17",N/A
+"February 15, 2020",Delaware,"Wilmington (Newport)","100 Bennett Ct",female,"Angelise Merced","Teen 12-17",N/A
+"February 15, 2020",Delaware,Wilmington,"1706 Philadelphia Pike",male,"Jason W. Tatom","Adult 18+",N/A
+"February 15, 2020",Delaware,Wilmington,"2300 block of Pine St",male,N/A,"Adult 18+",N/A
+"February 15, 2020",Delaware,Newark,"4000 block of Ogletown Stanton Rd",male,N/A,"Adult 18+",N/A
+"February 14, 2020",Delaware,Seaford,"700 block of Norman Eskridge Hwy",male,"Greg R. Harding","Adult 18+",N/A
+"February 13, 2020",Delaware,Wilmington,"1000 block of N Pine St",male,"Donald Tillman","Adult 18+",N/A
+"February 13, 2020",Delaware,Wilmington,"1000 block of N Pine St",male,"Curtis Cherry","Adult 18+",N/A
+"February 13, 2020",Delaware,Lincoln,"300 block of Cedar Dr",male,"Roberto Cantu","Adult 18+",N/A
+"February 13, 2020",Delaware,Lincoln,"300 block of Cedar Dr",male,"Mario J. Garza","Adult 18+",N/A
+"February 11, 2020",Delaware,Wilmington,"300 block of N Broom St",male,N/A,"Adult 18+",N/A
+"February 11, 2020",Delaware,Wilmington,"300 block of N Broom St",male,"Erick Coleman","Adult 18+",N/A
+"February 11, 2020",Delaware,Wilmington,"800 block of N Adams St",male,N/A,"Adult 18+",N/A
+"February 10, 2020",Delaware,Dover,"200 block of W Reed St",female,"Tiffany Montgomery","Adult 18+",N/A
+"February 10, 2020",Delaware,Dover,"200 block of W Reed St",male,N/A,"Adult 18+",N/A
+"February 10, 2020",Delaware,Dover,"200 block of W Reed St",male,N/A,"Adult 18+",N/A
+"February 10, 2020",Delaware,Dover,"200 block of W Reed St",female,N/A,"Adult 18+",N/A
+"February 10, 2020",Delaware,Dover,"200 block of W Reed St",male,N/A,"Adult 18+",N/A
+"February 7, 2020",Delaware,Magnolia,"100 block of Terry Dr",male,"Thomas M. Bailey Jr.","Adult 18+",N/A
+"February 7, 2020",Delaware,Magnolia,"100 block of Terry Dr",male,"William B. Goldsborough","Adult 18+",N/A
+"February 7, 2020",Delaware,Magnolia,"100 block of Terry Dr",female,"Patrice N. Anderson","Adult 18+",N/A
+"February 7, 2020",Delaware,Magnolia,"100 block of Terry Dr",male,"Roger L. Jones","Adult 18+",N/A
+"February 5, 2020",Delaware,Wilmington,"2212 N Market St",male,"Randolph White","Adult 18+",N/A
+"February 5, 2020",Delaware,Wilmington,"2212 N Market St",male,"Bryan Edwards","Adult 18+",N/A
+"February 2, 2020",Delaware,Magnolia,"50 block of Terry Dr",male,"Trey M. Bowden","Adult 18+",N/A
+"February 2, 2020",Delaware,Wilmington,"50 block of W 27th St",male,N/A,"Adult 18+",N/A
+"February 1, 2020",Delaware,Georgetown,"100 block of Garden Cir",female,N/A,"Adult 18+",N/A
+"February 1, 2020",Delaware,Georgetown,"100 block of Garden Cir",male,"Alvaro E Marroquinn","Adult 18+",N/A
+"January 31, 2020",Delaware,Milford,"900 block of SE Front St",male,"Marc Johnson","Adult 18+",N/A
+"January 29, 2020",Delaware,Frederica,"100 block of Maple Dr",male,N/A,"Adult 18+",N/A
+"January 29, 2020",Delaware,Frederica,"100 block of Maple Dr",male,N/A,"Adult 18+",N/A
+"January 29, 2020",Delaware,Frederica,"100 block of Maple Dr",male,N/A,"Adult 18+",N/A
+"January 29, 2020",Delaware,Dover,"500 Persimmon Tree Ln",male,"Xavier Marion","Adult 18+",N/A
+"January 29, 2020",Delaware,Wilmington,"600 block of E 6th St",male,N/A,"Adult 18+",N/A
+"January 28, 2020",Delaware,Dover,"200 block of Nob Hill Rd",male,"Shyder Davis","Adult 18+",N/A
+"January 27, 2020",Delaware,Dover,"400 block of Collins Dr",male,"Anthony Hart","Adult 18+",N/A
+"January 27, 2020",Delaware,Dover,"400 block of Collins Dr",male,"Jermaine Brown Jr.","Adult 18+",N/A
+"January 27, 2020",Delaware,Dover,"400 block of Collins Dr",male,"Arshawan Brown","Adult 18+",N/A
+"January 26, 2020",Delaware,Magnolia,"100 block of Terry Dr",male,N/A,"Adult 18+",N/A
+"January 25, 2020",Delaware,Wilmington,"800 block of N West St",male,N/A,"Adult 18+",N/A
+"January 24, 2020",Delaware,Dover,"70 Greenway Square",male,"Jamil Green","Adult 18+",N/A
+"January 23, 2020",Delaware,Wilmington,"300 block of Woodlawn Ave",male,N/A,"Teen 12-17",N/A
+"January 23, 2020",Delaware,Wilmington,"300 block of Woodlawn Ave",N/A,N/A,Unknown,N/A
+"January 23, 2020",Delaware,Wilmington,"300 block of Woodlawn Ave",N/A,N/A,Unknown,N/A
+"January 22, 2020",Delaware,Wilmington,"500 block of N Monroe St",male,N/A,"Adult 18+",N/A
+"January 22, 2020",Delaware,Wilmington,"500 block of N Monroe St",male,N/A,"Adult 18+",N/A
+"January 22, 2020",Delaware,Wilmington,"500 block of N Monroe St",male,N/A,"Adult 18+",N/A
+"January 22, 2020",Delaware,Ellendale,"12000 block of Ponder Rd",male,"Charles J. Turner","Adult 18+",N/A
+"January 21, 2020",Delaware,"Camden Wyoming (Camden)","239 Old North Rd",male,"Dakarae Piazza","Teen 12-17",N/A
+"January 20, 2020",Delaware,Wilmington,"1251 Centerville Rd",female,"Kaye L. Baltimore","Adult 18+",N/A
+"January 19, 2020",Delaware,Wilmington,"400 block of N Spruce St",male,N/A,"Teen 12-17",N/A
+"January 19, 2020",Delaware,Wilmington,"1200 block of Chestnut St",male,N/A,"Adult 18+",N/A
+"January 19, 2020",Delaware,Felton,"1300 block of Barney Jenkins Rd",female,N/A,"Adult 18+",N/A
+"January 19, 2020",Delaware,Felton,"1300 block of Barney Jenkins Rd",male,"Lawrence Horsey","Teen 12-17",N/A
+"January 19, 2020",Delaware,Felton,"1300 block of Barney Jenkins Rd",female,"Jada Wyatte","Teen 12-17",N/A
+"January 19, 2020",Delaware,Felton,"1300 block of Barney Jenkins Rd",male,"Jaden N. Wyatte","Teen 12-17",N/A
+"January 18, 2020",Delaware,Wilmington,"2700 block of N Claymont St",male,N/A,"Adult 18+",N/A
+"January 17, 2020",Delaware,Dover,"N Farmview Dr",male,"Kevin Wilkerson","Adult 18+",N/A
+"January 16, 2020",Delaware,Dover,"S Bay Rd and President Dr",male,"Lamar Howard","Teen 12-17",N/A
+"January 16, 2020",Delaware,Dover,"S Bay Rd and President Dr",male,"Sadique Ingram","Adult 18+",N/A
+"January 16, 2020",Delaware,Wilmington,"400 block of Queen St",male,N/A,"Teen 12-17",N/A
+"January 16, 2020",Delaware,Wilmington,"400 block of Queen St",male,N/A,"Teen 12-17",N/A
+"January 16, 2020",Delaware,Wilmington,"400 block of Queen St",male,N/A,"Teen 12-17",N/A
+"January 14, 2020",Delaware,Dover,"500 Persimmon Tree Ln",male,"Shyasia Hood","Adult 18+",N/A
+"January 14, 2020",Delaware,Dover,"500 Persimmon Tree Ln",male,"Javon Pollard","Adult 18+",N/A
+"January 14, 2020",Delaware,Wilmington,"300 block of W 6th St",male,"William Parker Jr.","Adult 18+",N/A
+"January 13, 2020",Delaware,Harbeson,"22000 block of Danfield Dr",male,"Robin C. Stephens","Adult 18+",N/A
+"January 13, 2020",Delaware,Harbeson,"22000 block of Danfield Dr",female,"Heather Kenny","Adult 18+",N/A
+"January 13, 2020",Delaware,Harbeson,"22000 block of Danfield Dr",N/A,N/A,Unknown,N/A
+"January 13, 2020",Delaware,Newark,"50 block of Salem Village Square",male,N/A,"Adult 18+",N/A
+"January 12, 2020",Delaware,Wilmington,"W 25th St and N West St",male,N/A,"Teen 12-17",N/A
+"January 12, 2020",Delaware,Dover,"900 block of W North St",male,N/A,"Adult 18+",N/A
+"January 12, 2020",Delaware,Dover,"900 block of W North St",male,"Syrian Grant","Teen 12-17",N/A
+"January 12, 2020",Delaware,Dover,"900 block of W North St",N/A,N/A,Unknown,N/A
+"January 11, 2020",Delaware,Wilmington,"700 block of N Spruce St",male,N/A,"Adult 18+",N/A
+"January 11, 2020",Delaware,Wilmington,"700 block of N Spruce St",male,"Kyndale Perkins","Adult 18+",N/A
+"January 11, 2020",Delaware,Wilmington,"700 block of N Spruce St",male,"Jayden Deputy","Adult 18+",N/A
+"January 10, 2020",Delaware,Dover,"50 block of S New St",male,"Kinon Teat Jr.","Adult 18+",N/A
+"January 10, 2020",Delaware,Dover,"50 block of S New St",male,"Jeremiah Hampton","Adult 18+",N/A
+"January 8, 2020",Delaware,Delmar,"11000 block of Buckingham Dr",female,N/A,"Adult 18+",N/A
+"January 6, 2020",Delaware,Dover,"Paul St and Davis Cir",male,"Kainami Grant","Teen 12-17",N/A
+"January 5, 2020",Delaware,Milford,"5 Linstone Ln",male,"Brandon D. Roberts","Adult 18+",N/A
+"January 1, 2020",Delaware,Dover,"400 block of Collins Dr",male,N/A,"Adult 18+",N/A
+"January 1, 2020",Delaware,Dover,"400 block of Collins Dr",female,N/A,"Adult 18+",N/A
+"December 31, 2019",Delaware,Bear,"Taylor Dr and Emerson Pl",male,"Jahlil Patton","Adult 18+",N/A
+"December 31, 2019",Delaware,Wilmington,"2400 block of N Market St",male,N/A,"Teen 12-17",N/A
+"December 31, 2019",Delaware,Dover,"100 block of Haman Dr",male,N/A,"Adult 18+",N/A
+"December 31, 2019",Delaware,"New Castle","700 block of Willings Way",male,"Cornelius Wright","Adult 18+",N/A
+"December 31, 2019",Delaware,"New Castle","700 block of Willings Way",male,"Ervin Christy Jr.","Adult 18+",N/A
+"December 31, 2019",Delaware,"New Castle","700 block of Willings Way",male,"Jerry Pritchett","Adult 18+",N/A
+"December 31, 2019",Delaware,Wilmington,"2200 block of N Market St",male,N/A,"Adult 18+",N/A
+"December 30, 2019",Delaware,Dover,"400 block of Barrister Pl",male,N/A,"Adult 18+",N/A
+"December 30, 2019",Delaware,Dover,"400 block of Barrister Pl",male,N/A,"Adult 18+",N/A
+"December 30, 2019",Delaware,Dover,"400 block of Barrister Pl",male,N/A,"Adult 18+",N/A
+"December 30, 2019",Delaware,Dover,"100 block of S New St",male,N/A,"Adult 18+",N/A
+"December 30, 2019",Delaware,Dover,"100 block of S New St",male,N/A,"Adult 18+",N/A
+"December 30, 2019",Delaware,Dover,"100 block of S New St",male,N/A,"Adult 18+",N/A
+"December 30, 2019",Delaware,Dover,"100 block of S New St",male,N/A,"Adult 18+",N/A
+"December 30, 2019",Delaware,Dover,"100 block of S New St",male,N/A,"Adult 18+",N/A
+"December 30, 2019",Delaware,Dover,"100 block of S New St",male,N/A,"Adult 18+",N/A
+"December 30, 2019",Delaware,Dover,"100 block of S New St",male,N/A,"Adult 18+",N/A
+"December 28, 2019",Delaware,"New Castle","Liborio Ln",N/A,N/A,"Teen 12-17",N/A
+"December 28, 2019",Delaware,"New Castle","Liborio Ln",N/A,N/A,"Teen 12-17",N/A
+"December 28, 2019",Delaware,Dover,"50 block of Kentwood Dr",male,N/A,"Adult 18+",N/A
+"December 28, 2019",Delaware,Dover,"50 block of Kentwood Dr",male,N/A,"Adult 18+",N/A
+"December 28, 2019",Delaware,Wilmington,"1300 block of E 29th St",male,"James Pinkett","Adult 18+",N/A
+"December 27, 2019",Delaware,Seaford,"14000 block of County Seat Hwy",male,"Brad Rippey","Adult 18+",N/A
+"December 27, 2019",Delaware,Dover,"200 block of S Governors Blvd",female,N/A,"Adult 18+",N/A
+"December 26, 2019",Delaware,Wilmington,"1300 block of Cedar St",male,N/A,"Adult 18+",N/A
+"December 25, 2019",Delaware,Wilmington,"900 block of Vandever Ave",female,"Robin McNeil","Adult 18+",N/A
+"December 25, 2019",Delaware,Wilmington,"N DuPont St and W 4th St",male,N/A,"Teen 12-17",N/A
+"December 24, 2019",Delaware,Wilmington,"200 block of Cityview Ave",male,N/A,"Adult 18+",N/A
+"December 24, 2019",Delaware,Wilmington,"200 block of Cityview Ave",male,"Daquell Walker","Adult 18+",N/A
+"December 24, 2019",Delaware,Wilmington,"500 block of New Castle Ave",male,N/A,"Adult 18+",N/A
+"December 24, 2019",Delaware,Dover,"S DuPont Hwy and Webbs Ln",male,N/A,"Adult 18+",N/A
+"December 24, 2019",Delaware,Dover,"S DuPont Hwy and Webbs Ln",male,N/A,"Adult 18+",N/A
+"December 24, 2019",Delaware,Dover,"S DuPont Hwy and Webbs Ln",male,N/A,"Teen 12-17",N/A
+"December 23, 2019",Delaware,Newark,"801 Christiana Rd",male,"Jakai White","Teen 12-17",N/A
+"December 23, 2019",Delaware,Dover,"N Governors Blvd",male,N/A,"Adult 18+",N/A
+"December 21, 2019",Delaware,Hartly,"Myers Dr",N/A,N/A,"Adult 18+",N/A
+"December 21, 2019",Delaware,Hartly,"Myers Dr",male,"Michael J. Rhinehardt","Adult 18+",N/A
+"December 20, 2019",Delaware,Seaford,"700 block of Collins Ave",male,N/A,"Adult 18+",N/A
+"December 20, 2019",Delaware,Seaford,"700 block of Collins Ave",male,"Xavier Mills-Davis","Adult 18+",N/A
+"December 18, 2019",Delaware,Milford,"200 block of North St",male,N/A,"Adult 18+",N/A
+"December 18, 2019",Delaware,Milford,"200 block of North St",male,N/A,"Adult 18+",N/A
+"December 17, 2019",Delaware,Wilmington,"1800 Block of Conrad St",male,N/A,"Adult 18+",N/A
+"December 16, 2019",Delaware,Wilmington,"2700 block of N West St",male,N/A,"Adult 18+",N/A
+"December 14, 2019",Delaware,Wilmington,"100 block of N Harrison St",male,N/A,"Teen 12-17",N/A
+"December 14, 2019",Delaware,Wilmington,"100 block of N Harrison St",male,"Isaiah Lecompte","Adult 18+",N/A
+"December 12, 2019",Delaware,Dover,"Mast Cir",male,N/A,"Adult 18+",N/A
+"December 12, 2019",Delaware,Dover,"Mast Cir",male,N/A,"Adult 18+",N/A
+"December 12, 2019",Delaware,Wilmington,"3400 block of Lancaster Pike",male,"Roger Williams","Adult 18+",N/A
+"December 12, 2019",Delaware,Wilmington,"3400 block of Lancaster Pike",male,"Michael Toombs","Adult 18+",N/A
+"December 11, 2019",Delaware,Harrington,"50 block of Diamond Ct",male,"Robert J. White","Adult 18+",N/A
+"December 7, 2019",Delaware,Selbyville,"29000 block of Poplar Ct",male,"Dionederik R. Godwin","Adult 18+",N/A
+"December 6, 2019",Delaware,Dover,"125 Haman Dr",male,N/A,"Adult 18+",N/A
+"December 6, 2019",Delaware,Dover,"125 Haman Dr",male,N/A,"Adult 18+",N/A
+"December 6, 2019",Delaware,Dover,"125 Haman Dr",male,N/A,"Adult 18+",N/A
+"December 4, 2019",Delaware,Dover,"400 block of E Water St",male,N/A,"Adult 18+",N/A
+"December 4, 2019",Delaware,Dover,"400 block of E Water St",male,"Jermaine Brown Jr.","Adult 18+",N/A
+"December 4, 2019",Delaware,Dover,"400 block of E Water St",male,"Arshawan Brown","Adult 18+",N/A
+"December 3, 2019",Delaware,Wilmington,"100 block of E 24th St",male,"Jaron Smullen","Adult 18+",N/A
+"December 3, 2019",Delaware,Wilmington,"100 block of E 24th St",male,"Keith Talley","Adult 18+",N/A
+"December 1, 2019",Delaware,Wilmington,"200 block of N Market St",female,N/A,"Adult 18+",N/A
+"December 1, 2019",Delaware,Wilmington,"200 block of N Market St",male,N/A,"Adult 18+",N/A
+"December 1, 2019",Delaware,Wilmington,"300 block of Barrett St",male,"Davine Boyce","Adult 18+",N/A
+"December 1, 2019",Delaware,Wilmington,"300 block of Barrett St",male,N/A,"Teen 12-17",N/A
+"December 1, 2019",Delaware,Wilmington,"300 block of Barrett St",male,N/A,"Teen 12-17",N/A
+"December 1, 2019",Delaware,Wilmington,"300 block of Barrett St",male,N/A,"Teen 12-17",N/A
+"November 29, 2019",Delaware,Lewes,"300 block of E Savannah Rd",male,N/A,"Adult 18+",N/A
+"November 27, 2019",Delaware,Bridgeville,"11000 block of Evans Dr",male,"James B. Bradt","Adult 18+",N/A
+"November 25, 2019",Delaware,Wilmington,"2300 block of Washington St",male,"Rajion Dinkins","Adult 18+",N/A
+"November 25, 2019",Delaware,Wilmington,"2300 block of Washington St",male,N/A,"Adult 18+",N/A
+"November 23, 2019",Delaware,Wilmington,"2300 block of Bowers St",male,N/A,"Adult 18+",N/A
+"November 23, 2019",Delaware,Wilmington,"2300 block of Bowers St",male,N/A,"Adult 18+",N/A
+"November 20, 2019",Delaware,Wilmington,"S Maryland Ave and E Newport Pike",male,N/A,"Adult 18+",N/A
+"November 20, 2019",Delaware,Delmar,"14122 Oak Branch Rd",male,"Tabvon L. Sabb","Adult 18+",N/A
+"November 18, 2019",Delaware,Wilmington,"100 block of E 24th St",male,N/A,"Adult 18+",N/A
+"November 18, 2019",Delaware,Wilmington,"100 block of E 24th St",male,"Markeevis McDougal","Adult 18+",N/A
+"November 16, 2019",Delaware,Dover,"S State St and Lake Land Ave",male,N/A,"Adult 18+",N/A
+"November 16, 2019",Delaware,Dover,"S State St and Lake Land Ave",male,N/A,"Adult 18+",N/A
+"November 16, 2019",Delaware,Dover,"S State St and Lake Land Ave",male,N/A,"Adult 18+",N/A
+"November 15, 2019",Delaware,Wilmington,"100 block of W 27th St",male,N/A,"Teen 12-17",N/A
+"November 13, 2019",Delaware,Dover,"50 block of Carlisle Dr",male,"Daevon C. Stratton","Adult 18+",N/A
+"November 11, 2019",Delaware,Wilmington,"1300 block of Chesnut St",male,"Andrew Burgos","Adult 18+",N/A
+"November 11, 2019",Delaware,Harrington,"100 block of Wolcott St",male,"Edward Bonsall Jr.","Adult 18+",N/A
+"November 11, 2019",Delaware,Wilmington,"301 W 29th St",male,N/A,"Adult 18+",N/A
+"November 11, 2019",Delaware,Wilmington,"301 W 29th St",male,N/A,"Teen 12-17",N/A
+"November 8, 2019",Delaware,Wilmington,"700 block of N Franklin St",male,"Xavier Nelson","Adult 18+",N/A
+"November 7, 2019",Delaware,Dover,"Karen Pl",male,"Angel Santiago","Adult 18+",N/A
+"November 5, 2019",Delaware,"Camden Wyoming","400 block of Jebb Rd",male,"William J. Edwards","Adult 18+",N/A
+"November 3, 2019",Delaware,Dover,"100 block of Old Forge Dr",female,N/A,"Adult 18+",N/A
+"November 3, 2019",Delaware,Dover,"100 block of Old Forge Dr",male,N/A,"Adult 18+",N/A
+"November 2, 2019",Delaware,Wilmington,"3800 block of N Market St",male,N/A,"Teen 12-17",N/A
+"November 2, 2019",Delaware,Wilmington,"3000 block of Washington St",male,N/A,"Teen 12-17",N/A
+"November 1, 2019",Delaware,Millsboro,"24000 block of Shoreline Dr",male,"Andrew L. Mudry","Adult 18+",N/A
+"November 1, 2019",Delaware,Millsboro,"24000 block of Shoreline Dr",male,"Ja’Charis D. Owens","Adult 18+",N/A
+"November 1, 2019",Delaware,Wilmington,"900 block of S Broom St",male,N/A,"Adult 18+",N/A
+"October 29, 2019",Delaware,Smyrna,"Chestnut St",male,"Kashar Mcivor","Adult 18+",N/A
+"October 29, 2019",Delaware,Dover,"100 block of Spruance Rd",male,"Joseph Barcita","Adult 18+",N/A
+"October 29, 2019",Delaware,Wilmington,"400 Foulk Rd",male,N/A,"Adult 18+",N/A
+"October 29, 2019",Delaware,Wilmington,"600 block of N West St",female,N/A,"Adult 18+",N/A
+"October 28, 2019",Delaware,Newark,"2360 Pulaski Hwy",male,N/A,"Adult 18+",N/A
+"October 28, 2019",Delaware,Newark,"2360 Pulaski Hwy",male,N/A,"Adult 18+",N/A
+"October 28, 2019",Delaware,Wilmington,"2500 block of Thatcher St",male,"Stephan Price","Adult 18+",N/A
+"October 28, 2019",Delaware,"New Castle","465 Marina Ln",male,N/A,"Adult 18+",N/A
+"October 28, 2019",Delaware,"New Castle","465 Marina Ln",male,N/A,"Adult 18+",N/A
+"October 28, 2019",Delaware,"New Castle","465 Marina Ln",male,N/A,"Adult 18+",N/A
+"October 28, 2019",Delaware,"New Castle","465 Marina Ln",male,N/A,"Adult 18+",N/A
+"October 28, 2019",Delaware,Newark,"50 block of Kings Cir",male,N/A,"Adult 18+",N/A
+"October 27, 2019",Delaware,Milton,"24000 block of Milton Ellendale Hwy",male,N/A,"Adult 18+",N/A
+"October 27, 2019",Delaware,Milton,"24000 block of Milton Ellendale Hwy",male,N/A,"Adult 18+",N/A
+"October 27, 2019",Delaware,Milton,"24000 block of Milton Ellendale Hwy",male,N/A,"Adult 18+",N/A
+"October 24, 2019",Delaware,Dover,"50 block of Harmony Hill Dr",male,"Rayquian Horsey","Adult 18+",N/A
+"October 24, 2019",Delaware,Dover,"50 block of Harmony Hill Dr",male,"Tywon Peace","Adult 18+",N/A
+"October 24, 2019",Delaware,Dover,"50 block of Harmony Hill Dr",male,"Michael Taylor","Adult 18+",N/A
+"October 24, 2019",Delaware,Dover,"50 block of Harmony Hill Dr",male,"Marquan Richardson","Adult 18+",N/A
+"October 24, 2019",Delaware,Dover,"50 block of Harmony Hill Dr",male,"Anthony Trower","Adult 18+",N/A
+"October 24, 2019",Delaware,Dover,"50 block of Harmony Hill Dr",male,"Deontray Watson","Adult 18+",N/A
+"October 24, 2019",Delaware,Dover,"50 block of Harmony Hill Dr",male,"Jawuan Horsey","Adult 18+",N/A
+"October 23, 2019",Delaware,Bear,"600 block of Parkman Ct",male,N/A,"Adult 18+",N/A
+"October 23, 2019",Delaware,Middletown,"1800 block of Choptank Rd",male,"Damaris Farmer-Rhamad","Adult 18+",N/A
+"October 23, 2019",Delaware,Middletown,"1800 block of Choptank Rd",male,"Derrick A. Rhamad","Adult 18+",N/A
+"October 22, 2019",Delaware,Harrington,"N West St",male,"Thomas Wester","Adult 18+",N/A
+"October 22, 2019",Delaware,Seaford,"24000 block of Concord Pond Rd",male,"Damon L. Dillard","Adult 18+",N/A
+"October 22, 2019",Delaware,Seaford,"24000 block of Concord Pond Rd",female,"Bonnie L. Cannon","Adult 18+",N/A
+"October 21, 2019",Delaware,Hockessin,"4000 block of Newport Gap Pike",female,N/A,"Adult 18+",N/A
+"October 21, 2019",Delaware,Smyrna,"500 block of Owens Brook Dr",male,N/A,"Adult 18+",N/A
+"October 20, 2019",Delaware,Dover,"50 block of S New St",male,N/A,"Adult 18+",N/A
+"October 20, 2019",Delaware,Wilmington,"300 block of N Franklin St",male,"James Broadnax","Adult 18+",N/A
+"October 20, 2019",Delaware,Wilmington,"300 block of N Franklin St",male,"Marcus Swanson","Adult 18+",N/A
+"October 20, 2019",Delaware,Wilmington,"300 block of N Franklin St",male,"Marcel Swanson","Adult 18+",N/A
+"October 19, 2019",Delaware,Laurel,"1000 Holly Brook Apartments",male,"Taj Trammell","Adult 18+",N/A
+"October 18, 2019",Delaware,Wilmington,"2200 block of N Spruce St",male,N/A,"Adult 18+",N/A
+"October 17, 2019",Delaware,Hartly,"200 block of Will Scarlet Ln",male,"Roy G Kolaco","Adult 18+",N/A
+"October 17, 2019",Delaware,"Wilmington (Edgemoor)","Bedford Dr",female,N/A,"Adult 18+",N/A
+"October 16, 2019",Delaware,Dover,"200 block of W Division St",male,N/A,"Teen 12-17",N/A
+"October 16, 2019",Delaware,"Wilmington (Edgemoor)","S Cannon Dr",male,N/A,"Teen 12-17",N/A
+"October 12, 2019",Delaware,Wilmington,"900 block of N Lombard St",male,N/A,"Adult 18+",N/A
+"October 12, 2019",Delaware,Wilmington,"900 block of N Lombard St",male,"Shyheim Bordrick","Adult 18+",N/A
+"October 8, 2019",Delaware,Seaford,"24000 block of German Rd",male,"Rayshawn Sheppard","Adult 18+",N/A
+"October 8, 2019",Delaware,Seaford,"24000 block of German Rd",male,"Dajuan C Sheppard","Adult 18+",N/A
+"October 5, 2019",Delaware,Dover,"200 block of S Dupont Hwy",male,"Dakota Borntreger","Adult 18+",N/A
+"October 3, 2019",Delaware,Greenwood,"6200 block of Hickman Rd",male,"Demond L. Anderson","Adult 18+",N/A
+"October 3, 2019",Delaware,Greenwood,"6200 block of Hickman Rd",male,"Steven R. Keely","Adult 18+",N/A
+"October 3, 2019",Delaware,Greenwood,"6200 block of Hickman Rd",male,"Karen A. Clineff","Adult 18+",N/A
+"October 3, 2019",Delaware,Greenwood,"6200 block of Hickman Rd",male,"Steven C. Keely","Adult 18+",N/A
+"September 30, 2019",Delaware,Wilmington,"700 block of N Washington St",male,"Artezz Finney","Adult 18+",N/A
+"September 29, 2019",Delaware,Newark,"300 block of Terrace Dr",male,"George McCullough","Adult 18+",N/A
+"September 29, 2019",Delaware,"New Castle","Briarcliff Dr",male,"Aaron Hill","Adult 18+",N/A
+"September 27, 2019",Delaware,Wilmington,"2500 block of N Monroe St",male,"Hakeem Smalls","Adult 18+",N/A
+"September 26, 2019",Delaware,Laurel,"2708 Daniel St",male,"Tijere Baldwin","Adult 18+",N/A
+"September 26, 2019",Delaware,Laurel,"2708 Daniel St",male,"Stephon McDonald","Adult 18+",N/A
+"September 26, 2019",Delaware,Bear,"108 Mario Dr",male,N/A,"Adult 18+",N/A
+"September 26, 2019",Delaware,Bear,"108 Mario Dr",male,"Jordyn Williams","Adult 18+",N/A
+"September 25, 2019",Delaware,Dover,"865 N DuPont Hwy",male,N/A,"Adult 18+",N/A
+"September 25, 2019",Delaware,Dover,"865 N DuPont Hwy",female,N/A,"Adult 18+",N/A
+"September 25, 2019",Delaware,Dover,"865 N DuPont Hwy",female,N/A,"Adult 18+",N/A
+"September 23, 2019",Delaware,Harrington,"1259 Corn Crib Rd",male,N/A,"Adult 18+",N/A
+"September 23, 2019",Delaware,Harrington,"1259 Corn Crib Rd",male,N/A,"Adult 18+",N/A
+"September 23, 2019",Delaware,Seaford,"23000 block of German Rd",male,N/A,"Adult 18+",N/A
+"September 23, 2019",Delaware,Seaford,"23000 block of German Rd",male,N/A,"Adult 18+",N/A
+"September 23, 2019",Delaware,Seaford,"23000 block of German Rd",male,N/A,"Adult 18+",N/A
+"September 23, 2019",Delaware,Seaford,"23000 block of German Rd",male,N/A,"Adult 18+",N/A
+"September 22, 2019",Delaware,Dover,"1210 White Oak Rd",male,N/A,"Adult 18+",N/A
+"September 22, 2019",Delaware,Dover,"1210 White Oak Rd",male,N/A,"Adult 18+",N/A
+"September 22, 2019",Delaware,Dover,"1210 White Oak Rd",male,"William E. Cane Jr.","Adult 18+",N/A
+"September 21, 2019",Delaware,Wilmington,"600 block of N Monroe St",male,"Ignacio Russell","Adult 18+",N/A
+"September 20, 2019",Delaware,Milford,"Bay Rd",male,"Shawn Colson","Adult 18+",N/A
+"September 20, 2019",Delaware,Seaford,"700 block of Atlanta Rd",male,"Daniel A. Allen","Adult 18+",N/A
+"September 20, 2019",Delaware,Seaford,"700 block of Atlanta Rd",female,"Alexia K. Allen","Adult 18+",N/A
+"September 18, 2019",Delaware,Newark,"457 Stanton Christiana Rd",male,"Rashaad Benson","Adult 18+",N/A
+"September 16, 2019",Delaware,Dover,"3100 block of Forrest Ave",female,N/A,"Adult 18+",N/A
+"September 16, 2019",Delaware,Wilmington,"W 7th St and N Monroe St",male,N/A,"Adult 18+",N/A
+"September 16, 2019",Delaware,Wilmington,"1000 block of N Van Buren St",male,"Kenyotta Manuel","Adult 18+",N/A
+"September 15, 2019",Delaware,Bear,"3800 block of Wrangle Hill Rd",male,"Jesse E. Davis","Adult 18+",N/A
+"September 15, 2019",Delaware,Wilmington,"1900 block of N Washington St",male,N/A,"Adult 18+",N/A
+"September 14, 2019",Delaware,Wilmington,"900 block of E 4th St",male,"Lamont Robinson","Adult 18+",N/A
+"September 13, 2019",Delaware,Wilmington,"900 block of Bennett St",female,"Nadine Midgette","Adult 18+",N/A
+"September 13, 2019",Delaware,Wilmington,"N Monroe St and W 5th St",male,"Dwayne Britt","Adult 18+",N/A
+"September 13, 2019",Delaware,Wilmington,"N Monroe St and W 5th St",male,"Kenneth Hamilton","Adult 18+",N/A
+"September 12, 2019",Delaware,Dover,"200 block of Harmony Ln",male,"Jarmar Richardson","Adult 18+",N/A
+"September 12, 2019",Delaware,Dover,"200 block of Harmony Ln",male,"Stefan Rush-Wilson","Adult 18+",N/A
+"September 12, 2019",Delaware,Wilmington,"600 block of Concord Ave",male,"Davante Hawkins","Adult 18+",N/A
+"September 12, 2019",Delaware,Wilmington,"600 block of Concord Ave",male,"Jewel Henry","Adult 18+",N/A
+"September 11, 2019",Delaware,Wilmington,"200 block of N Harrison St",male,"Wali Minor","Adult 18+",N/A
+"September 11, 2019",Delaware,Wilmington,"E 10th St and Wilson St",male,"Brook Charles","Adult 18+",N/A
+"September 10, 2019",Delaware,Wilmington,"700 block of N Monroe St",female,N/A,"Adult 18+",N/A
+"September 9, 2019",Delaware,Wilmington,"700 block of N Monroe St",female,N/A,"Adult 18+",N/A
+"September 7, 2019",Delaware,Wilmington,"2600 block of N Tatnall St",male,N/A,"Teen 12-17",N/A
+"September 7, 2019",Delaware,Wilmington,"2600 block of N Tatnall St",male,N/A,"Teen 12-17",N/A
+"September 7, 2019",Delaware,Wilmington,"2600 block of N Tatnall St",male,N/A,"Teen 12-17",N/A
+"September 7, 2019",Delaware,Wilmington,"2600 block of N Tatnall St",male,N/A,"Teen 12-17",N/A
+"September 7, 2019",Delaware,Wilmington,"2600 block of N Tatnall St",male,N/A,"Teen 12-17",N/A
+"September 5, 2019",Delaware,Milford,"Old Shawnee Rd",male,"Treyvon L. Bowman","Adult 18+",N/A
+"September 5, 2019",Delaware,Milford,"Old Shawnee Rd",male,"William Harris","Adult 18+",N/A
+"September 5, 2019",Delaware,Harrington,"Mill St",male,"Nathan Sample","Adult 18+",N/A
+"September 5, 2019",Delaware,Harrington,"Mill St",male,"Eric R. McDonald","Adult 18+",N/A
+"September 4, 2019",Delaware,Dover,"50 block of Stevenson Dr",male,"Vaughn Hall","Teen 12-17",N/A
+"September 4, 2019",Delaware,Dover,"50 block of Stevenson Dr",male,N/A,Unknown,N/A
+"September 3, 2019",Delaware,Magnolia,"Walnut Shade Rd",male,"Christopher M. Foraker","Adult 18+",N/A
+"September 3, 2019",Delaware,Wilmington,"400 block of E 35th St",male,"Naithan Grzybowski","Adult 18+",N/A
+"September 3, 2019",Delaware,Wilmington,"600 block of N Scott St",male,N/A,"Adult 18+",N/A
+"September 1, 2019",Delaware,Smyrna,"5000 block of Smyrna Leipsic Rd",male,"Sean R. Speed","Adult 18+",N/A
+"September 1, 2019",Delaware,Smyrna,"5000 block of Smyrna Leipsic Rd",male,"Jeffery L. Peer","Adult 18+",N/A
+"September 1, 2019",Delaware,Wilmington,"1000 block of Spruce St",male,N/A,"Adult 18+",N/A
+"September 1, 2019",Delaware,Wilmington,"1000 block of Spruce St",male,N/A,"Teen 12-17",N/A
+"August 31, 2019",Delaware,Bridgeville,"1st St and Vine St",female,N/A,"Adult 18+",N/A
+"August 31, 2019",Delaware,Wilmington,"400 block of S Van Buren St",female,"Alexis Anthony","Adult 18+",N/A
+"August 30, 2019",Delaware,Wilmington,"300 block of S Jackson St",male,"Tyrone Folks","Adult 18+",N/A
+"August 30, 2019",Delaware,Wilmington,"2700 block of Washington St",male,"Ricardo Hylton","Adult 18+",N/A
+"August 30, 2019",Delaware,Wilmington,"600 block of N Van Buren St",male,"Michael Lacy","Adult 18+",N/A
+"August 29, 2019",Delaware,Dagsboro,"Main St and Iron Branch Rd",male,"Bryan Irvin","Adult 18+",N/A
+"August 29, 2019",Delaware,"Wilmington (Stanton)","50 block of Cypress Ave",male,"Brett Johns","Adult 18+",N/A
+"August 29, 2019",Delaware,"Wilmington (Stanton)","50 block of Cypress Ave",male,"John Sniadowski","Adult 18+",N/A
+"August 28, 2019",Delaware,Wilmington,N/A,male,"Carl D. Roy","Adult 18+",N/A
+"August 27, 2019",Delaware,Wilmington,"DE-2 and Limestone Rd",male,"Gerald Crooks Jr.","Adult 18+",N/A
+"August 27, 2019",Delaware,Wilmington,"400 block of N Church St",female,"Keyhonna Brown","Adult 18+",N/A
+"August 26, 2019",Delaware,Dover,"Tollhouse Pl",male,"Corey M. Patrick","Adult 18+",N/A
+"August 25, 2019",Delaware,Claymont,"50 block of Balfour Ave",male,N/A,"Adult 18+",N/A
+"August 25, 2019",Delaware,Claymont,"50 block of Balfour Ave",male,"Shacir Hunter","Adult 18+",N/A
+"August 24, 2019",Delaware,Dover,"2000 block of Generals Way",male,"Glenn Klebart","Adult 18+",N/A
+"August 24, 2019",Delaware,Milton,"100 block of Bangor Ln",male,"Kaleb R. Lemaire","Adult 18+",N/A
+"August 23, 2019",Delaware,Wilmington,"1700 block of W 4th St",male,"Donald Wilson","Adult 18+",N/A
+"August 21, 2019",Delaware,Newark,"500 block of Salem Church Rd",male,"Antwan R. Bonaparte","Adult 18+",N/A
+"August 21, 2019",Delaware,Milton,"Coastal Hwy and Broadkill Rd",male,"Russell H. Zern Jr.","Adult 18+",N/A
+"August 21, 2019",Delaware,Seaford,"22681 Eskridge Rd",male,"Howard F. Green IV","Adult 18+",N/A
+"August 20, 2019",Delaware,Newark,"1119 S College Ave",male,"Deonte Lewis","Adult 18+",N/A
+"August 20, 2019",Delaware,Wilmington,"300 block of N Connell St",male,"Albert Nunez","Adult 18+",N/A
+"August 19, 2019",Delaware,Wilmington,"900 block of N Church St",male,"Sharif Elsayed","Adult 18+",N/A
+"August 19, 2019",Delaware,Wilmington,"200 block of N Harrison St",male,"Tyree Jackson","Adult 18+",N/A
+"August 19, 2019",Delaware,Wilmington,"200 block of N Harrison St",male,"Malik Youngblood","Adult 18+",N/A
+"August 18, 2019",Delaware,Newark,"1119 S College Ave",male,"Donte Hammond","Adult 18+",N/A
+"August 18, 2019",Delaware,Newark,"1119 S College Ave",male,N/A,"Adult 18+",N/A
+"August 18, 2019",Delaware,"Wilmington (Newport)","3000 block of Valley Brook Dr",male,"Michael Guzman","Adult 18+",N/A
+"August 18, 2019",Delaware,"Wilmington (Newport)","3000 block of Valley Brook Dr",male,"William Barnett","Adult 18+",N/A
+"August 18, 2019",Delaware,"Wilmington (Newport)","3000 block of Valley Brook Dr",male,"Cartney Goode","Adult 18+",N/A
+"August 18, 2019",Delaware,"Wilmington (Newport)","3000 block of Valley Brook Dr",male,"Nazir Henry","Adult 18+",N/A
+"August 18, 2019",Delaware,Wilmington,"2200 block of N Locust St",male,N/A,"Adult 18+",N/A
+"August 17, 2019",Delaware,Dover,"S New St and Reed St",male,N/A,"Adult 18+",N/A
+"August 16, 2019",Delaware,Wilmington,"13th St and Thatcher St",male,N/A,"Teen 12-17",N/A
+"August 16, 2019",Delaware,Wilmington,"1300 block of Banning St",male,N/A,"Teen 12-17",N/A
+"August 15, 2019",Delaware,Wilmington,"E 23rd St and Pine St",male,N/A,"Teen 12-17",N/A
+"August 15, 2019",Delaware,Wilmington,"2000 block of W 6th St",male,N/A,"Teen 12-17",N/A
+"August 15, 2019",Delaware,Frankford,"Star Ln and Peppers Corner Rd",male,N/A,"Adult 18+",N/A
+"August 15, 2019",Delaware,Frankford,"Star Ln and Peppers Corner Rd",female,N/A,"Adult 18+",N/A
+"August 15, 2019",Delaware,Frankford,"Star Ln and Peppers Corner Rd",female,"Maureen E. Gray","Adult 18+",N/A
+"August 15, 2019",Delaware,Wilmington,"2200 block of Locust St",male,N/A,"Adult 18+",N/A
+"August 14, 2019",Delaware,Wilmington,"800 block of N Pine St",male,N/A,"Adult 18+",N/A
+"August 14, 2019",Delaware,Wilmington,"2100 block of Locust St",male,"Ivan Cornelious","Adult 18+",N/A
+"August 13, 2019",Delaware,Wilmington,"E 23rd St and Lamotte St",female,N/A,"Adult 18+",N/A
+"August 12, 2019",Delaware,Wilmington,"3000 block of N West St",male,N/A,"Adult 18+",N/A
+"August 11, 2019",Delaware,Dover,"50 block of S New St",female,N/A,"Adult 18+",N/A
+"August 11, 2019",Delaware,Dover,"50 block of S New St",male,"Zion Saunders","Adult 18+",N/A
+"August 10, 2019",Delaware,Wilmington,"600 block of Tatnall St",male,N/A,"Teen 12-17",N/A
+"August 10, 2019",Delaware,Newark,"Bellevue Rd",male,"Brandon Norman","Adult 18+",N/A
+"August 9, 2019",Delaware,Smyrna,"Kent Way and Owens Brook Dr",male,"Bashan McIvor","Adult 18+",N/A
+"August 8, 2019",Delaware,Wilmington,"50 block of Race St",male,"David Murray","Adult 18+",N/A
+"August 7, 2019",Delaware,Wilmington,"800 block of W 3rd St",male,"Luis Quiles","Adult 18+",N/A
+"August 7, 2019",Delaware,Wilmington,"200 block of W St",male,"Joshua Tricarico","Adult 18+",N/A
+"August 6, 2019",Delaware,Wilmington,"50 block of Lower Oak St",male,N/A,"Teen 12-17",N/A
+"August 6, 2019",Delaware,Wilmington,"50 block of Lower Oak St",male,"Nazir Henry","Teen 12-17",N/A
+"August 6, 2019",Delaware,Wilmington,"600 block of E 10th St",male,N/A,"Adult 18+",N/A
+"August 6, 2019",Delaware,Dover,"2000 block of Generals Way",male,"Khalil Hanzer","Adult 18+",N/A
+"August 6, 2019",Delaware,Dover,"2000 block of Generals Way",female,"Tiffiny Melton","Adult 18+",N/A
+"August 5, 2019",Delaware,Wilmington,"200 block of N Harrison St",female,N/A,"Adult 18+",N/A
+"August 5, 2019",Delaware,Wilmington,"200 block of N Harrison St",male,N/A,"Adult 18+",N/A
+"August 3, 2019",Delaware,Newark,"101 Geoffrey Dr",male,"Charles Dangel Jr","Adult 18+",N/A
+"August 3, 2019",Delaware,Wilmington,"600 block of Taylor St",male,N/A,"Adult 18+",N/A
+"August 3, 2019",Delaware,Dover,"6 W Lebanon Rd",male,N/A,"Adult 18+",N/A
+"August 3, 2019",Delaware,Dover,"6 W Lebanon Rd",male,"Anthony P. Taylor","Adult 18+",N/A
+"August 3, 2019",Delaware,Delmar,"37000 block of Marsha St",male,"Jonathan L. Palmer","Adult 18+",N/A
+"August 2, 2019",Delaware,Dover,"Rockford Crossing",male,"Kampta Sharma","Adult 18+",N/A
+"August 1, 2019",Delaware,Dover,"200 block of E Sheldrake Cir",male,"Jahheam Taylor","Adult 18+",N/A
+"August 1, 2019",Delaware,Dover,"200 block of E Sheldrake Cir",male,N/A,"Teen 12-17",N/A
+"August 1, 2019",Delaware,Dover,"200 block of E Sheldrake Cir",male,N/A,"Teen 12-17",N/A
+"August 1, 2019",Delaware,Dover,"200 block of E Sheldrake Cir",male,N/A,"Teen 12-17",N/A
+"July 29, 2019",Delaware,Milton,"Fisher Rd",male,"Vincent M. Schlothauer","Adult 18+",N/A
+"July 28, 2019",Delaware,Wilmington,"700 block of W 5th St",female,N/A,"Adult 18+",N/A
+"July 28, 2019",Delaware,Wilmington,"700 block of W 5th St",male,"Cecil Williams","Adult 18+",N/A
+"July 28, 2019",Delaware,Wilmington,"700 block of W 5th St",male,"Jamarr Williams","Adult 18+",N/A
+"July 28, 2019",Delaware,Harrington,"100 block of Dorman St",male,"John Slack","Adult 18+",N/A
+"July 25, 2019",Delaware,Wilmington,"700 block of W 4th St",male,"Terry Wise","Adult 18+",N/A
+"July 25, 2019",Delaware,Wilmington,"700 block of W 4th St",male,"Nazir Henry","Adult 18+",N/A
+"July 23, 2019",Delaware,Ellendale,"16979 Beach Hwy",male,"Jordan L. Young","Adult 18+",N/A
+"July 23, 2019",Delaware,Wilmington,"1700 block of W 4th St",male,N/A,"Adult 18+",N/A
+"July 23, 2019",Delaware,Wilmington,"1700 block of W 4th St",male,"Robert Deshields","Adult 18+",N/A
+"July 22, 2019",Delaware,Wilmington,"1800 block of W 2nd St",male,N/A,"Adult 18+",N/A
+"July 22, 2019",Delaware,Wilmington,"1800 block of W 2nd St",male,"Dupree Burroughs","Adult 18+",N/A
+"July 21, 2019",Delaware,Dover,"S New St",male,"James Ewell","Adult 18+",N/A
+"July 21, 2019",Delaware,Dover,"S New St",male,"Jonair Pollard","Adult 18+",N/A
+"July 21, 2019",Delaware,Dover,"S New St and W Reed St",male,N/A,"Adult 18+",N/A
+"July 21, 2019",Delaware,Dover,"S New St and W Reed St",male,N/A,"Adult 18+",N/A
+"July 20, 2019",Delaware,Wilmington,"1600 block of N Market St",male,N/A,"Teen 12-17",N/A
+"July 20, 2019",Delaware,Wilmington,"500 Delaware Ave",male,"Emmanuel Kamara Jr.","Adult 18+",N/A
+"July 20, 2019",Delaware,Wilmington,"700 Foulk Rd",female,"Gail F. Camerota","Adult 18+",N/A
+"July 20, 2019",Delaware,Wilmington,"700 Foulk Rd",male,"Louis M. Camerota","Adult 18+",N/A
+"July 19, 2019",Delaware,Dover,"805 Forest Ave",male,"Joseph Rivard","Adult 18+",N/A
+"July 17, 2019",Delaware,Wilmington,"4304 N Market St",male,N/A,"Adult 18+",N/A
+"July 17, 2019",Delaware,Wilmington,"4304 N Market St",male,N/A,"Adult 18+",N/A
+"July 17, 2019",Delaware,Wilmington,"4304 N Market St",N/A,N/A,Unknown,N/A
+"July 16, 2019",Delaware,Dover,"S New St and W Reed St",male,"Kolby Fluitt","Adult 18+",N/A
+"July 15, 2019",Delaware,Wilmington,"1300 block of Beech St",male,N/A,"Teen 12-17",N/A
+"July 15, 2019",Delaware,Newark,"50 block of Waltham St",male,"Mar-ky Frederick","Adult 18+",N/A
+"July 15, 2019",Delaware,Wilmington,"3000 block of Lancaster Ave",male,"Dylan Lewandowski","Adult 18+",N/A
+"July 15, 2019",Delaware,Smyrna,"White Rabbit Dr and Groundhog Ln",male,"Donahue Ellis III","Adult 18+",N/A
+"July 14, 2019",Delaware,Magnolia,"S Draper Cir",male,"Andrew J. Wharff","Adult 18+",N/A
+"July 12, 2019",Delaware,Wilmington,"600 block of W 5th St",male,N/A,"Adult 18+",N/A
+"July 11, 2019",Delaware,Milford,"200 block of Charles St",male,"Jamel Littlepage","Adult 18+",N/A
+"July 10, 2019",Delaware,Lincoln,"15866 Winners Cir",male,"Brian D. Chirdon","Adult 18+",N/A
+"July 10, 2019",Delaware,Lincoln,"15866 Winners Cir",male,"David Bernard Chirdon","Adult 18+",N/A
+"July 9, 2019",Delaware,Seaford,"800 block of Clementine Ct",male,"Charlie V. Riddick","Adult 18+",N/A
+"July 9, 2019",Delaware,Seaford,"800 block of Clementine Ct",male,"Isiah J. Major","Adult 18+",N/A
+"July 9, 2019",Delaware,Wilmington,"2500 block of Baynard Blvd",male,"Aaron Brooks","Adult 18+",N/A
+"July 9, 2019",Delaware,Seaford,"N Paula Lynne Dr",female,"Toya D. Roberts","Adult 18+",N/A
+"July 6, 2019",Delaware,Wilmington,"W 5th St and N Bancroft Pkwy",male,"Anthony Gray","Adult 18+",N/A
+"July 6, 2019",Delaware,Dover,"6000 block of N DuPont Hwy",male,"Christopher Scott","Adult 18+",N/A
+"July 5, 2019",Delaware,Newark,"164 Aspen Dr",male,"Kemuel Luo","Adult 18+",N/A
+"July 5, 2019",Delaware,Wilmington,"600 block of N West St",male,N/A,"Adult 18+",N/A
+"July 4, 2019",Delaware,Dover,"100 block of Katrina Way",male,"Christopher Evans","Teen 12-17",N/A
+"July 4, 2019",Delaware,Dover,"100 block of Katrina Way",male,"Romeo Downs","Teen 12-17",N/A
+"July 4, 2019",Delaware,Dover,"100 block of Katrina Way",male,N/A,"Adult 18+",N/A
+"July 4, 2019",Delaware,Dover,"100 block of Katrina Way",male,"Jason Brittingham","Adult 18+",N/A
+"July 4, 2019",Delaware,Magnolia,"50 block of Woodville Dr",male,N/A,"Adult 18+",N/A
+"July 3, 2019",Delaware,Wilmington,"700 block of 4th St",male,N/A,"Teen 12-17",N/A
+"July 3, 2019",Delaware,Wilmington,"700 block of 4th St",male,N/A,"Teen 12-17",N/A
+"July 3, 2019",Delaware,Wilmington,"600 block of 5th St",male,"Joseph Hodges","Adult 18+",N/A
+"July 1, 2019",Delaware,Wilmington,"600 block of W 5th St",male,"Michael McNeary Jr.","Adult 18+",N/A
+"June 29, 2019",Delaware,Wilmington,"50 block of Gordon St",male,N/A,"Adult 18+",N/A
+"June 29, 2019",Delaware,Wilmington,"50 block of Gordon St",male,N/A,"Teen 12-17",N/A
+"June 28, 2019",Delaware,"Rehoboth Beach","35567 Big Oaks Ln",male,"John P Wolfe","Adult 18+",N/A
+"June 26, 2019",Delaware,Harrington,"7250 Milford Harrington Hwy",female,"Leiarra Burton","Teen 12-17",N/A
+"June 25, 2019",Delaware,Dover,"50 block of N Kirkwood St",male,"Sencier Mansfield","Adult 18+",N/A
+"June 25, 2019",Delaware,Dover,"50 block of Howe Dr",male,"Justin Topolski","Adult 18+",N/A
+"June 21, 2019",Delaware,Seaford,"500 Findley Way",male,"Isaiah J Greene","Adult 18+",N/A
+"June 19, 2019",Delaware,Bridgeville,"Meadowlark Dr",male,"Jevontae L. Dale","Adult 18+",N/A
+"June 18, 2019",Delaware,Wilmington,"1100 block of W 4th St",male,"Neville Waters","Adult 18+",N/A
+"June 16, 2019",Delaware,Dover,"Barrister Pl",male,N/A,"Adult 18+",N/A
+"June 16, 2019",Delaware,Dover,"Barrister Pl",male,N/A,"Adult 18+",N/A
+"June 15, 2019",Delaware,Smyrna,"DE 1",male,"Antonio F. Williams","Adult 18+",N/A
+"June 15, 2019",Delaware,Wilmington,"1100 block of W 5th St",male,"Keenan Geter-Boatswain","Adult 18+",N/A
+"June 12, 2019",Delaware,Dover,"100 block of Willis Rd",male,"Jaquell McDonald","Adult 18+",N/A
+"June 7, 2019",Delaware,Smyrna,"N Albright Dr",male,"Tyler Scott","Adult 18+",N/A
+"June 7, 2019",Delaware,Smyrna,"N Albright Dr",male,"Malik Rothwell","Adult 18+",N/A
+"June 6, 2019",Delaware,Dover,"300 block of Frear Dr",male,"Nathaniel Hampton","Adult 18+",N/A
+"June 6, 2019",Delaware,Dover,"300 block of Frear Dr",female,"Vanessa Leon","Adult 18+",N/A
+"June 5, 2019",Delaware,Laurel,"36000 block of Waycross Rd",male,"Donnie J. Bennett","Adult 18+",N/A
+"June 4, 2019",Delaware,Wilmington,"100 block of S Harrison St",male,"Luther Sellers","Adult 18+",N/A
+"June 4, 2019",Delaware,Wilmington,"1900 block of N Market St",female,"Shakira Wideman","Adult 18+",N/A
+"June 2, 2019",Delaware,Dover,"865 N Dupont Hwy",male,"Naquan Ingram","Adult 18+",N/A
+"June 2, 2019",Delaware,Dover,"865 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"June 2, 2019",Delaware,Wilmington,"2300 block of Baynard Blvd",male,"Dylan Joyner","Adult 18+",N/A
+"June 2, 2019",Delaware,Wilmington,"1000 block of E 27th St",male,N/A,"Teen 12-17",N/A
+"June 1, 2019",Delaware,Dover,"492 Walnut Shade Rd",male,"Cameron Houck","Adult 18+",N/A
+"June 1, 2019",Delaware,Wilmington,"1100 block of E 13th St",female,N/A,"Adult 18+",N/A
+"June 1, 2019",Delaware,Wilmington,"1100 block of E 13th St",male,N/A,"Adult 18+",N/A
+"June 1, 2019",Delaware,Wilmington,"1200 block of N Walnut St",male,"Davvar Odom","Adult 18+",N/A
+"June 1, 2019",Delaware,Wilmington,"1200 block of N Walnut St",male,"Rahmir Williams","Adult 18+",N/A
+"June 1, 2019",Delaware,Ellendale,"12327 DuPont Blvd",male,N/A,"Adult 18+",N/A
+"June 1, 2019",Delaware,Ellendale,"12327 DuPont Blvd",male,"Reggie D. White","Adult 18+",N/A
+"June 1, 2019",Delaware,Ellendale,"12327 DuPont Blvd",male,"Curtis L. Taylor","Adult 18+",N/A
+"June 1, 2019",Delaware,Ellendale,"12327 DuPont Blvd",male,"Joshua A. Wright","Adult 18+",N/A
+"June 1, 2019",Delaware,Dover,"211 W Loockerman St",male,"Julius Johnson","Adult 18+",N/A
+"June 1, 2019",Delaware,Dover,"211 W Loockerman St",male,"Dion Williams","Adult 18+",N/A
+"June 1, 2019",Delaware,Claymont,"Fourth Ave",male,N/A,"Adult 18+",N/A
+"May 31, 2019",Delaware,Wilmington,"24th St and Market St",male,N/A,"Teen 12-17",N/A
+"May 31, 2019",Delaware,Seaford,"20000 block of Mellin Rd",male,"Roy F. Nichols Jr.","Adult 18+",N/A
+"May 31, 2019",Delaware,Seaford,"20000 block of Mellin Rd",male,"Jonathan I. Tunnell","Adult 18+",N/A
+"May 30, 2019",Delaware,Wilmington,"1700 block of Lancaster Ave",male,"Cedrick Facon","Adult 18+",N/A
+"May 30, 2019",Delaware,Wilmington,"1700 block of Lancaster Ave",male,"Nijir Lee","Adult 18+",N/A
+"May 29, 2019",Delaware,Bear,"Wicklow Rd",male,"Isaiah Dejesus","Adult 18+",N/A
+"May 29, 2019",Delaware,Bear,"Wicklow Rd",male,"Bryce Sanders","Adult 18+",N/A
+"May 29, 2019",Delaware,Bear,"Wicklow Rd",male,"Kevon Gavin","Adult 18+",N/A
+"May 29, 2019",Delaware,Wilmington,"Cedar St and Wright St",male,"Malik Brown","Adult 18+",N/A
+"May 29, 2019",Delaware,Wilmington,"900 block of E 17th St",male,"Francis Miller","Adult 18+",N/A
+"May 24, 2019",Delaware,Wilmington,"600 block of Taylor St",male,N/A,"Adult 18+",N/A
+"May 24, 2019",Delaware,Wilmington,"300 block of Concord Ave",male,"Steven Coverdale","Adult 18+",N/A
+"May 24, 2019",Delaware,Wilmington,"700 block of S Van Buren St",male,N/A,"Teen 12-17",N/A
+"May 23, 2019",Delaware,Dover,"400 block of S Governors Ave",male,N/A,"Adult 18+",N/A
+"May 23, 2019",Delaware,Dover,"400 block of S Governors Ave",male,"Jamal Jones","Adult 18+",N/A
+"May 23, 2019",Delaware,Dover,"400 block of S Governors Ave",male,N/A,"Adult 18+",N/A
+"May 23, 2019",Delaware,Wilmington,"100 block of N Van Buren St",male,"Jawahn Harper","Adult 18+",N/A
+"May 23, 2019",Delaware,Dover,"50 block of Stevenson Dr",female,N/A,"Adult 18+",N/A
+"May 23, 2019",Delaware,Dover,"50 block of Stevenson Dr",male,"Brandon Scott","Teen 12-17",N/A
+"May 23, 2019",Delaware,Dover,"50 block of Stevenson Dr",male,"Johnny Bottomley","Adult 18+",N/A
+"May 23, 2019",Delaware,Dover,"50 block of Stevenson Dr",male,N/A,"Adult 18+",N/A
+"May 22, 2019",Delaware,Newark,"2400 block of Millstone Dr",male,"Patrick Powell","Adult 18+",N/A
+"May 22, 2019",Delaware,Wilmington,"1100 block of W 4th St",male,"Clarence Jarman","Adult 18+",N/A
+"May 22, 2019",Delaware,Wilmington,"1100 block of W 4th St",male,"Eddy Peguero","Adult 18+",N/A
+"May 22, 2019",Delaware,Wilmington,"1100 block of W 4th St",male,N/A,"Teen 12-17",N/A
+"May 21, 2019",Delaware,Lewes,"22971 Suburban Blvd",female,"Taylor Gasiewski","Teen 12-17",N/A
+"May 21, 2019",Delaware,Wilmington,"9th St and Tatnall St",male,"Ronald Leslie","Adult 18+",N/A
+"May 21, 2019",Delaware,Wilmington,"9th St and Tatnall St",male,"Monte Scott","Adult 18+",N/A
+"May 20, 2019",Delaware,Wilmington,"400 block of Tatnall St",male,N/A,"Adult 18+",N/A
+"May 19, 2019",Delaware,Dover,"Barrister Pl and S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"May 19, 2019",Delaware,Magnolia,"500 block of Millchop Ln",male,N/A,"Adult 18+",N/A
+"May 19, 2019",Delaware,Magnolia,"500 block of Millchop Ln",male,N/A,"Adult 18+",N/A
+"May 19, 2019",Delaware,Magnolia,"500 block of Millchop Ln",male,N/A,"Adult 18+",N/A
+"May 19, 2019",Delaware,Magnolia,"500 block of Millchop Ln",male,N/A,"Adult 18+",N/A
+"May 19, 2019",Delaware,Wilmington,"800 block of E 13th St",male,N/A,"Adult 18+",N/A
+"May 18, 2019",Delaware,"New Castle","1213 West Ave",male,"Leovardo Dominguez-Amezquita","Adult 18+",N/A
+"May 17, 2019",Delaware,Wilmington,"800 block of Towne Ct",male,N/A,"Adult 18+",N/A
+"May 17, 2019",Delaware,Wilmington,"16th St and Jessup St",male,N/A,"Teen 12-17",N/A
+"May 16, 2019",Delaware,Wilmington,N/A,male,N/A,"Adult 18+",N/A
+"May 16, 2019",Delaware,Wilmington,"300 block of E 7th St",male,"Najee Hammond","Adult 18+",N/A
+"May 16, 2019",Delaware,Bear,"700 block of Pulaski Hwy",male,"James C. Moore","Adult 18+",N/A
+"May 16, 2019",Delaware,Bear,"700 block of Pulaski Hwy",male,"Justin Taylor","Adult 18+",N/A
+"May 16, 2019",Delaware,Wilmington,"400 block of Delamore Pl",male,"Louis Hall","Adult 18+",N/A
+"May 15, 2019",Delaware,Wilmington,"700 block of W 4th St",male,"Rasheed Patterson","Adult 18+",N/A
+"May 15, 2019",Delaware,Lincoln,"8000 block of Clendaniel Pond Rd",male,"Richard D. Stratton","Adult 18+",N/A
+"May 15, 2019",Delaware,Wilmington,"2800 block of N Tatnall St",male,"Musa Glascoe","Adult 18+",N/A
+"May 14, 2019",Delaware,Cheswold,"DE 13 and DE 42",male,"Wayne Roane","Adult 18+",N/A
+"May 14, 2019",Delaware,Harrington,"S DuPont Hwy and Center St",male,"Dontreze McDonald","Adult 18+",N/A
+"May 13, 2019",Delaware,Wilmington,N/A,male,"Andrew Peace","Adult 18+",N/A
+"May 10, 2019",Delaware,Wilmington,"300 block of E 23rd St",male,"Henry Sellers","Adult 18+",N/A
+"May 9, 2019",Delaware,Wilmington,"6th St and N Madison St",male,N/A,"Adult 18+",N/A
+"May 9, 2019",Delaware,Wilmington,"6th St and N Madison St",male,"Caron Collins","Adult 18+",N/A
+"May 9, 2019",Delaware,Wilmington,"6th St and N Madison St",male,"Tyaire Norris","Adult 18+",N/A
+"May 8, 2019",Delaware,Wilmington,"100 block of N Rodney St",female,N/A,"Adult 18+",N/A
+"May 8, 2019",Delaware,Wilmington,"500 block of Washington St",male,"James Wing","Adult 18+",N/A
+"May 8, 2019",Delaware,Wilmington,"500 block of Washington St",male,"Michael Sullivan-Wilson","Adult 18+",N/A
+"May 8, 2019",Delaware,Wilmington,"500 block of Washington St",female,"Serlina Wing","Adult 18+",N/A
+"May 8, 2019",Delaware,Wilmington,"500 block of Washington St",male,"Christopher Blake","Adult 18+",N/A
+"May 8, 2019",Delaware,Wilmington,"500 block of Washington St",male,"Shamar Foster","Adult 18+",N/A
+"May 8, 2019",Delaware,Newark,"50 block of Westerly St",male,N/A,"Adult 18+",N/A
+"May 7, 2019",Delaware,Seaford,"8700 block of Garden Ln",male,N/A,"Adult 18+",N/A
+"May 7, 2019",Delaware,Seaford,"8700 block of Garden Ln",male,N/A,"Adult 18+",N/A
+"May 7, 2019",Delaware,Seaford,"8700 block of Garden Ln",male,N/A,"Adult 18+",N/A
+"May 4, 2019",Delaware,Wilmington,"W 27th St and Tatnall St",male,N/A,"Teen 12-17",N/A
+"May 4, 2019",Delaware,Wilmington,"W 27th St and Tatnall St",female,N/A,"Adult 18+",N/A
+"May 4, 2019",Delaware,Wilmington,"W 27th St and Tatnall St",male,N/A,"Adult 18+",N/A
+"May 4, 2019",Delaware,Wilmington,"W 27th St and Tatnall St",male,N/A,"Adult 18+",N/A
+"May 4, 2019",Delaware,Dover,"865 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"May 4, 2019",Delaware,Dover,"865 N Dupont Hwy",male,N/A,"Adult 18+",N/A
+"May 3, 2019",Delaware,"New Castle (Wilmington Manor)","50 block of McMullen Ave",female,N/A,"Teen 12-17",N/A
+"May 3, 2019",Delaware,"New Castle (Wilmington Manor)","50 block of McMullen Ave",male,"Sayvien McRae","Adult 18+",N/A
+"May 1, 2019",Delaware,Dover,"50 block of S New St",male,"Corey Lewis","Adult 18+",N/A
+"May 1, 2019",Delaware,Dover,"50 block of S New St",female,"Shirmeria Brinson","Adult 18+",N/A
+"May 1, 2019",Delaware,Wilmington,"2400 block of Pine St",male,"Harry Hale","Adult 18+",N/A
+"May 1, 2019",Delaware,Wilmington,"2400 block of Pine St",male,N/A,"Adult 18+",N/A
+"May 1, 2019",Delaware,Wilmington,"2400 block of Pine St",female,N/A,"Adult 18+",N/A
+"April 30, 2019",Delaware,Seaford,"9817 Spotless St",male,"Jesse Drummond","Adult 18+",N/A
+"April 29, 2019",Delaware,Wilmington,"1300 block of Pennsylvania Ave",male,"David Billups","Adult 18+",N/A
+"April 26, 2019",Delaware,Wilmington,"500 block of Willing St",male,"Tonnaire McNair-Matthews","Adult 18+",N/A
+"April 25, 2019",Delaware,Greenwood,"2400 block of Hickman Rd",male,"Clifton McKinney","Adult 18+",N/A
+"April 25, 2019",Delaware,Greenwood,"2400 block of Hickman Rd",male,"Jarel Schaefer","Adult 18+",N/A
+"April 24, 2019",Delaware,Georgetown,"21306 Legal Dr",male,N/A,"Adult 18+",N/A
+"April 24, 2019",Delaware,Georgetown,"21306 Legal Dr",male,"Tyrone Fassett","Adult 18+",N/A
+"April 24, 2019",Delaware,Wilmington,"E 22nd St and N Spruce St",male,"Lamar White","Adult 18+",N/A
+"April 23, 2019",Delaware,Wilmington,"1900 block of Maryland Ave",male,"Markevis Powell","Adult 18+",N/A
+"April 23, 2019",Delaware,Wilmington,"5th Ave and Duncan St",male,"Kayveon McGriff","Adult 18+",N/A
+"April 23, 2019",Delaware,Wilmington,"5th Ave and Duncan St",male,"Antoine Davis","Adult 18+",N/A
+"April 22, 2019",Delaware,Wilmington,"W 29th St",male,"Barry Felton","Adult 18+",N/A
+"April 22, 2019",Delaware,Wilmington,"W 29th St",male,"Qasim Pointer","Teen 12-17",N/A
+"April 20, 2019",Delaware,Hockessin,"50 block of Robin Dr",male,"John Ripple","Adult 18+",N/A
+"April 19, 2019",Delaware,Bridgeville,"Craft Rd",male,"Kenneth McDowell","Adult 18+",N/A
+"April 18, 2019",Delaware,Smyrna,"600 block of Dairy Dr",male,"Cardin Qualls","Adult 18+",N/A
+"April 18, 2019",Delaware,Smyrna,"600 block of Dairy Dr",female,"Tynequa Qualls","Adult 18+",N/A
+"April 17, 2019",Delaware,Wilmington,"400 block of W 7th St",male,"Michael Griffin","Adult 18+",N/A
+"April 17, 2019",Delaware,Wilmington,"400 block of W 7th St",male,"James Watson","Adult 18+",N/A
+"April 16, 2019",Delaware,Wilmington,"500 block of W 26th St",male,"Derrick Jones","Adult 18+",N/A
+"April 12, 2019",Delaware,"New Castle","3125 New Castle Ave",male,N/A,"Adult 18+",N/A
+"April 12, 2019",Delaware,"New Castle","3125 New Castle Ave",male,N/A,"Adult 18+",N/A
+"April 9, 2019",Delaware,Wilmington,"900 block of Vandever Ave",N/A,"Tykeem Tackett-Fairley","Adult 18+",N/A
+"April 7, 2019",Delaware,Wilmington,"940 N Pine St",male,N/A,"Adult 18+",N/A
+"April 7, 2019",Delaware,Wilmington,"940 N Pine St",male,N/A,"Adult 18+",N/A
+"April 7, 2019",Delaware,Wilmington,"940 N Pine St",male,N/A,"Adult 18+",N/A
+"April 7, 2019",Delaware,Wilmington,"940 N Pine St",male,N/A,"Adult 18+",N/A
+"April 7, 2019",Delaware,Wilmington,"940 N Pine St",male,N/A,"Adult 18+",N/A
+"April 7, 2019",Delaware,Wilmington,"940 N Pine St",male,N/A,"Teen 12-17",N/A
+"April 3, 2019",Delaware,Wilmington,"1400 block of W 3rd St",male,"Kevis Tyler","Adult 18+",N/A
+"April 3, 2019",Delaware,Wilmington,"1400 block of W 3rd St",male,"Terrell Mobley","Adult 18+",N/A
+"April 1, 2019",Delaware,Georgetown,"100 Charles Way",female,"Sheena Hopkins","Adult 18+",N/A
+"April 1, 2019",Delaware,Georgetown,"100 Charles Way",male,"Tramar Hopkins","Adult 18+",N/A
+"March 31, 2019",Delaware,"Delaware City","Canal St",male,N/A,"Teen 12-17",N/A
+"March 31, 2019",Delaware,"Delaware City","Canal St",N/A,N/A,"Teen 12-17",N/A
+"March 30, 2019",Delaware,Dover,"50 block of Weston Dr",male,"Tyrone Sampson","Adult 18+",N/A
+"March 30, 2019",Delaware,Dover,"50 block of Weston Dr",male,"Jermaine Brown","Adult 18+",N/A
+"March 30, 2019",Delaware,Wilmington,"1800 block of Pennsylvania Ave",male,"Xavier Nelson","Adult 18+",N/A
+"March 30, 2019",Delaware,"Rehoboth Beach","Rehoboth Ave and Columbia Ave",male,"Theaddis I. Johnson","Adult 18+",N/A
+"March 30, 2019",Delaware,"Rehoboth Beach","Rehoboth Ave and Columbia Ave",male,"Richard R. Vantine","Adult 18+",N/A
+"March 27, 2019",Delaware,Dagsboro,"Irons Ln and Old Mill Rd",male,"Brandon Pumarejo","Teen 12-17",N/A
+"March 27, 2019",Delaware,Dagsboro,"Irons Ln and Old Mill Rd",male,"John W. Barnhard","Adult 18+",N/A
+"March 27, 2019",Delaware,Claymont,"3000 block of 4th Ave",male,"Kysir Brokenbough","Adult 18+",N/A
+"March 27, 2019",Delaware,Seaford,"1 Chandler St",male,"Dale Seth Jr.","Adult 18+",N/A
+"March 27, 2019",Delaware,Seaford,"1 Chandler St",male,"Keiford Copper III","Adult 18+",N/A
+"March 27, 2019",Delaware,Seaford,"1 Chandler St",male,"Ja’Bron Cooper","Adult 18+",N/A
+"March 27, 2019",Delaware,Dover,"480 Country Dr",male,N/A,"Adult 18+",N/A
+"March 26, 2019",Delaware,Hartly,"3000 block of Halltown Rd",female,"Tiffany Creed","Adult 18+",N/A
+"March 26, 2019",Delaware,Hartly,"3000 block of Halltown Rd",male,"David D. Smith","Adult 18+",N/A
+"March 26, 2019",Delaware,Hartly,"3000 block of Halltown Rd",male,"Jason Johnson","Adult 18+",N/A
+"March 26, 2019",Delaware,Hartly,"3000 block of Halltown Rd",female,"Tina Creed","Adult 18+",N/A
+"March 26, 2019",Delaware,Wilmington,"2400 block of Tatnall St",male,N/A,"Teen 12-17",N/A
+"March 20, 2019",Delaware,Wilmington,"500 block of Madison St",male,"Leonard Brown","Adult 18+",N/A
+"March 16, 2019",Delaware,Wilmington,"2200 block of Baynard Blvd",male,N/A,"Teen 12-17",N/A
+"March 15, 2019",Delaware,Wilmington,"2900 block of Tatnall St",male,"Lloyd Tomlinson","Adult 18+",N/A
+"March 15, 2019",Delaware,Wilmington,"2900 block of Tatnall St",female,"Kelli Brisco","Adult 18+",N/A
+"March 13, 2019",Delaware,Wilmington,"104 Richards Dr",female,"Laura Connell","Adult 18+",N/A
+"March 13, 2019",Delaware,Wilmington,"400 block of W 7th St",male,"Richard Iverson","Adult 18+",N/A
+"March 12, 2019",Delaware,Wilmington,"300 block of S Union St",male,"Michael Bijansky","Adult 18+",N/A
+"March 12, 2019",Delaware,Wilmington,"1100 block of E 14th St",male,"Andre Church","Adult 18+",N/A
+"March 12, 2019",Delaware,Wilmington,"1100 block of E 14th St",male,"Andre Church","Adult 18+",N/A
+"March 11, 2019",Delaware,Townsend,"200 block of Saw Mill Rd",male,"Daniel J. Ford","Adult 18+",N/A
+"March 11, 2019",Delaware,Wilmington,"50 block of W 26th St",male,"Christian Coffield","Teen 12-17",N/A
+"March 11, 2019",Delaware,Wilmington,"50 block of W 26th St",female,"Janiya Henry","Teen 12-17",N/A
+"March 11, 2019",Delaware,Wilmington,"50 block of W 26th St",male,N/A,Unknown,N/A
+"March 11, 2019",Delaware,Wilmington,"50 block of W 26th St",male,N/A,Unknown,N/A
+"March 11, 2019",Delaware,Wilmington,"50 block of W 26th St",male,N/A,Unknown,N/A
+"March 9, 2019",Delaware,Laurel,"S Shell Bridge Rd and Holly Branch Dr",female,"Tia A. Tucker","Adult 18+",N/A
+"March 9, 2019",Delaware,Laurel,"S Shell Bridge Rd and Holly Branch Dr",male,"Joseph Beck","Adult 18+",N/A
+"March 9, 2019",Delaware,Newark,"W Main St and Hillside Rd",male,"Keith Johnson","Adult 18+",N/A
+"March 9, 2019",Delaware,Wilmington,"400 block of W 8th St",male,"Dawan Devlin","Adult 18+",N/A
+"March 7, 2019",Delaware,Wilmington,"800 block of N Grant Ave",male,N/A,"Adult 18+",N/A
+"March 7, 2019",Delaware,Marydel,"300 block of Grygo Rd",female,"Amanda Husfelt","Adult 18+",N/A
+"March 7, 2019",Delaware,Marydel,"300 block of Grygo Rd",male,"Quioly Demby","Adult 18+",N/A
+"March 7, 2019",Delaware,Wilmington,"3500 block of Washington St",female,N/A,"Adult 18+",N/A
+"March 7, 2019",Delaware,Wilmington,"3500 block of Washington St",male,"Keith Waters","Adult 18+",N/A
+"March 6, 2019",Delaware,Wilmington,"700 block of Tatnall St",male,N/A,"Adult 18+",N/A
+"March 6, 2019",Delaware,Wilmington,"700 block of Tatnall St",female,N/A,"Adult 18+",N/A
+"March 6, 2019",Delaware,Dover,"400 block of Barrister Pl",male,"Donald Brown","Adult 18+",N/A
+"March 6, 2019",Delaware,Newark,"50 block of Raven Turn",male,"Dyron Nuriddin","Adult 18+",N/A
+"March 4, 2019",Delaware,Dover,"50 Block of Village Dr",male,"Zykee Bull","Adult 18+",N/A
+"March 2, 2019",Delaware,Smyrna,"699 S Carter Rd",male,N/A,"Teen 12-17",N/A
+"March 1, 2019",Delaware,Milton,"28000 block of Carpenter Rd",male,"Deion Ayers","Adult 18+",N/A
+"March 1, 2019",Delaware,"Wilmington (Stanton)","106 Main St",female,N/A,"Adult 18+",N/A
+"March 1, 2019",Delaware,"Wilmington (Stanton)","106 Main St",female,N/A,"Adult 18+",N/A
+"February 26, 2019",Delaware,Wilmington,"Northeast Blvd and Thatcher St",male,N/A,"Adult 18+",N/A
+"February 25, 2019",Delaware,Wilmington,"600 block of N Jefferson St",male,N/A,"Adult 18+",N/A
+"February 25, 2019",Delaware,Wilmington,"600 block of N Jefferson St",male,"Barry Felton","Adult 18+",N/A
+"February 23, 2019",Delaware,Seaford,"20300 block of Wesley Church Rd",male,"James M. Frazier","Adult 18+",N/A
+"February 23, 2019",Delaware,Seaford,"20300 block of Wesley Church Rd",female,"Trivette A. Jackson","Adult 18+",N/A
+"February 23, 2019",Delaware,Seaford,"20300 block of Wesley Church Rd",female,"Donisha Holland","Adult 18+",N/A
+"February 23, 2019",Delaware,Seaford,"20300 block of Wesley Church Rd",male,"Reginald L. Sample","Adult 18+",N/A
+"February 22, 2019",Delaware,Frederica,"200 block of Market St",male,"Joseph Whaley","Adult 18+",N/A
+"February 22, 2019",Delaware,Dover,"55 Loockerman Plaza",male,"Michael Palmer Jr.","Adult 18+",N/A
+"February 22, 2019",Delaware,Dover,"55 Loockerman Plaza",male,"Sheldon Claud","Adult 18+",N/A
+"February 21, 2019",Delaware,Bear,"13 S Cedar Creek Ct",male,N/A,"Adult 18+",N/A
+"February 21, 2019",Delaware,Bear,"13 S Cedar Creek Ct",male,"Parish Lloyd","Adult 18+",N/A
+"February 21, 2019",Delaware,Bear,"13 S Cedar Creek Ct",male,"Erogers Bey","Adult 18+",N/A
+"February 21, 2019",Delaware,Seaford,"300 block of N Pine St",male,"Djemsley Florestal","Adult 18+",N/A
+"February 21, 2019",Delaware,Smyrna,"1069 McQuail Rd",male,"Melvin J. Durand","Adult 18+",N/A
+"February 18, 2019",Delaware,Dover,"400 block of New Castle Ave",male,"Joseph Carter","Adult 18+",N/A
+"February 16, 2019",Delaware,Felton,"11 S Lombard St",male,"William J. Paskey","Adult 18+",N/A
+"February 16, 2019",Delaware,Lewes,"32000 block of Spruce Ct",male,"Christopher B. Lare","Adult 18+",N/A
+"February 16, 2019",Delaware,"Ocean View","50 block of Dorothy Cir",male,"Joshua Welsh","Adult 18+",N/A
+"February 14, 2019",Delaware,Harrington,"8700 block of Park Brown Rd",male,"Donte Demunguia","Adult 18+",N/A
+"February 14, 2019",Delaware,Harrington,"8700 block of Park Brown Rd",male,"Devon Emfinger","Adult 18+",N/A
+"February 14, 2019",Delaware,Wilmington,"2nd St and Van Buren St",male,"Emanuel Stackhouse","Adult 18+",N/A
+"February 14, 2019",Delaware,Wilmington,"2nd St and Van Buren St",male,"Frank Butts","Adult 18+",N/A
+"February 14, 2019",Delaware,Wilmington,"1100 block of Kirkwood St",male,"Andrew Charles","Adult 18+",N/A
+"February 13, 2019",Delaware,Dover,"200 block of S Governors Blvd",male,"Dewayne Bordley","Adult 18+",N/A
+"February 12, 2019",Delaware,"Rehoboth Beach","36179 Palace Ln",male,"Michael R. Henry","Adult 18+",N/A
+"February 8, 2019",Delaware,Wilmington,"400 block of Heald St",male,N/A,"Adult 18+",N/A
+"February 8, 2019",Delaware,Wilmington,"400 block of Heald St",male,"Nathaniel Bunch","Adult 18+",N/A
+"February 7, 2019",Delaware,Bear,"50 block of Wildfields Ct",male,"Benjamin Boudart","Adult 18+",N/A
+"February 7, 2019",Delaware,Dover,"383 N DuPont Hwy",male,"Keith Landry","Adult 18+",N/A
+"February 6, 2019",Delaware,Wilmington,"50 block of Jensen Dr",male,N/A,"Teen 12-17",N/A
+"February 5, 2019",Delaware,Newark,N/A,male,N/A,"Teen 12-17",N/A
+"February 4, 2019",Delaware,Wilmington,"1400 block of N Walnut St",male,N/A,"Teen 12-17",N/A
+"February 4, 2019",Delaware,Wilmington,"1400 block of N Walnut St",male,N/A,"Teen 12-17",N/A
+"February 3, 2019",Delaware,Wilmington,"DE 4 and Champlain Ave",male,N/A,"Teen 12-17",N/A
+"February 2, 2019",Delaware,Dover,"51 Webbs Ln",female,N/A,"Adult 18+",N/A
+"February 2, 2019",Delaware,Dover,"51 Webbs Ln",male,N/A,"Adult 18+",N/A
+"February 2, 2019",Delaware,Wilmington,"W 27th St and Moore St",male,"Yahim Harris","Adult 18+",N/A
+"February 2, 2019",Delaware,Wilmington,"W 27th St and Moore St",male,N/A,"Teen 12-17",N/A
+"February 2, 2019",Delaware,Wilmington,"2500 block of Bowers St",male,"Salvador Vasquez","Adult 18+",N/A
+"February 1, 2019",Delaware,"New Castle","Christiana Rd and Catherine St",male,"Thomas Porter","Adult 18+",N/A
+"January 31, 2019",Delaware,Wilmington,"1100 block of Pleasant St",male,"Aracelio Cruz","Adult 18+",N/A
+"January 31, 2019",Delaware,Wilmington,"1100 block of Pleasant St",male,"Frederick Trice","Adult 18+",N/A
+"January 31, 2019",Delaware,Wilmington,"W 7th St and N Monroe St",male,"Nazjheir Lloyd","Adult 18+",N/A
+"January 28, 2019",Delaware,Seaford,"400 block of N Pine St",male,N/A,"Adult 18+",N/A
+"January 28, 2019",Delaware,Seaford,"400 block of N Pine St",male,N/A,"Adult 18+",N/A
+"January 28, 2019",Delaware,Wilmington,"700 block of N Madison St",male,N/A,"Adult 18+",N/A
+"January 26, 2019",Delaware,Wilmington,"3700 block of N Van Buren St",male,N/A,"Adult 18+",N/A
+"January 26, 2019",Delaware,Wilmington,"3700 block of N Van Buren St",male,N/A,"Teen 12-17",N/A
+"January 26, 2019",Delaware,Wilmington,"3700 block of N Van Buren St",male,"Jamar Jackson","Adult 18+",N/A
+"January 25, 2019",Delaware,Wilmington,"W 39th St and Shipley St",male,N/A,"Adult 18+",N/A
+"January 25, 2019",Delaware,Bridgeville,"11000 block of Fisher Cir",male,"Ellis J Cannon II","Adult 18+",N/A
+"January 25, 2019",Delaware,Dagsboro,"30000 block of Squirrel Ln",male,"David Tharp","Adult 18+",N/A
+"January 24, 2019",Delaware,Wilmington,"2702 Jacqueline Dr",male,"Dametrius Benson","Teen 12-17",N/A
+"January 22, 2019",Delaware,Wilmington,"2300 block of Pine St",male,"Larry Lee","Adult 18+",N/A
+"January 18, 2019",Delaware,Bear,"1551 Pulaski Highway",male,N/A,"Teen 12-17",N/A
+"January 17, 2019",Delaware,Millville,"Railway Rd",male,"Paul E. Daisey","Adult 18+",N/A
+"January 17, 2019",Delaware,Wilmington,"400 block of E 11th St",male,N/A,"Adult 18+",N/A
+"January 17, 2019",Delaware,Wilmington,"400 block of E 11th St",male,"Artemus Portis","Adult 18+",N/A
+"January 17, 2019",Delaware,Wilmington,"400 block of E 11th St",male,"Antwine Jackson","Adult 18+",N/A
+"January 16, 2019",Delaware,Wilmington,"600 block of E 5th St",male,N/A,"Adult 18+",N/A
+"January 16, 2019",Delaware,Wilmington,"600 block of E 5th St",male,N/A,"Adult 18+",N/A
+"January 15, 2019",Delaware,Wilmington,"1200 block of Conrad St",male,"Kellier Flamer","Adult 18+",N/A
+"January 13, 2019",Delaware,Dover,"300 block of Frear Dr",male,"Nathaniel Hampton","Adult 18+",N/A
+"January 13, 2019",Delaware,Dover,"300 block of Frear Dr",female,"Chelsie Cooper","Adult 18+",N/A
+"January 10, 2019",Delaware,Dover,"35 E Loockerman St",N/A,N/A,"Teen 12-17",N/A
+"January 10, 2019",Delaware,Dover,"35 E Loockerman St",male,"Jayaire Brittingham","Adult 18+",N/A
+"January 7, 2019",Delaware,Wilmington,"700 block of N Dupont St",female,N/A,"Adult 18+",N/A
+"January 7, 2019",Delaware,Wilmington,"700 block of N Dupont St",male,"Marcellis Dandy","Adult 18+",N/A
+"January 7, 2019",Delaware,Wilmington,"700 block of N Dupont St",male,"Aaron Jackson","Adult 18+",N/A
+"January 7, 2019",Delaware,Wilmington,"700 block of N Dupont St",male,"Messiah Woodall","Adult 18+",N/A
+"January 6, 2019",Delaware,Frederica,"50 block of 3rd St",male,"William H. Cloak IV","Adult 18+",N/A
+"January 5, 2019",Delaware,Dover,"200 block of Kentwood Dr",male,"Jesse Stanford","Adult 18+",N/A
+"January 5, 2019",Delaware,Dover,"200 block of Kentwood Dr",N/A,"Cahlil Simmons","Adult 18+",N/A
+"January 5, 2019",Delaware,Dover,"200 block of Kentwood Dr",male,"Jaquell A. McDonald","Adult 18+",N/A
+"January 3, 2019",Delaware,"Kent (county)",N/A,male,"Ricardo L. Barnaby","Adult 18+",N/A
+"January 3, 2019",Delaware,"Kent (county)",N/A,male,"Barry V. Haith","Adult 18+",N/A
+"January 3, 2019",Delaware,"Kent (county)",N/A,male,"Lamont K. McCove","Adult 18+",N/A
+"January 2, 2019",Delaware,Newark,"1120 S College Ave",male,N/A,"Adult 18+",N/A
+"January 2, 2019",Delaware,Felton,"100 block of Gelden Rd",male,N/A,"Adult 18+",N/A
+"January 2, 2019",Delaware,Felton,"100 block of Gelden Rd",male,N/A,"Adult 18+",N/A
+"January 2, 2019",Delaware,Felton,"100 block of Gelden Rd",male,N/A,"Adult 18+",N/A
+"January 2, 2019",Delaware,Felton,"100 block of Gelden Rd",male,N/A,"Adult 18+",N/A
+"January 1, 2019",Delaware,Wilmington,"1101 E 8th St",male,N/A,"Adult 18+",N/A
+"December 30, 2018",Delaware,Wilmington,"500 block of W 11th St",male,"Nyhe Toston","Adult 18+",N/A
+"December 30, 2018",Delaware,Wilmington,"500 block of W 11th St",male,"Kenai Truitt","Adult 18+",N/A
+"December 30, 2018",Delaware,Wilmington,"500 block of W 11th St",male,"Stephan Curtis","Teen 12-17",N/A
+"December 30, 2018",Delaware,Wilmington,"500 block of W 11th St",male,"Mohamed Conde","Teen 12-17",N/A
+"December 29, 2018",Delaware,Newark,"91 Thorn Ln",male,N/A,"Adult 18+",N/A
+"December 29, 2018",Delaware,Newark,"91 Thorn Ln",male,"Nicholas Hulsey","Adult 18+",N/A
+"December 28, 2018",Delaware,Wilmington,"600 block of W 7th St",male,N/A,"Adult 18+",N/A
+"December 28, 2018",Delaware,Wilmington,"600 block of W 7th St",female,N/A,"Adult 18+",N/A
+"December 28, 2018",Delaware,Wilmington,"600 block of W 7th St",male,N/A,"Teen 12-17",N/A
+"December 25, 2018",Delaware,Lincoln,"19000 block of Pine St",female,N/A,"Adult 18+",N/A
+"December 25, 2018",Delaware,Lincoln,"19000 block of Pine St",male,"Javaghn D. Waples","Adult 18+",N/A
+"December 24, 2018",Delaware,"Rehoboth Beach","Munchy Branch Rd and Coastal Hwy",male,"Tre Jamal Edwards","Adult 18+",N/A
+"December 23, 2018",Delaware,Wilmington,"800 block of E 13th St",male,"Derro Smith","Adult 18+",N/A
+"December 23, 2018",Delaware,Wilmington,"800 block of E 13th St",male,N/A,"Adult 18+",N/A
+"December 23, 2018",Delaware,Milford,"300 Aurora Pl",female,N/A,"Child 0-11",N/A
+"December 23, 2018",Delaware,Milford,"300 Aurora Pl",male,"Derrick Morris","Adult 18+",N/A
+"December 23, 2018",Delaware,Wilmington,"2300 block of West St",male,N/A,"Teen 12-17",N/A
+"December 23, 2018",Delaware,Wilmington,"100 block of N Harrison St",female,N/A,"Adult 18+",N/A
+"December 20, 2018",Delaware,Millsboro,"28000 block of Mount Joy Rd",male,"Clarence Mobley","Adult 18+",N/A
+"December 20, 2018",Delaware,Millsboro,"28000 block of Mount Joy Rd",male,"Daquon Johnson","Adult 18+",N/A
+"December 20, 2018",Delaware,Millsboro,"28000 block of Mount Joy Rd",male,"Jerrontae Holden","Adult 18+",N/A
+"December 19, 2018",Delaware,Dover,"3000 block of William St",male,"Gary Stanley","Adult 18+",N/A
+"December 17, 2018",Delaware,Newark,"41 Winterhaven Dr",male,N/A,"Teen 12-17",N/A
+"December 17, 2018",Delaware,Dagsboro,"30000 block of Iron Branch Rd",male,"Christopher L. Sturgis","Adult 18+",N/A
+"December 12, 2018",Delaware,Dover,"700 block of Bacon Ave",male,"Bradley Parker","Adult 18+",N/A
+"December 11, 2018",Delaware,Millsboro,N/A,male,"Brendon Dibble","Adult 18+",N/A
+"December 11, 2018",Delaware,Millsboro,N/A,male,"William Novello","Adult 18+",N/A
+"December 7, 2018",Delaware,Seaford,"23450 Sussex Hwy",male,"Trevor Savage","Adult 18+",N/A
+"December 7, 2018",Delaware,Seaford,"23450 Sussex Hwy",male,"Montez Lake","Adult 18+",N/A
+"December 7, 2018",Delaware,Seaford,"23450 Sussex Hwy",N/A,N/A,"Teen 12-17",N/A
+"December 5, 2018",Delaware,Harrington,"101 W Center St",male,"James McNeil","Adult 18+",N/A
+"November 29, 2018",Delaware,Milford,"S DuPont Blvd and Lakeview Ave",male,"Mike A. Chavez","Adult 18+",N/A
+"November 28, 2018",Delaware,Dover,"89 Kings Hwy",N/A,N/A,"Adult 18+",N/A
+"November 28, 2018",Delaware,Dover,"89 Kings Hwy",N/A,N/A,"Adult 18+",N/A
+"November 28, 2018",Delaware,Dover,"89 Kings Hwy",N/A,N/A,"Adult 18+",N/A
+"November 28, 2018",Delaware,Dover,"89 Kings Hwy",N/A,N/A,"Adult 18+",N/A
+"November 28, 2018",Delaware,Dagsboro,"32000 block of Swamp Rd",male,"Sean Johnson","Adult 18+",N/A
+"November 28, 2018",Delaware,Dover,"200 block of N Kirkwood St",male,"Nathan Ward","Adult 18+",N/A
+"November 27, 2018",Delaware,Wilmington,"900 block of N Pine St",male,N/A,"Adult 18+",N/A
+"November 25, 2018",Delaware,"Wilmington (Edgemoor)","E Salisbury Dr and Bedford Dr",male,N/A,"Adult 18+",N/A
+"November 23, 2018",Delaware,Wilmington,"Centerville Rd and Boxwood Rd",male,"Jason W. Carroll","Adult 18+",N/A
+"November 23, 2018",Delaware,Harrington,"S Rehoboth Blvd",male,"Kaleb M. Tribek","Adult 18+",N/A
+"November 22, 2018",Delaware,Milton,"18647 Rd 281",N/A,N/A,Unknown,N/A
+"November 20, 2018",Delaware,Smyrna,"South St and East St",male,N/A,"Adult 18+",N/A
+"November 20, 2018",Delaware,Wilmington,"2300 block of Jessup St",male,N/A,"Adult 18+",N/A
+"November 20, 2018",Delaware,Wilmington,"2300 block of Jessup St",male,N/A,"Adult 18+",N/A
+"November 20, 2018",Delaware,Wilmington,"2300 block of Jessup St",male,"Jameel Anderson","Adult 18+",N/A
+"November 18, 2018",Delaware,Seaford,"Park Dr",male,"Teron West","Adult 18+",N/A
+"November 18, 2018",Delaware,Dover,"400 block of E Water St",male,N/A,"Adult 18+",N/A
+"November 18, 2018",Delaware,Dover,"400 block of E Water St",male,N/A,"Adult 18+",N/A
+"November 18, 2018",Delaware,Dover,"400 block of E Water St",male,N/A,"Adult 18+",N/A
+"November 18, 2018",Delaware,Dover,"400 block of E Water St",male,N/A,"Adult 18+",N/A
+"November 18, 2018",Delaware,Dover,"400 block of E Water St",male,N/A,"Adult 18+",N/A
+"November 18, 2018",Delaware,Dover,"400 block of E Water St",male,N/A,"Adult 18+",N/A
+"November 16, 2018",Delaware,"Wilmington (Newport)","500 block of Essex Ave",male,"Master Cpl. Michael Ballard","Adult 18+",N/A
+"November 16, 2018",Delaware,"Camden Wyoming (Camden)","155 S West St",female,"Ahyanna Baker-Griffin","Adult 18+",N/A
+"November 16, 2018",Delaware,"Camden Wyoming (Camden)","155 S West St",male,"Dishiem Johnson","Adult 18+",N/A
+"November 15, 2018",Delaware,Middletown,"US 13 and DE 1",male,"Stanley L. Bates","Adult 18+",N/A
+"November 14, 2018",Delaware,Townsend,"100 block of Esch St",male,"Edward W. Benson","Adult 18+",N/A
+"November 12, 2018",Delaware,Wilmington,"W 5th St and N Franklin St",male,N/A,"Teen 12-17",N/A
+"November 11, 2018",Delaware,Dover,"400 block of Barrister Pl",female,N/A,"Adult 18+",N/A
+"November 10, 2018",Delaware,Wilmington,"N Lake St and Matthes Ave",male,N/A,"Adult 18+",N/A
+"November 8, 2018",Delaware,Claymont,"50 block of New York Ave",female,"Mary Ellen Slider","Adult 18+",N/A
+"November 8, 2018",Delaware,Claymont,"50 block of New York Ave",male,"Joseph R. Slider","Adult 18+",N/A
+"November 8, 2018",Delaware,Dover,"200 block of W Reed St",male,"Abdul Tillery","Adult 18+",N/A
+"November 8, 2018",Delaware,Dover,"200 block of W Reed St",male,"Adriene Stevenson","Adult 18+",N/A
+"November 6, 2018",Delaware,"New Castle","4000 N DuPont Hwy",N/A,"Ronald E. Maddrey","Adult 18+",N/A
+"November 5, 2018",Delaware,Smyrna,"400 block of Baldwin Dr",male,N/A,"Adult 18+",N/A
+"November 5, 2018",Delaware,Smyrna,"400 block of Baldwin Dr",male,N/A,"Teen 12-17",N/A
+"November 5, 2018",Delaware,Smyrna,"400 block of Baldwin Dr",male,"Jeffrey T Thomas","Adult 18+",N/A
+"November 5, 2018",Delaware,Smyrna,"400 block of Baldwin Dr",male,"Devante Blocker","Adult 18+",N/A
+"November 5, 2018",Delaware,Harrington,N/A,male,"Joshua P. Dorrell","Adult 18+",N/A
+"November 5, 2018",Delaware,Wilmington,"300 block of W 7th St",male,N/A,"Adult 18+",N/A
+"November 1, 2018",Delaware,Wilmington,"200 block of S Franklin St",male,"Dwayne Wright","Adult 18+",N/A
+"November 1, 2018",Delaware,Wilmington,"200 block of S Franklin St",male,N/A,"Adult 18+",N/A
+"October 29, 2018",Delaware,Wilmington,"2300 block of N Washington St",male,N/A,"Adult 18+",N/A
+"October 29, 2018",Delaware,Seaford,"24000 block of German Rd",male,N/A,"Adult 18+",N/A
+"October 29, 2018",Delaware,Dover,"W Division St and S New St",male,"Arthur Darden Jr.","Adult 18+",N/A
+"October 29, 2018",Delaware,Dover,"W Division St and S New St",male,"Phillip Waters","Adult 18+",N/A
+"October 28, 2018",Delaware,Wilmington,"1701 Delaware Ave",male,"Tyler Vega","Adult 18+",N/A
+"October 28, 2018",Delaware,Newark,"900 block of Harmony Rd",male,N/A,"Adult 18+",N/A
+"October 26, 2018",Delaware,Wilmington,"600 block of W 6th St",male,"Sean Hammond","Adult 18+",N/A
+"October 25, 2018",Delaware,Wilmington,"900 block of Spruce St",female,"Shirley Coleman","Adult 18+",N/A
+"October 25, 2018",Delaware,Wilmington,"900 block of Spruce St",male,N/A,"Teen 12-17",N/A
+"October 23, 2018",Delaware,Dover,"400 block of E Water St",male,"Damir Hughes-Warren","Adult 18+",N/A
+"October 23, 2018",Delaware,Dover,"400 block of E Water St",female,"Louella Cooper","Adult 18+",N/A
+"October 23, 2018",Delaware,"New Castle","111 S DuPont Hwy",male,"Angel L. Arbolay","Adult 18+",N/A
+"October 22, 2018",Delaware,Wilmington,"100 block of 24th St",male,N/A,"Adult 18+",N/A
+"October 19, 2018",Delaware,Wilmington,"900 block of Linden St",male,"Ethan Keller","Adult 18+",N/A
+"October 18, 2018",Delaware,Wilmington,"400 block of E 2nd St",male,"Andre Richards","Adult 18+",N/A
+"October 18, 2018",Delaware,Dover,"200 block of N Governor Blvd",male,"Lamar J. Dozier","Adult 18+",N/A
+"October 18, 2018",Delaware,Wilmington,"300 N Walnut St",N/A,"Joseph Brown","Adult 18+",N/A
+"October 18, 2018",Delaware,Wilmington,"400 block of N Clayton St",male,N/A,"Adult 18+",N/A
+"October 17, 2018",Delaware,Wilmington,"2300 block of N Market St",male,"Blayton Palmer","Adult 18+",N/A
+"October 16, 2018",Delaware,Newark,"800 block of Coventry Ln",male,"Clifton Armstead","Adult 18+",N/A
+"October 16, 2018",Delaware,Newark,"800 block of Coventry Ln",male,"Sequoyah Harris","Adult 18+",N/A
+"October 15, 2018",Delaware,Dover,"Bay Tree Rd",male,"James Rochester","Adult 18+",N/A
+"October 14, 2018",Delaware,Dover,"428 N DuPont Hwy",male,N/A,"Adult 18+",N/A
+"October 14, 2018",Delaware,Dover,"428 N DuPont Hwy",male,"Antonio Bynum","Adult 18+",N/A
+"October 11, 2018",Delaware,Lewes,"19000 block of Ward Rd",N/A,N/A,Unknown,N/A
+"October 11, 2018",Delaware,Lewes,"19000 block of Ward Rd",N/A,N/A,Unknown,N/A
+"October 11, 2018",Delaware,Wilmington,"600 block of W 8th St",male,N/A,"Adult 18+",N/A
+"October 11, 2018",Delaware,Wilmington,"600 block of W 8th St",male,"Maurice Williams","Adult 18+",N/A
+"October 11, 2018",Delaware,Wilmington,"600 block of W 8th St",male,"Parrish Brown","Adult 18+",N/A
+"October 11, 2018",Delaware,Dover,"800 S Governors Ave",male,"Aaron L. Williams","Adult 18+",N/A
+"October 11, 2018",Delaware,Wilmington,"1300 block of Lancaster Ave",male,"Chaze Peete","Adult 18+",N/A
+"October 10, 2018",Delaware,Dover,"1492 N Little Creek Rd",male,"Kenneth Holland","Adult 18+",N/A
+"October 8, 2018",Delaware,Smyrna,"DE 9 and Lighthouse Rd",male,"Joseph Reyes","Adult 18+",N/A
+"October 6, 2018",Delaware,Clayton,"Lion Hope Rd",male,"David L Moser","Adult 18+",N/A
+"October 5, 2018",Delaware,Wilmington,"1000 Bennett St",male,"Charles Riley","Adult 18+",N/A
+"October 3, 2018",Delaware,Wilmington,"700 block of W 5th St",male,N/A,"Adult 18+",N/A
+"October 3, 2018",Delaware,Wilmington,"Taylor St and N Spruce St",male,N/A,"Adult 18+",N/A
+"October 2, 2018",Delaware,Dover,"50 Webbs Ln",male,N/A,"Adult 18+",N/A
+"October 2, 2018",Delaware,Wilmington,"200 block of N Clayton St",male,"Grayson Ewell","Adult 18+",N/A
+"October 2, 2018",Delaware,Wilmington,"200 block of N Clayton St",male,"Terrell Mobley","Adult 18+",N/A
+"October 2, 2018",Delaware,"Camden Wyoming","Pony Track Rd",male,N/A,"Adult 18+",N/A
+"October 2, 2018",Delaware,"Camden Wyoming","Pony Track Rd",male,"Adelio A. Guzman","Adult 18+",N/A
+"September 30, 2018",Delaware,Seaford,"26000 block of Kelly Cir",N/A,N/A,Unknown,N/A
+"September 30, 2018",Delaware,Dover,"298 S DuPont Hwy",male,"Tyrell Joseph","Adult 18+",N/A
+"September 29, 2018",Delaware,Harrington,"200 block of Delaware Ave",male,N/A,"Teen 12-17",N/A
+"September 29, 2018",Delaware,Harrington,"200 block of Delaware Ave",male,N/A,"Teen 12-17",N/A
+"September 29, 2018",Delaware,Harrington,"200 block of Delaware Ave",female,N/A,"Adult 18+",N/A
+"September 28, 2018",Delaware,Dover,"915 S DuPont Hwy",male,"Jeremy Thompson","Adult 18+",N/A
+"September 26, 2018",Delaware,Laurel,"Portsville Rd and Dogwood Ln",male,"Isaac Hatton","Adult 18+",N/A
+"September 26, 2018",Delaware,Laurel,"Portsville Rd and Dogwood Ln",male,"Jerry L. Reed","Adult 18+",N/A
+"September 26, 2018",Delaware,Laurel,"Portsville Rd and Dogwood Ln",male,"Traevon Dixon","Adult 18+",N/A
+"September 20, 2018",Delaware,Dover,"100 block of S Governors Blvd",male,N/A,"Adult 18+",N/A
+"September 20, 2018",Delaware,Harrington,"200 block of Hanley St",male,"Kevin Hughes","Adult 18+",N/A
+"September 20, 2018",Delaware,Harrington,"200 block of Hanley St",male,"Lavar Smith","Adult 18+",N/A
+"September 20, 2018",Delaware,Magnolia,N/A,male,N/A,"Adult 18+",N/A
+"September 20, 2018",Delaware,Seaford,"22588 Bridgeville Hwy",male,"Jose Cabrera-Malpica","Adult 18+",N/A
+"September 20, 2018",Delaware,Seaford,"22588 Bridgeville Hwy",male,"Arslan Chaudhary","Adult 18+",N/A
+"September 20, 2018",Delaware,Wilmington,"400 block of N Adams St",N/A,N/A,Unknown,N/A
+"September 19, 2018",Delaware,Dover,"SR 1",female,"Tilaiya M. Holland","Adult 18+",N/A
+"September 19, 2018",Delaware,Dover,"SR 1",female,"Kiara N. Watkins","Adult 18+",N/A
+"September 19, 2018",Delaware,Dover,"SR 1",male,"Jason D. Calhum","Teen 12-17",N/A
+"September 18, 2018",Delaware,Milford,"7000 block of Elgin Dr",male,"Bernard Wison","Adult 18+",N/A
+"September 17, 2018",Delaware,Dover,"428 DuPont Hwy",male,"Derrick Wilcox","Adult 18+",N/A
+"September 17, 2018",Delaware,Dover,"428 DuPont Hwy",male,"Bobby Pitts","Adult 18+",N/A
+"September 17, 2018",Delaware,Dover,"428 DuPont Hwy",male,"Thomas Bolden","Adult 18+",N/A
+"September 15, 2018",Delaware,Marydel,"300 block of Grygo Rd",male,"Anthony Jones","Adult 18+",N/A
+"September 15, 2018",Delaware,Marydel,"300 block of Grygo Rd",female,"Angela D. Greenwood","Adult 18+",N/A
+"September 15, 2018",Delaware,Dover,"51 Webbs Ln",male,N/A,"Adult 18+",N/A
+"September 15, 2018",Delaware,Dover,"51 Webbs Ln",male,N/A,"Adult 18+",N/A
+"September 13, 2018",Delaware,Milford,"900 Block of N Walnut St",male,"Kevin Woods","Adult 18+",N/A
+"September 13, 2018",Delaware,Milford,"900 Block of N Walnut St",female,"Marshay Johnson","Adult 18+",N/A
+"September 10, 2018",Delaware,Harrington,"966 Jackson Ditch Rd",male,"David Frasier","Adult 18+",N/A
+"September 8, 2018",Delaware,Bridgeville,"Mill Park Dr and Coverdale Rd",male,"Monte D. Murray","Adult 18+",N/A
+"September 8, 2018",Delaware,Bridgeville,"Mill Park Dr and Coverdale Rd",female,"Tashyra N. Scott","Adult 18+",N/A
+"September 8, 2018",Delaware,Dover,"50 block of Nicholas Dr",male,N/A,"Adult 18+",N/A
+"September 8, 2018",Delaware,Dover,"50 block of Nicholas Dr",female,N/A,"Adult 18+",N/A
+"September 8, 2018",Delaware,Dover,"50 block of Nicholas Dr",male,"Marquis Harris","Adult 18+",N/A
+"September 8, 2018",Delaware,Seaford,"400 Block of Phillips St",male,"William A. Torres Jr.","Adult 18+",N/A
+"September 7, 2018",Delaware,Bear,"1800 block of Pulaski Hwy",male,"Tymier Byrd","Teen 12-17",N/A
+"September 6, 2018",Delaware,Wilmington,"500 block of Vandever Ave",male,"Dion Brooks","Adult 18+",N/A
+"September 5, 2018",Delaware,Middletown,"100 block of Rosie Dr",male,"Bryce Holton","Adult 18+",N/A
+"September 4, 2018",Delaware,Wilmington,"50 block of 6th Ave",N/A,N/A,"Adult 18+",N/A
+"September 4, 2018",Delaware,Wilmington,"50 block of 6th Ave",male,"David Lumb","Adult 18+",N/A
+"September 3, 2018",Delaware,Hartly,"2000 block of Slaughter Station Rd",male,N/A,"Adult 18+",N/A
+"September 3, 2018",Delaware,Hartly,"2000 block of Slaughter Station Rd",male,N/A,"Adult 18+",N/A
+"August 31, 2018",Delaware,Harbeson,"18000 block of Indian Mission Rd",male,"Wesley J. Fagg","Adult 18+",N/A
+"August 31, 2018",Delaware,Wilmington,"1100 block of Conrad St",male,"Phillip Chapman","Adult 18+",N/A
+"August 31, 2018",Delaware,Wilmington,"1100 block of Conrad St",male,"Qy-Mere Maddrey","Adult 18+",N/A
+"August 30, 2018",Delaware,"Wilmington (Edgemoor)","Rysing Dr and Polk Rd",male,N/A,"Adult 18+",N/A
+"August 30, 2018",Delaware,Middletown,"2111 Dupont Hwy",male,"James L Bouchat","Adult 18+",N/A
+"August 29, 2018",Delaware,Bridgeville,"Evans Dr and Iris Field Ln",male,"Gregory A. Dukes","Adult 18+",N/A
+"August 29, 2018",Delaware,Claymont,"50 block of Balfour Ave",male,N/A,"Teen 12-17",N/A
+"August 29, 2018",Delaware,Claymont,"50 block of Balfour Ave",male,"Travis Shaw","Adult 18+",N/A
+"August 29, 2018",Delaware,Claymont,"50 block of Balfour Ave",N/A,N/A,"Adult 18+",N/A
+"August 29, 2018",Delaware,Claymont,"50 block of Balfour Ave",N/A,N/A,"Adult 18+",N/A
+"August 29, 2018",Delaware,Claymont,"50 block of Balfour Ave",N/A,N/A,"Adult 18+",N/A
+"August 29, 2018",Delaware,Greenwood,"100 block of Unity Ln",male,N/A,"Adult 18+",N/A
+"August 28, 2018",Delaware,Harbeson,"22000 block of Harbeson Rd",male,"Robert Knox","Adult 18+",N/A
+"August 28, 2018",Delaware,Harbeson,"22000 block of Harbeson Rd",male,"Andrew Knox","Adult 18+",N/A
+"August 28, 2018",Delaware,Harbeson,"22000 block of Harbeson Rd",male,"Andrew Ayers","Adult 18+",N/A
+"August 28, 2018",Delaware,Dover,"629 Buckson Dr",male,"Rodney West","Adult 18+",N/A
+"August 28, 2018",Delaware,Dover,"629 Buckson Dr",male,"Derrick Combs","Adult 18+",N/A
+"August 27, 2018",Delaware,"New Castle","2034 New Castle Ave",male,"David R. Ramirez","Adult 18+",N/A
+"August 27, 2018",Delaware,"New Castle","2034 New Castle Ave",male,"Elliott S. Colon","Adult 18+",N/A
+"August 27, 2018",Delaware,"New Castle","2034 New Castle Ave",female,"Maria D. Simpson","Adult 18+",N/A
+"August 26, 2018",Delaware,Selbyville,"W McCabe St and Rodgers Ave",male,"Michael R. Smith","Adult 18+",N/A
+"August 24, 2018",Delaware,Dover,"S State St and Webbs Ln",male,"Stevie S. Cornwell","Adult 18+",N/A
+"August 23, 2018",Delaware,"New Castle","4000 N DuPont Hwy",male,"Devin K. Chavis","Adult 18+",N/A
+"August 22, 2018",Delaware,Smyrna,"400 block of S Carter Rd",female,"Melanie Ballard","Adult 18+",N/A
+"August 22, 2018",Delaware,Wilmington,"Philadelphia Pike",male,"Shane Williams",Unknown,N/A
+"August 21, 2018",Delaware,Dover,"Reed St and New St",female,N/A,"Adult 18+",N/A
+"August 21, 2018",Delaware,Wilmington,"2400 block of Lamotte St",male,N/A,"Adult 18+",N/A
+"August 21, 2018",Delaware,Wilmington,"3800 block of N Madison St",male,N/A,"Adult 18+",N/A
+"August 20, 2018",Delaware,Wilmington,"2000 block of N Jefferson St",male,N/A,"Adult 18+",N/A
+"August 17, 2018",Delaware,"New Castle","1 block of Revelle St",female,"Mahogany Felton","Adult 18+",N/A
+"August 17, 2018",Delaware,"New Castle","1 block of Revelle St",male,"Charles Moore","Adult 18+",N/A
+"August 17, 2018",Delaware,"New Castle","1 block of Revelle St",female,"Kayla Judkins","Adult 18+",N/A
+"August 17, 2018",Delaware,"New Castle","1 block of Revelle St",male,"Richard Thomas","Adult 18+",N/A
+"August 17, 2018",Delaware,"New Castle","1 block of Revelle St",male,"Kevin Moore","Adult 18+",N/A
+"August 17, 2018",Delaware,Dover,"1300 block of Rose Valley School Rd",male,N/A,"Adult 18+",N/A
+"August 16, 2018",Delaware,"New Castle","Second Ave and Valley Rd",male,"Warren May","Adult 18+",N/A
+"August 15, 2018",Delaware,Dover,"63 Stoney Dr",male,"Larry Harris","Adult 18+",N/A
+"August 15, 2018",Delaware,Dover,"63 Stoney Dr",male,"Dewayne Scott","Teen 12-17",N/A
+"August 15, 2018",Delaware,Dover,"63 Stoney Dr",male,"Derek Johnson","Adult 18+",N/A
+"August 15, 2018",Delaware,Dover,"63 Stoney Dr",female,"Lutricia Ingram","Adult 18+",N/A
+"August 15, 2018",Delaware,Dover,"63 Stoney Dr",female,"Katherine Howard","Adult 18+",N/A
+"August 15, 2018",Delaware,Dover,"63 Stoney Dr",female,"Michele Machado","Adult 18+",N/A
+"August 13, 2018",Delaware,Wilmington,"200 block of N Lincoln St",male,N/A,"Adult 18+",N/A
+"August 8, 2018",Delaware,Dover,"900 block of Simon Cir",male,"Maurice Butler","Adult 18+",N/A
+"August 8, 2018",Delaware,Dover,"900 block of Simon Cir",female,"Mary Honey","Adult 18+",N/A
+"August 7, 2018",Delaware,Newark,"6 N Skyward Dr",female,"Rachel Roberts","Adult 18+",N/A
+"August 7, 2018",Delaware,Newark,"6 N Skyward Dr",male,"Probyn Morris","Adult 18+",N/A
+"August 5, 2018",Delaware,Dagsboro,"30000 block of Power Plant Rd",male,N/A,"Adult 18+",N/A
+"August 5, 2018",Delaware,Dagsboro,"30000 block of Power Plant Rd",male,N/A,"Adult 18+",N/A
+"August 5, 2018",Delaware,Dagsboro,"30000 block of Power Plant Rd",male,N/A,"Adult 18+",N/A
+"August 5, 2018",Delaware,Dagsboro,"30000 block of Power Plant Rd",male,N/A,"Adult 18+",N/A
+"August 5, 2018",Delaware,Dagsboro,"30000 block of Power Plant Rd",male,N/A,"Adult 18+",N/A
+"August 5, 2018",Delaware,"New Castle","1200 West Ave",male,N/A,"Adult 18+",N/A
+"August 4, 2018",Delaware,Smyrna,"300 block of Southern View Dr",male,"Kashar McIvor","Adult 18+",N/A
+"August 4, 2018",Delaware,Smyrna,"300 block of Southern View Dr",male,"Douglas Hodges","Adult 18+",N/A
+"August 4, 2018",Delaware,Smyrna,"300 block of Southern View Dr",male,"Brian Sadler","Adult 18+",N/A
+"August 4, 2018",Delaware,Bear,"1607 Pulaski Hwy",male,N/A,"Adult 18+",N/A
+"August 3, 2018",Delaware,Wilmington,"1300 block of E 27th St",male,"Tymier Shelby","Teen 12-17",N/A
+"August 2, 2018",Delaware,"Rehoboth Beach","37000 of Johnson St",male,N/A,"Adult 18+",N/A
+"August 2, 2018",Delaware,"Rehoboth Beach","37000 of Johnson St",female,"Delilah Boyernd","Adult 18+",N/A
+"August 2, 2018",Delaware,"Rehoboth Beach","37000 of Johnson St",male,"Marvin Burton","Adult 18+",N/A
+"July 30, 2018",Delaware,"New Castle","I-95 and Airport Rd",male,N/A,"Adult 18+",N/A
+"July 30, 2018",Delaware,"New Castle","I-95 and Airport Rd",male,N/A,"Adult 18+",N/A
+"July 27, 2018",Delaware,Georgetown,"20000 block of Donovans Rd",male,"Leeron Sabb","Adult 18+",N/A
+"July 25, 2018",Delaware,"New Castle","West Ave and New Castle Ave",male,"Christopher Longstaff","Adult 18+",N/A
+"July 24, 2018",Delaware,Dover,"Cherry St and Lincoln St",male,"Christopher Brewer",Unknown,N/A
+"July 21, 2018",Delaware,Georgetown,"Old Furnace Rd",male,"Ethan A. Mulford","Adult 18+",N/A
+"July 21, 2018",Delaware,Georgetown,"Old Furnace Rd",male,"Mark J. Smith Jr.","Adult 18+",N/A
+"July 21, 2018",Delaware,Georgetown,"Old Furnace Rd",male,"Matthew R. King Jr.","Adult 18+",N/A
+"July 20, 2018",Delaware,Milton,"Coastal Hwy",male,"Ricky D. Waters","Adult 18+",N/A
+"July 20, 2018",Delaware,Wilmington,"W 5th St and Delamore Pl",male,N/A,"Adult 18+",N/A
+"July 20, 2018",Delaware,Dover,"S Old Mill Rd",male,N/A,"Adult 18+",N/A
+"July 20, 2018",Delaware,Dover,"S Old Mill Rd",male,N/A,"Adult 18+",N/A
+"July 20, 2018",Delaware,Dover,"S Old Mill Rd",female,N/A,"Adult 18+",N/A
+"July 18, 2018",Delaware,Wilmington,"800 block of W 5th St",male,"Sean Spencer","Adult 18+",N/A
+"July 15, 2018",Delaware,Seaford,"Chandler St",male,"Donald White Jr.","Adult 18+",N/A
+"July 13, 2018",Delaware,"New Castle","1200 West Ave",male,N/A,"Adult 18+",N/A
+"July 12, 2018",Delaware,Wilmington,"500 block of E 10th St",male,N/A,"Adult 18+",N/A
+"July 12, 2018",Delaware,Wilmington,"500 block of E 10th St",male,N/A,"Adult 18+",N/A
+"July 12, 2018",Delaware,Wilmington,"2100 block of Lamotte St",male,N/A,"Adult 18+",N/A
+"July 9, 2018",Delaware,Wilmington,"2709 Ferris Rd",male,"Julie Burton Edwards","Adult 18+",N/A
+"July 9, 2018",Delaware,Wilmington,"2709 Ferris Rd",N/A,"Jacob Edwards","Child 0-11",N/A
+"July 9, 2018",Delaware,Wilmington,"2709 Ferris Rd",female,"Brinley Edwards","Child 0-11",N/A
+"July 9, 2018",Delaware,Wilmington,"2709 Ferris Rd",male,"Paxton Edwards","Child 0-11",N/A
+"July 9, 2018",Delaware,Wilmington,"2709 Ferris Rd",male,"Matthew Edwards","Adult 18+",N/A
+"July 9, 2018",Delaware,Laurel,"801 Daniel St",male,"Trevor McClements","Adult 18+",N/A
+"July 9, 2018",Delaware,Laurel,"801 Daniel St",male,"Dwayne A. Dotson","Adult 18+",N/A
+"July 9, 2018",Delaware,Laurel,"801 Daniel St",female,N/A,"Adult 18+",N/A
+"July 9, 2018",Delaware,Laurel,"801 Daniel St",female,N/A,"Adult 18+",N/A
+"July 8, 2018",Delaware,Wilmington,"2600 block of Jessup St",male,"Rashaad Wisher","Adult 18+",N/A
+"July 6, 2018",Delaware,Newark,"1 block of Hanna Dr",male,"Nathanial Harmon","Adult 18+",N/A
+"July 6, 2018",Delaware,Georgetown,"S DuPont Blvd and Old Laurel Rd",male,"Devynne Hobbs","Adult 18+",N/A
+"July 5, 2018",Delaware,Wilmington,"200 block of S Harrison St",male,N/A,"Adult 18+",N/A
+"July 5, 2018",Delaware,Smyrna,"US 13 and Hickory Ridge Rd",male,"Lawrence D. Baily","Adult 18+",N/A
+"July 5, 2018",Delaware,Dover,"S Governors Ave and Reed St",male,N/A,"Adult 18+",N/A
+"July 4, 2018",Delaware,Frankford,"Jones Church Rd",male,"Charles N. West Jr.","Adult 18+",N/A
+"July 2, 2018",Delaware,Wilmington,"400 block of W 6th St",male,N/A,"Adult 18+",N/A
+"July 1, 2018",Delaware,Middletown,"38 E Main St",male,"Ramaj Thompson","Adult 18+",N/A
+"July 1, 2018",Delaware,Middletown,"38 E Main St",male,"Marquis James","Adult 18+",N/A
+"June 30, 2018",Delaware,Wilmington,"I-495 and E 12th St",male,"Robert A. Powell","Adult 18+",N/A
+"June 25, 2018",Delaware,Lewes,"30000 block of Pine Town Rd",male,"Jhareed Ayers","Adult 18+",N/A
+"June 25, 2018",Delaware,Millsboro,"34000 block of Tugboat Ct",male,"Dwayne A. Barnes","Adult 18+",N/A
+"June 24, 2018",Delaware,Wilmington,"700 block of Broom St",male,"Curtis Gregory","Adult 18+",N/A
+"June 23, 2018",Delaware,Wilmington,"5th St and Monroe St",female,N/A,"Adult 18+",N/A
+"June 23, 2018",Delaware,Wilmington,"5th St and Monroe St",male,"Tymir Walley","Adult 18+",N/A
+"June 23, 2018",Delaware,Wilmington,"200 block of W 26th St",male,N/A,"Adult 18+",N/A
+"June 22, 2018",Delaware,Dover,"1289 Walker Rd",male,"Sylvester Lee","Adult 18+",N/A
+"June 22, 2018",Delaware,Dover,"1289 Walker Rd",male,"Timothy L. Safford","Adult 18+",N/A
+"June 20, 2018",Delaware,Dover,"100 block of President Dr",male,N/A,"Adult 18+",N/A
+"June 20, 2018",Delaware,Dover,"100 block of President Dr",N/A,N/A,Unknown,N/A
+"June 17, 2018",Delaware,Wilmington,"50 block of Lloyd St",female,"Doris Dorsey","Teen 12-17",N/A
+"June 17, 2018",Delaware,Wilmington,"50 block of Lloyd St",male,"Vincent DiMenco","Adult 18+",N/A
+"June 17, 2018",Delaware,Wilmington,"50 block of Lloyd St",male,"Doris Dorsey (same name as daughter)","Adult 18+",N/A
+"June 17, 2018",Delaware,Wilmington,"50 block of Lloyd St",male,"Glenford Blackwood","Adult 18+",N/A
+"June 13, 2018",Delaware,"New Castle","50 block of Rambo Terrace",N/A,"Jarryd Blankenbiller","Adult 18+",N/A
+"June 13, 2018",Delaware,"New Castle","50 block of Rambo Terrace",N/A,"George Lomas","Adult 18+",N/A
+"June 13, 2018",Delaware,"New Castle","50 block of Rambo Terrace",male,N/A,"Adult 18+",N/A
+"June 13, 2018",Delaware,"New Castle","50 block of Rambo Terrace",female,N/A,"Adult 18+",N/A
+"June 13, 2018",Delaware,"New Castle","50 block of Rambo Terrace",N/A,"Daquan Hammond","Adult 18+",N/A
+"June 13, 2018",Delaware,"New Castle","50 block of Rambo Terrace",N/A,"Evan Dayton","Adult 18+",N/A
+"June 12, 2018",Delaware,Dover,"Periwinkle Dr and Caroline Pl",male,N/A,"Adult 18+",N/A
+"June 12, 2018",Delaware,Dover,"Periwinkle Dr and Caroline Pl",male,N/A,"Adult 18+",N/A
+"June 12, 2018",Delaware,"New Castle","117 Wilton Blvd",male,N/A,"Adult 18+",N/A
+"June 12, 2018",Delaware,"New Castle","117 Wilton Blvd",female,N/A,"Adult 18+",N/A
+"June 11, 2018",Delaware,Wilmington,"1100 block of Flint Hill Rd",male,"Elijah Gordy-Stith","Adult 18+",N/A
+"June 11, 2018",Delaware,Greenwood,"10900 block of Webb Farm Rd",male,N/A,"Adult 18+",N/A
+"June 11, 2018",Delaware,Greenwood,"10900 block of Webb Farm Rd",female,N/A,"Adult 18+",N/A
+"June 11, 2018",Delaware,Greenwood,"10900 block of Webb Farm Rd",male,"Jeffrey Allen","Adult 18+",N/A
+"June 11, 2018",Delaware,Greenwood,"10900 block of Webb Farm Rd",male,"Patrick J. Rafferty","Adult 18+",N/A
+"June 11, 2018",Delaware,Greenwood,"10900 block of Webb Farm Rd",male,"Eric C. Howard","Adult 18+",N/A
+"June 11, 2018",Delaware,Greenwood,"10900 block of Webb Farm Rd",male,"Kenneth J. Passwaters","Adult 18+",N/A
+"June 10, 2018",Delaware,Clayton,"Sudlersville Rd",male,"George Thomas III","Adult 18+",N/A
+"June 10, 2018",Delaware,Clayton,"Sudlersville Rd",female,"Destiny Thomas","Adult 18+",N/A
+"June 10, 2018",Delaware,Wilmington,"200 block of W 29th St",male,N/A,"Adult 18+",N/A
+"June 7, 2018",Delaware,Dover,"50 block of Village Dr",male,N/A,"Adult 18+",N/A
+"June 7, 2018",Delaware,Wilmington,"Northeast Blvd and E 28th St",male,N/A,"Teen 12-17",N/A
+"June 6, 2018",Delaware,Dover,"50 block of Stevenson Dr",male,N/A,"Adult 18+",N/A
+"May 31, 2018",Delaware,Wilmington,"E 23rd St and Lamotte St",male,"Raquis Deburnure","Teen 12-17",N/A
+"May 30, 2018",Delaware,Wilmington,"1400 block of Lancaster Ave",male,N/A,"Adult 18+",N/A
+"May 30, 2018",Delaware,Wilmington,"1400 block of Lancaster Ave",male,N/A,"Adult 18+",N/A
+"May 30, 2018",Delaware,"New Castle","200 block of Christiana Rd",male,"Shawn G. Madden","Adult 18+",N/A
+"May 30, 2018",Delaware,Newark,"400 block of Wollaston Ave",male,"Kyle Wallace","Adult 18+",N/A
+"May 29, 2018",Delaware,Wilmington,"35th St and Church St",male,N/A,"Adult 18+",N/A
+"May 29, 2018",Delaware,Wilmington,"35th St and Church St",male,"Jy-Aire Dennis","Adult 18+",N/A
+"May 29, 2018",Delaware,Dover,"S Bradford St and Loockerman St",male,"Dareus Anderson","Adult 18+",N/A
+"May 29, 2018",Delaware,Hartly,"4000 block of Arthursville Rd",female,"Mary James","Adult 18+",N/A
+"May 29, 2018",Delaware,Hartly,"4000 block of Arthursville Rd",male,"John James","Adult 18+",N/A
+"May 27, 2018",Delaware,Dover,"300 block of W Division St",male,"Alex Durham","Adult 18+",N/A
+"May 26, 2018",Delaware,Wilmington,"2300 block of Lamotte St",male,N/A,"Adult 18+",N/A
+"May 25, 2018",Delaware,Laurel,"N Poplar St and Maryland Ave",male,"Quandre Winder","Adult 18+",N/A
+"May 24, 2018",Delaware,Wilmington,"500 block of Madison St",male,"Jeremy Tunnell","Adult 18+",N/A
+"May 24, 2018",Delaware,Wilmington,"Kiamensi Rd and Rothwell Dr",female,"Isabel Cooper","Adult 18+",N/A
+"May 24, 2018",Delaware,Wilmington,"Kiamensi Rd and Rothwell Dr",male,"Thessalonians Berry","Adult 18+",N/A
+"May 24, 2018",Delaware,Wilmington,"Kiamensi Rd and Rothwell Dr",male,"Walter Lolley","Adult 18+",N/A
+"May 23, 2018",Delaware,Dover,"900 block of Whatcoat Dr",male,"Russell Ewell Jr.","Adult 18+",N/A
+"May 23, 2018",Delaware,Wilmington,"2800 block of N Claymont St",female,"Morgan Dixon","Adult 18+",N/A
+"May 22, 2018",Delaware,Dover,"Vera Way and College Rd",male,"Eric Lloyd","Adult 18+",N/A
+"May 19, 2018",Delaware,Wilmington,"2600 block of Moore St",male,N/A,"Adult 18+",N/A
+"May 19, 2018",Delaware,Seaford,"122 Seaford Meadows Dr",male,N/A,"Adult 18+",N/A
+"May 19, 2018",Delaware,Seaford,"122 Seaford Meadows Dr",male,N/A,"Adult 18+",N/A
+"May 18, 2018",Delaware,Middletown,"120 Silver Lake Rd",male,"Tymere Moore","Adult 18+",N/A
+"May 15, 2018",Delaware,Wilmington,"300 block of Shipley Rd",male,"Ruben P. Harper","Adult 18+",N/A
+"May 13, 2018",Delaware,Dover,"50 block of Mitscher Rd",male,"Jameir Vann-Robinson","Adult 18+",N/A
+"May 13, 2018",Delaware,Dover,"50 block of Mitscher Rd",male,"Eugene Riley","Adult 18+",N/A
+"May 13, 2018",Delaware,Dover,"50 block of Mitscher Rd",male,"Ahmir Bailey","Adult 18+",N/A
+"May 13, 2018",Delaware,Wilmington,"1300 block of Chestnut St",male,N/A,"Adult 18+",N/A
+"May 12, 2018",Delaware,Wilmington,"500 block of W 6th St",male,N/A,"Teen 12-17",N/A
+"May 11, 2018",Delaware,Bridgeville,"21000 block of Mill Park Dr",male,"Corey Bailey","Adult 18+",N/A
+"May 11, 2018",Delaware,Bridgeville,"21000 block of Mill Park Dr",male,"McArthur M. Risper Jr.","Adult 18+",N/A
+"May 11, 2018",Delaware,Bridgeville,"21000 block of Mill Park Dr",male,N/A,"Adult 18+",N/A
+"May 11, 2018",Delaware,Dover,"1061 S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"May 11, 2018",Delaware,Dover,"1061 S Little Creek Rd",male,N/A,"Adult 18+",N/A
+"May 11, 2018",Delaware,Wilmington,"900 block of Anchorage St",male,N/A,"Adult 18+",N/A
+"May 10, 2018",Delaware,Wilmington,"W 8th St and Morrow St",male,"James Madlock","Adult 18+",N/A
+"May 10, 2018",Delaware,Wilmington,"601 Concord Ave",male,N/A,"Adult 18+",N/A
+"May 10, 2018",Delaware,Wilmington,"600 block of Monroe St",male,"James Madlock","Adult 18+",N/A
+"May 9, 2018",Delaware,Wilmington,"E 10th St and N Pine St",male,"Robert Pearsell","Adult 18+",N/A
+"May 7, 2018",Delaware,Wilmington,"700 block of E 5th St",male,"Khalif Friend","Adult 18+",N/A
+"May 5, 2018",Delaware,Milford,"S Washington St and SE 3rd St",male,"Ronnier Elmore","Adult 18+",N/A
+"May 5, 2018",Delaware,Wilmington,"700 block of E 11th St",male,"Zyaire Dubose","Adult 18+",N/A
+"May 4, 2018",Delaware,Wilmington,"500 block of Lombard St",male,"Joseph Steinmacher","Adult 18+",N/A
+"May 3, 2018",Delaware,Wilmington,"1000 block of N Lombard St",male,N/A,"Adult 18+",N/A
+"May 3, 2018",Delaware,Milford,"300 Aurora Pl",male,"Ronnier Elmore","Adult 18+",N/A
+"April 29, 2018",Delaware,"Rehoboth Beach (Dewey Beach)","2009 Highway One",male,"Alex Johnson","Adult 18+",N/A
+"April 28, 2018",Delaware,Dover,"Lakewood Dr and Columbia Ave",male,"Shabazz Barlow","Adult 18+",N/A
+"April 28, 2018",Delaware,Dover,"Lakewood Dr and Columbia Ave",male,"Jerry Green","Adult 18+",N/A
+"April 28, 2018",Delaware,Dover,"Lakewood Dr and Columbia Ave",male,N/A,"Teen 12-17",N/A
+"April 28, 2018",Delaware,Harrington,"US 13",male,"Michael D. Folmar","Adult 18+",N/A
+"April 24, 2018",Delaware,Magnolia,"100 block of Woodville Dr",male,"Kwamai Johnson","Adult 18+",N/A
+"April 24, 2018",Delaware,Dover,"200 block of W Reed St",male,N/A,"Adult 18+",N/A
+"April 24, 2018",Delaware,Dover,"200 block of W Reed St",male,"Khahiem Lewis","Teen 12-17",N/A
+"April 24, 2018",Delaware,Dover,"200 block of W Reed St",male,"Alton Kinsey","Teen 12-17",N/A
+"April 24, 2018",Delaware,Dover,"200 block of W Reed St",male,"Shiheem Durham","Teen 12-17",N/A
+"April 24, 2018",Delaware,Dover,"200 block of W Reed St",male,"Zymire Martinez","Teen 12-17",N/A
+"April 24, 2018",Delaware,Wilmington,"1000 block of N Heald St",male,N/A,"Adult 18+",N/A
+"April 24, 2018",Delaware,Wilmington,"1000 block of N Heald St",female,"Maya Lewis","Adult 18+",N/A
+"April 22, 2018",Delaware,Selbyville,"Shade Tree Ln",male,"Tristan Stone Kelly","Adult 18+",N/A
+"April 22, 2018",Delaware,Selbyville,"Shade Tree Ln",female,"Atlanta Blaze Crumbley","Teen 12-17",N/A
+"April 20, 2018",Delaware,Middletown,"Ash Blvd and Foxtail Ln",male,"Devantee Smith","Adult 18+",N/A
+"April 20, 2018",Delaware,Wilmington,"1200 block of E 22nd St",male,N/A,"Adult 18+",N/A
+"April 19, 2018",Delaware,Dover,"Old Forge Dr and Meadow Garden Ln",male,"Daquan Giddens","Adult 18+",N/A
+"April 19, 2018",Delaware,Newark,"200 block of Peach Rd",male,"Charles R. Dunagan","Adult 18+",N/A
+"April 17, 2018",Delaware,Dover,"400 Block of E Water St",male,"Syncere Friends","Adult 18+",N/A
+"April 17, 2018",Delaware,"New Castle","50 block of Birkshire Rd",male,"Lquan Reddon","Adult 18+",N/A
+"April 17, 2018",Delaware,Harrington,"50 block of Clark St",female,N/A,"Teen 12-17",N/A
+"April 17, 2018",Delaware,Harrington,"50 block of Clark St",male,"Daquan Walker","Adult 18+",N/A
+"April 17, 2018",Delaware,Harrington,"50 block of Clark St",female,"Christina D. Morgan","Adult 18+",N/A
+"April 17, 2018",Delaware,Dover,"50 block of Ann Ave",male,"David Austin","Adult 18+",N/A
+"April 17, 2018",Delaware,Smyrna,"200 block of Bryn Ln",male,"Joseph Swiggett","Adult 18+",N/A
+"April 17, 2018",Delaware,Smyrna,"200 block of Bryn Ln",male,"Anthony Price","Adult 18+",N/A
+"April 17, 2018",Delaware,Smyrna,"200 block of Bryn Ln",female,"Symone Brooks","Adult 18+",N/A
+"April 16, 2018",Delaware,Dover,"100 block of Mannering Dr",male,N/A,"Adult 18+",N/A
+"April 16, 2018",Delaware,Dover,"100 block of Mannering Dr",male,"David I. Brown","Adult 18+",N/A
+"April 15, 2018",Delaware,Wilmington,"3318 Kirkwood Hwy",male,"Robert C. Oldham","Adult 18+",N/A
+"April 14, 2018",Delaware,Magnolia,"McKinley Cir",male,"Davion Scott","Teen 12-17",N/A
+"April 14, 2018",Delaware,Wilmington,"Philadelphia Pike and Murphy Rd",male,"Donald C. Vavala III","Adult 18+",N/A
+"April 14, 2018",Delaware,Newark,"50 block of E Cherokee Dr",male,N/A,"Adult 18+",N/A
+"April 14, 2018",Delaware,Newark,"50 block of E Cherokee Dr",female,N/A,"Adult 18+",N/A
+"April 14, 2018",Delaware,Newark,"50 block of E Cherokee Dr",male,"Gregory Johnson","Adult 18+",N/A
+"April 13, 2018",Delaware,Milford,"300 Aurora Pl",N/A,N/A,Unknown,N/A
+"April 13, 2018",Delaware,Milford,"300 Aurora Pl",N/A,N/A,Unknown,N/A
+"April 13, 2018",Delaware,Smyrna,"SR 1 and Smyrna Leipsic Rd",male,"Quajan Daniels","Adult 18+",N/A
+"April 13, 2018",Delaware,Dover,"William St and Pear St",male,"David Austin","Adult 18+",N/A
+"April 9, 2018",Delaware,Wilmington,"1100 block of W 3rd St",male,N/A,"Teen 12-17",N/A
+"April 9, 2018",Delaware,Dover,"640 S DuPont Hwy",male,"Henry Ross","Adult 18+",N/A
+"April 9, 2018",Delaware,Dover,"640 S DuPont Hwy",male,"Donald Washington","Adult 18+",N/A
+"April 8, 2018",Delaware,Wilmington,"400 block of N Pine St",male,N/A,"Adult 18+",N/A
+"April 8, 2018",Delaware,Wilmington,"400 block of N Pine St",male,N/A,"Adult 18+",N/A
+"April 7, 2018",Delaware,Milford,"Park Ave and N Washington St",male,N/A,"Adult 18+",N/A
+"April 7, 2018",Delaware,Milford,"Park Ave and N Washington St",male,"Charles Larsen, Jr.","Adult 18+",N/A
+"April 7, 2018",Delaware,Dover,"1 block of Headstart Ln",male,N/A,"Adult 18+",N/A
+"April 7, 2018",Delaware,Dover,"1 block of Headstart Ln",male,N/A,"Adult 18+",N/A
+"April 5, 2018",Delaware,Wilmington,"100 block of North Clayton St",male,N/A,"Adult 18+",N/A
+"April 3, 2018",Delaware,Felton,"S Dupont Hwy",male,"Robert Harding","Adult 18+",N/A
+"April 1, 2018",Delaware,Dover,"295 S Dupont Hwy",male,N/A,Unknown,N/A
+"April 1, 2018",Delaware,Dover,"295 S Dupont Hwy",male,N/A,Unknown,N/A
+"April 1, 2018",Delaware,Dover,"26 S Governors Ave",male,N/A,"Adult 18+",N/A
+"April 1, 2018",Delaware,Wilmington,"Brookside Dr",male,N/A,"Adult 18+",N/A
+"March 31, 2018",Delaware,Townsend,"US 13 and DE 71",N/A,"Raymond C. Robinson Jr.","Adult 18+",N/A
+"March 31, 2018",Delaware,Townsend,"US 13 and DE 71",male,"Mark A. Lee","Adult 18+",N/A
+"March 28, 2018",Delaware,Wilmington,"50 block of W 27th St",male,N/A,"Adult 18+",N/A
+"March 27, 2018",Delaware,Dover,"Lepore Rd and N DuPont Hwy",female,"Shakera Williams","Adult 18+",N/A
+"March 27, 2018",Delaware,Wilmington,"900 block of Vandever Ave",male,N/A,"Adult 18+",N/A
+"March 24, 2018",Delaware,Dover,"N Dupont Hwy and Messina Hill Rd",male,"Marcos Vinicio Godoy","Adult 18+",N/A
+"March 20, 2018",Delaware,Seaford,"Chandler Heights",male,"Davion Lewis","Adult 18+",N/A
+"March 20, 2018",Delaware,Newark,"S Main St",male,"Malcolm Cheeks","Adult 18+",N/A
+"March 20, 2018",Delaware,Newark,"S Main St",male,"Isaiah Cheeks","Adult 18+",N/A
+"March 19, 2018",Delaware,Newark,"750 E Delaware Ave",female,N/A,"Teen 12-17",N/A
+"March 19, 2018",Delaware,Milford,"1029 S Walnut St",male,N/A,"Adult 18+",N/A
+"March 17, 2018",Delaware,Newark,"1119 S College Ave",male,"Sajhid Goldson","Adult 18+",N/A
+"March 17, 2018",Delaware,Dover,"S Governors Ave and W Division St",male,N/A,"Adult 18+",N/A
+"March 17, 2018",Delaware,Dover,"S Governors Ave and W Division St",male,N/A,Unknown,N/A
+"March 15, 2018",Delaware,Milford,"50 block of Causey Ave",male,"Carlos Feliciano-Concepcion","Adult 18+",N/A
+"March 15, 2018",Delaware,Milford,"50 block of Causey Ave",male,"Amilcar Jose Merced-Centeno","Adult 18+",N/A
+"March 15, 2018",Delaware,Dover,"Buckson Dr and Bacon Ave",male,"Alfred Terry","Adult 18+",N/A
+"March 14, 2018",Delaware,Wilmington,"100 block of N Broom St",male,"William Teasley III","Adult 18+",N/A
+"March 13, 2018",Delaware,Wilmington,"900 block of Vandever Ave",male,N/A,"Adult 18+",N/A
+"March 12, 2018",Delaware,Newark,"900 Churchmans Rd",male,"Eric T. Dunn","Adult 18+",N/A
+"March 12, 2018",Delaware,Harrington,"Dorman St and Commerce St",male,"Ivory Brown","Adult 18+",N/A
+"March 11, 2018",Delaware,Dover,"Martin Luther King Jr Blvd",male,"Gerald Bonanni","Adult 18+",N/A
+"March 11, 2018",Delaware,Dover,"S New St",male,"William Caldwell","Adult 18+",N/A
+"March 10, 2018",Delaware,Dover,"1365 N Dupont Hwy",male,"Jawan Custis","Adult 18+",N/A
+"March 9, 2018",Delaware,Wilmington,"300 block of N Van Buren St",male,"Stephan Minus","Adult 18+",N/A
+"March 9, 2018",Delaware,Newark,"Malvern Rd and Augusta Dr",male,"William Laws","Adult 18+",N/A
+"March 9, 2018",Delaware,Newark,"Malvern Rd and Augusta Dr",male,"Kalif Reeves","Adult 18+",N/A
+"March 9, 2018",Delaware,Newark,"Malvern Rd and Augusta Dr",male,"Shai Thodos","Adult 18+",N/A
+"March 9, 2018",Delaware,Newark,"Malvern Rd and Augusta Dr",male,"Noah Youngs","Adult 18+",N/A
+"March 9, 2018",Delaware,Newark,"Malvern Rd and Augusta Dr",male,"Edwin Rivera","Adult 18+",N/A
+"March 3, 2018",Delaware,Dover,"200 block of S Queen St",male,"Khalil Bratton","Adult 18+",N/A
+"March 3, 2018",Delaware,Wilmington,"800 block of N Pine St",male,N/A,"Adult 18+",N/A
+"March 2, 2018",Delaware,Bear,"Bear Christiana Rd",male,"Khalil Malloy","Adult 18+",N/A
+"February 27, 2018",Delaware,Lewes,"17000 block of N Brandt St",male,"Michael Gallo","Adult 18+",N/A
+"February 27, 2018",Delaware,Dover,"White Oak Rd and Stevenson Dr",N/A,N/A,"Teen 12-17",N/A
+"February 27, 2018",Delaware,Dover,"White Oak Rd and Stevenson Dr",N/A,N/A,"Teen 12-17",N/A
+"February 25, 2018",Delaware,Wilmington,"2300 block of N Market St",male,"Richard Young","Adult 18+",N/A
+"February 25, 2018",Delaware,Dover,"50 block of S State St",male,"Benjamin Wilson","Adult 18+",N/A


### PR DESCRIPTION
This PR adds data from the [gun violence archive](https://www.gunviolencearchive.org/). Two types of data are added:
1. Incidents (multiple files downloaded separately for Delaware, with some overlaps, due to 2000-limit on queries)
2. Participants (not sure what to do with these csv--no way to link them back to incidents since incident ID field is lacking)